### PR TITLE
Fix unit tests which depended on execution order

### DIFF
--- a/wcomponents-examples/src/test/java/com/github/bordertech/wcomponents/examples/petstore/model/PetStoreDao_Test.java
+++ b/wcomponents-examples/src/test/java/com/github/bordertech/wcomponents/examples/petstore/model/PetStoreDao_Test.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 /**
  * Unit tests for {@link PetStoreDAO}.
- * 
+ *
  * @author Anthony O'Connor
  * @since 1.0.0
  */
@@ -14,8 +14,40 @@ public class PetStoreDao_Test
     /** expectedInventorySize from private PetStoreDao.DummyData. */
     private static final int EXPECTED_INVENTORY_SIZE = 6;
 
+    private static final int GOAT_ID = 3;
+
     /** A dummy description for all the products, private in the class being tested. */
     private static final String DUMMY_DESCRIPTION = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. In tristique pellentesque massa, et placerat justo ullamcorper vel. Nunc scelerisque, sem ut hendrerit pharetra, tellus erat dictum felis, at facilisis metus odio ac justo. Curabitur rutrum lacus in nulla iaculis at vestibulum metus facilisis. Aenean id nulla massa. Suspendisse vitae nunc nec urna laoreet elementum. Duis in orci ac leo elementum sagittis ac non massa. Sed vel massa purus, eu facilisis ipsum. Maecenas quis mi non metus scelerisque sagittis quis ac lacus. Fusce faucibus, urna ut viverra vulputate, tellus metus venenatis enim, eget mollis neque libero a turpis. Nullam convallis, lacus vel gravida suscipit, ipsum ante interdum libero, placerat laoreet dui magna et odio.\n\nPhasellus interdum placerat risus ut aliquam. In hac habitasse platea dictumst. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Fusce varius sem sit amet lorem commodo at ornare dui ultricies. Morbi consequat nunc sit amet magna facilisis luctus. Sed sit amet dapibus mi. Donec non quam tortor, sed tincidunt felis. Cras pulvinar ultrices elit in molestie. Morbi sapien nisi, porta in tempor et, dignissim quis nisl. Phasellus facilisis commodo mauris, in tristique velit semper in. Nullam vehicula, urna vel gravida molestie, lectus arcu semper urna, eget feugiat est augue id diam. Nulla dapibus eleifend justo, et malesuada erat accumsan vitae.";
+
+    /**
+     * Test writeProduct.
+     */
+    @Test
+    public void testWriteProduct()
+    {
+        final int testProductId = GOAT_ID;
+
+        ProductBean oldProduct = PetStoreDao.readProduct(testProductId);  // save this so we can restore it once the test is complete
+
+        try
+        {
+            final String newShortTitle = "lemming";
+            final String newImage = "lemming.gif";
+            final String newDescription = "has been modified";
+
+            PetStoreDao.writeProduct(new ProductBean(testProductId, newShortTitle, newImage, newDescription));
+
+            ProductBean newProduct = PetStoreDao.readProduct(testProductId);
+            Assert.assertEquals("should get productId requested", testProductId, newProduct.getId());
+            Assert.assertEquals("should get title for productdId " + testProductId, newShortTitle, newProduct.getShortTitle());
+            Assert.assertEquals("should get image for productId " + testProductId, newImage, newProduct.getImage());
+            Assert.assertEquals("should get description for productId " + testProductId, newDescription, newProduct.getDescription());
+        }
+        finally
+        {
+            PetStoreDao.writeProduct(oldProduct);  // restore the original product
+        }
+    }
 
     /**
      * TestReadInventory.
@@ -58,13 +90,13 @@ public class PetStoreDao_Test
         final int expectedCount = 0;
         final int expectedCost = 75000;
 
-        final int testProductId = 3; // the goat
+        final int testProductId = GOAT_ID;
         InventoryBean item = PetStoreDao.readInventory(testProductId);
 
         Assert.assertEquals("should get expected  productId", testProductId, item.getProductId());
-        Assert.assertEquals("should get status for productId 3", expectedStatus, item.getStatus());
-        Assert.assertEquals("should get count for productId 3", expectedCount, item.getCount());
-        Assert.assertEquals("should get cost for productId 3", expectedCost, item.getUnitCost());
+        Assert.assertEquals("should get status for productId " + testProductId, expectedStatus, item.getStatus());
+        Assert.assertEquals("should get count for productId " + testProductId, expectedCount, item.getCount());
+        Assert.assertEquals("should get cost for productId " + testProductId, expectedCost, item.getUnitCost());
     }
 
     /**
@@ -77,13 +109,13 @@ public class PetStoreDao_Test
         final String expectedImage = "goat.gif";
         final String expectedDescription = DUMMY_DESCRIPTION;
 
-        final int testProductId = 3; // the goat
+        final int testProductId = GOAT_ID;
         ProductBean product = PetStoreDao.readProduct(testProductId);
 
         Assert.assertEquals("should get productId requested", testProductId, product.getId());
-        Assert.assertEquals("should get title for productdId 3", expectedTitle, product.getShortTitle());
-        Assert.assertEquals("should get image for productId 3", expectedImage, product.getImage());
-        Assert.assertEquals("should get description for productId 3", expectedDescription, product.getDescription());
+        Assert.assertEquals("should get title for productdId " + testProductId, expectedTitle, product.getShortTitle());
+        Assert.assertEquals("should get image for productId " + testProductId, expectedImage, product.getImage());
+        Assert.assertEquals("should get description for productId " + testProductId, expectedDescription, product.getDescription());
     }
 
     /**
@@ -110,7 +142,7 @@ public class PetStoreDao_Test
     @Test
     public void testWriteInventory()
     {
-        final int testProductId = 3; // the goat again
+        final int testProductId = GOAT_ID; // the goat again
 
         final int newStatus = InventoryBean.STATUS_NEW;
         final int newCount = 99;
@@ -121,29 +153,8 @@ public class PetStoreDao_Test
         InventoryBean item = PetStoreDao.readInventory(testProductId);
 
         Assert.assertEquals("should get expected  productId", testProductId, item.getProductId());
-        Assert.assertEquals("should get new status for productId 3", newStatus, item.getStatus());
-        Assert.assertEquals("should get new count for productId 3", newCount, item.getCount());
-        Assert.assertEquals("should get new cost for productId 3", newUnitCost, item.getUnitCost());
-    }
-
-    /**
-     * Test writeProduct.
-     */
-    @Test
-    public void testWriteProduct()
-    {
-        final int testProductId = 3; // the goat
-
-        final String newShortTitle = "lemming";
-        final String newImage = "lemming.gif";
-        final String newDescription = "has been modified";
-
-        PetStoreDao.writeProduct(new ProductBean(testProductId, newShortTitle, newImage, newDescription));
-
-        ProductBean newProduct = PetStoreDao.readProduct(testProductId);
-        Assert.assertEquals("should get productId requested", testProductId, newProduct.getId());
-        Assert.assertEquals("should get title for productdId 3", newShortTitle, newProduct.getShortTitle());
-        Assert.assertEquals("should get image for productId 3", newImage, newProduct.getImage());
-        Assert.assertEquals("should get description for productId 3", newDescription, newProduct.getDescription());
+        Assert.assertEquals("should get new status for productId " + testProductId, newStatus, item.getStatus());
+        Assert.assertEquals("should get new count for productId " + testProductId, newCount, item.getCount());
+        Assert.assertEquals("should get new cost for productId " + testProductId, newUnitCost, item.getUnitCost());
     }
 }


### PR DESCRIPTION
Fixes #65

This was not a concurrency issue, instead some unit tests expected to be run in a particular order or they would fail. JUnit does not promise to run tests in any particular order therefore these tests would randomly fail.

@jonathanaustin PTAL