### PR TITLE
Remove unnecessary IE8 CSS

### DIFF
--- a/wcomponents-theme/src/main/sass/wc.ui.selectToggle.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.selectToggle.ie8.scss
@@ -14,11 +14,6 @@
 		&[aria-checked="true"]:before {
 			content: url(../images/checkbox-s.ie8.png);
 		}
-		&[aria-checked="mixed"] {
-			&:before {
-				content: url(../images/checkbox-d.ie8.png);
-			}
-		}
 		&[disabled] {
 			&:before, &[aria-checked]:before {
 				content: url(../images/checkbox-d.ie8.png);


### PR DESCRIPTION
Removed a reference to a missing (unnecessary) file in IE8 specific CSS.