### PR TITLE
Remove erroneous image in IE8 CSS

### DIFF
--- a/wcomponents-theme/src/main/sass/wc.ui.selectToggle.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.selectToggle.ie8.scss
@@ -18,9 +18,6 @@
 			&:before {
 				content: url(../images/checkbox-d.ie8.png);
 			}
-			&[disabled]:before {
-				content: url(../images/checkbox-i-d.ie8.png);
-			}
 		}
 		&[disabled] {
 			&:before, &[aria-checked]:before {


### PR DESCRIPTION
A reference to a non-existent image was recently added to
wc.ui.selectToggleie8.css. This has been removed. The CSS is unnecessary