### PR TITLE
Ported bug fixes

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/selectLoader.js
+++ b/wcomponents-theme/src/main/js/wc/ui/selectLoader.js
@@ -84,9 +84,15 @@ define(["wc/ui/listLoader",
 								}
 								// re-select all the options that were originally selected
 								Array.prototype.forEach.call(currentOptions, function(next) {
-									var nextIdx = selectboxSearch.indexOf(next, optContainer);
+									var nextIdx = selectboxSearch.indexOf(next, optContainer), selIdx;
 									if (nextIdx >= 0) {
-										shed.select(element.options[nextIdx], true);  // do not publish as the selection has not changed
+										shed.select(element.options[nextIdx], true); // do not publish as the selection has not changed.
+										if (!element.hasAttribute(("multiple"))) { // the following is a Safari 8.0.8 bug workaround.
+											selIdx = selectboxSearch.indexOf(next, element);
+											if (element.selectedIndex !== selIdx) {
+												element.selectedIndex = selIdx;
+											}
+										}
 									}
 								});
 							}

--- a/wcomponents-theme/src/main/xslt/wc.ui.dateField.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.dateField.xsl
@@ -205,16 +205,9 @@
 								</xsl:otherwise>
 							</xsl:choose>
 						</xsl:if>
-						<xsl:if test="@required or not(@allowPartial)">
+						<xsl:if test="@required">
 							<xsl:attribute name="placeholder">
-								<xsl:choose>
-									<xsl:when test="@required">
-										<xsl:value-of select="$$${wc.common.i18n.requiredPlaceholder}"/>
-									</xsl:when>
-									<xsl:otherwise>
-										<xsl:value-of select="$$${wc.ui.dateField.i18n.mask.format}"/>
-									</xsl:otherwise>
-								</xsl:choose>
+								<xsl:value-of select="$$${wc.common.i18n.requiredPlaceholder}"/>
 							</xsl:attribute>
 						</xsl:if>
 						<xsl:call-template name="ajaxController"/>


### PR DESCRIPTION
Put in a workaround for a Safari 8.0.8 bug which resulted in a select
element not updating its exposed selected option when selectedIndex is
updated programatically under some very specific conditions. Removed
the date format placeholder from ui:dateField XSLT as it (a) causes
issues in NVDA and (b) does not really reflect the range of allowed
input options.