### PR TITLE
Improve scss-lint comment rule

### DIFF
--- a/wcomponents-theme/.scss-lint.yml
+++ b/wcomponents-theme/.scss-lint.yml
@@ -2,8 +2,8 @@ linters:
 # inherit defaults except:
 
   Comment:
-    # default true but we really need CSS style comments - see the SASS README.md file.
-    enabled: false
+    enabled: true
+    allowed: '^\/\*(:? [e|E]nd)? wc\.[a-zA-Z0-9\._]+\.scss \*\/$' # allow file name in head and tail comment.
 
   ElsePlacement:
     enabled: true

--- a/wcomponents-theme/src/main/sass/README.md
+++ b/wcomponents-theme/src/main/sass/README.md
@@ -40,7 +40,7 @@ CSS file `screen.ff.css` and the CSS loader will be told to load this file if `h
   to to keep a selector on one line.
 * Sass should be linted. The lint rules are here to make the SCSS more readable for humans and are the defaults for
   scss-lint with the following exceptions:
-    * CSS comments are allowed (see below for more information about commenting);
+    * CSS comments are allowed only as the file head and tail comment (see below for details);
     * @else must be placed on a new line;
     * @import must include the file extension (this is to improve integration with common IDE's auto-complete);
     * indentation is by **TAB** ONLY - single tab per level of indent;
@@ -54,35 +54,34 @@ CSS file `screen.ff.css` and the CSS loader will be told to load this file if `h
   !important rules.
 
 ### Comments
-* Each CSS and SCSS file must commence with a CSS comment which includes its file name and end with a comment which
-  includes the word 'end' and its file name. This makes CSS debugging much easier (remember that CSS style comments are
-  stripped in the final compressed output but Sass comments are stripped in all circumstances).
-* Comments **must be in Sass single line** style unless they are pertinent to debugging. This is still in a state of
-  flux due to our recent CSS to Sass transition. If a particular declaration in a declaration block requires a comment
-  it **must be in Sass single line form**.
-* There must be a single space between the start of a comment and the first character of the comment content. CSS
-  comments must also have a single space between the last character of the comment content and the comment end unless
-  the comment end is on its own line.
-* If a rule is commented there must not be any empty lines between the last line of the comment and the first selector
-  and the comment must not be on the same line as the selector.
-* Do not place a CSS style comment inside a declaration block (it causes issues with Safari's developer tools).
-* Sass single line comments are permitted inside rule blocks.
+
+* Each CSS and SCSS file must commence with a CSS comment which includes **only** its file name and end with a comment
+  which includes **only** the word 'end' and its file name. This makes CSS debugging much easier (remember that CSS
+  style comments are stripped in the final compressed output but Sass comments are stripped in all circumstances).
+* Comments **must be in Sass single line** style unless they are pertinent to debugging and then they must have a local
+  override of the `Comments` scss-lint rule. If a particular declaration in a declaration block requires a comment it
+  **must be in Sass single line form** under all circumstances.
+* There must be a single space between the start of a comment and the first character of the comment content.
+* If a rule is commented there must not be any empty lines between the last line of the comment and the first selector.
+* Do not place a CSS style comment inside a declaration block (it causes issues with Safari's developer tools). Sass
+  single line comments are permitted inside rule blocks.
 * If a particular selector in a multi-selector rule requires a comment it should be placed on the same line as the
   selector. If the comment is CSS style then it must precede the comma or opening brace (if it is the last selector).
   Sass comments must always be at the end of a line (of course).
 
+#### Example
 
-    /* my.component.scss */
-
+    /* wc.my.component.scss */
+	//scss-lint:disable Comment
     /* This declaration block does something odd and I need to know about it in debug mode */
+	//scss-lint:enable Comment
     .foo,
     .bar > .somelongclassname [aria-selected='true'] > :first-child {
         ....
         line-height: -2px; // The line-height declaration is used to ... which is needed for ...
         ....
     }
-
-    /* end my.component.scss */
+    /* end wc.my.component.scss */
 
 ## Media rules and specific CSS: when to use which
 

--- a/wcomponents-theme/src/main/sass/wc.common.accesskey.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.accesskey.dt.scss
@@ -19,24 +19,20 @@
 .wc_alt .wc_accesskey { //the character in a string corresponding to the control's access key is underlined
 	text-decoration: underline;
 }
-/*	Accesskey Tooltips
-	Styling for the callout (shows when ALT is held down to fire an accesskey).
-	Some of these styles are !important because of the nesting arrangements. see,
-	for example, top level menu item with an accesskey.
-	NOTE: the padding is important to over-ride menu rules which may also apply.
-*/
+//	Accesskey Tooltips
+//	Styling for the callout (shows when ALT is held down to fire an accesskey).
 [role='tooltip'] {
 	@include accesskey-border;
 	background-color: $wc-ui-color-tooltip-bg;
 	color: $wc-ui-color-tooltip-fg;
 	// scss-lint:disable ImportantRule
-	font-weight: bold !important;
+	font-weight: bold !important; //important to over-ride menu rules which may also apply.
 	margin-left: -0.5em;
 	margin-top: -2.25em;
-	padding: 0.25em !important;
+	padding: 0.25em !important; //important to over-ride menu rules which may also apply.
 	position: absolute;
 	text-align: center;
-	width: auto !important;
+	width: auto !important; //important to over-ride menu rules which may also apply.
 	// scss-lint:enable ImportantRule
 
 	&:before,
@@ -66,4 +62,4 @@
 		display: inline-block;
 	}
 }
-/* end accesskey.dt.scss */
+/* end wc.common.accesskey.dt.scss */

--- a/wcomponents-theme/src/main/sass/wc.common.button.pattern_ios.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.button.pattern_ios.scss
@@ -1,4 +1,4 @@
-/* wc.common.button.ios.css */
+/* wc.common.button.ios.scss */
 @import 'vars_all.scss';
 
 button {
@@ -33,4 +33,4 @@ button {
 .wc_btn_link:active {
 	background-color: transparent;
 }
-/* end wc.common.button.ios.css */
+/* end wc.common.button.ios.scss */

--- a/wcomponents-theme/src/main/sass/wc.common.buttonLinkImages.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.buttonLinkImages.scss
@@ -1,4 +1,4 @@
-/*  wc.common.buttonLinkImages.scss */
+/* wc.common.buttonLinkImages.scss */
 // Positioning of an image in a WButton or WLink based on the component's imagePosition property. XS:TOKENs for this
 // property are 'n','e','s','w'.
 // Used by:

--- a/wcomponents-theme/src/main/sass/wc.common.buttons.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.buttons.scss
@@ -26,9 +26,7 @@ button {
 }
 
 
-/*
- * CLASS wc_btn_nada has all style stripped. CLASS wc_btn_link is made to look like a link.
- */
+// CLASS wc_btn_nada has all style stripped. CLASS wc_btn_link is made to look like a link.
 .wc_btn {
 	&_link,
 	&_nada {

--- a/wcomponents-theme/src/main/sass/wc.common.form.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.form.ie8.scss
@@ -1,4 +1,4 @@
-/* wc.common.form.ie8.css */
+/* wc.common.form.ie8.scss */
 // Setting max-width 100% in IE before 9 results in usability and a11y failures in select and unusual collapsing in some
 // layouts.
 textarea,
@@ -7,4 +7,4 @@ option,
 select {
 	max-width: none;
 }
-/* end wc.common.form.ie8.css */
+/* end wc.common.form.ie8.scss */

--- a/wcomponents-theme/src/main/sass/wc.common.form.pattern_ios.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.form.pattern_ios.scss
@@ -1,4 +1,4 @@
-/* wc.common.form.ios.css */
+/* wc.common.form.ios.scss */
 @import 'vars_all.scss';
 
 input,
@@ -18,4 +18,4 @@ input {
 	border: 0 none;
 	height: auto;
 }
-/* end wc.common.form.ios.css */
+/* end wc.common.form.ios.scss */

--- a/wcomponents-theme/src/main/sass/wc.common.form.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.form.scss
@@ -66,4 +66,4 @@ textarea {
 	max-width: 100%;
 	word-wrap: break-word;
 }
-/* end of wc.common.form.scss */
+/* end wc.common.form.scss */

--- a/wcomponents-theme/src/main/sass/wc.common.listSort.pattern_ff.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.listSort.pattern_ff.scss
@@ -2,4 +2,4 @@
 .wc_sorter {
 	padding: 0;
 }
-/* end of  wc.common.listSort.ff.scss */
+/* end wc.common.listSort.ff.scss */

--- a/wcomponents-theme/src/main/sass/wc.common.listSort.pattern_ios.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.listSort.pattern_ios.scss
@@ -1,8 +1,8 @@
-/* wc.common.listSort.ios.css */
+/* wc.common.listSort.ios.scss */
 @import 'mixins_common.scss';
 
 .wc_sorter {
 	@include border($color: $wc-color-ios-interactive);
 	border-radius: 3px;
 }
-/* end of  wc.common.listSort.ios.css */
+/* end wc.common.listSort.ios.scss */

--- a/wcomponents-theme/src/main/sass/wc.common.listSort.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.listSort.scss
@@ -58,4 +58,4 @@
 	}
 }
 // scss-lint:enable NestingDepth
-/* end of  wc.common.listSort.scss */
+/* end wc.common.listSort.scss */

--- a/wcomponents-theme/src/main/sass/wc.common.modalShim.ie9.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.modalShim.ie9.scss
@@ -1,7 +1,7 @@
-/* wc.common.modalShim.ie9.css */
+/* wc.common.modalShim.ie9.scss */
 // scss-lint:disable IdSelector
 #wc_shim {
 	background-color: transparent;
 	background-image: url('../images/modalShim.png');
 }
-/* wc.common.modalShim.ie9.css*/
+/* end wc.common.modalShim.ie9.scss */

--- a/wcomponents-theme/src/main/sass/wc.common.page.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.page.ie8.scss
@@ -1,7 +1,7 @@
-/* wc.common.page.ie8.css */
+/* wc.common.page.ie8.scss */
 // Text mode optgroup emulation for multiple selection controls readOnly mode: WMultiSelect, WMultiSelectPair, WShuffler
 // Internet Explorer chooses to render an optgroup in an italic font.
 .wc_optgroup {
 	font-style: italic;
 }
-/* end wc.common.page.ie8.css */
+/* end wc.common.page.ie8.scss */

--- a/wcomponents-theme/src/main/sass/wc.common.page.pattern_ios.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.page.pattern_ios.scss
@@ -1,7 +1,7 @@
-/* wc.common.page.ios.css */
+/* wc.common.page.ios.scss */
 @import 'vars_all.scss';
 
 body {
 	font-family: $ios-font;
 }
-/* end wc.common.page.ios.css */
+/* end wc.common.page.ios.scss */

--- a/wcomponents-theme/src/main/sass/wc.common.page.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.page.scss
@@ -25,7 +25,6 @@ pre {
 	font-family: $mono-font;
 }
 
-/* phrase elements */
 a {
 	color: $wc-ui-color-link;
 
@@ -60,9 +59,7 @@ img {
 	@include offscreen;
 }
 
-/*
-  Text alignment
-*/
+// Text alignment
 .left {
 	@include align(left);
 }
@@ -112,4 +109,4 @@ a[name],
 input[type='number'][maxlength] {
 	@include outline($color: $wc-ui-color-error-fg);
 }
-/* end wc.common.page.css */
+/* end wc.common.page.scss */

--- a/wcomponents-theme/src/main/sass/wc.debug.abbr.scss
+++ b/wcomponents-theme/src/main/sass/wc.debug.abbr.scss
@@ -1,4 +1,4 @@
-/* wc.debug.abbr.css */
+/* wc.debug.abbr.scss */
 abbr {
 	&[data-wc-debuginfo],
 	&[data-wc-debugwarn],
@@ -6,4 +6,4 @@ abbr {
 		display: inline-block;
 	}
 }
-/* end wc.debug.abbr.css */
+/* end wc.debug.abbr.scss */

--- a/wcomponents-theme/src/main/sass/wc.debug.button.scss
+++ b/wcomponents-theme/src/main/sass/wc.debug.button.scss
@@ -1,11 +1,8 @@
-/* wc.debug.button.css */
+/* wc.debug.button.scss */
 // styling for WButton, WCancelButton, WConfirmButton, WPrintButton and WLink[type.BUTTON] components in debug diagnostic mode.
-
-/* making the text align left puts the error/warning in a more sensible place
-   without changing the dimensions of the button.*/
 // scss-lint:disable QualifyingElement
 button[data-wc-debugerr],
 button[data-wc-debugwarn] {
-	text-align: left;
+	text-align: left; // puts the error/warning in a more sensible place without changing the dimensions of the button.
 }
-/* end wc.debug.button.css */
+/* end wc.debug.button.scss */

--- a/wcomponents-theme/src/main/sass/wc.debug.debugInfo.scss
+++ b/wcomponents-theme/src/main/sass/wc.debug.debugInfo.scss
@@ -95,7 +95,7 @@ $wc-color-debug-crumb-bg: #f3f3f3;
 }
 
 
-/* the instruction box */
+// the instruction box
 .wc_db_message {
 	@include border($color: $wc-color-debug-infobox-border, $width: 2px);
 	background-color: $wc-color-debug-infobox-bg;

--- a/wcomponents-theme/src/main/sass/wc.debug.decoratedLabel.scss
+++ b/wcomponents-theme/src/main/sass/wc.debug.decoratedLabel.scss
@@ -1,4 +1,4 @@
-/* wc.debug.decoratedLabel.css */
+/* wc.debug.decoratedLabel.scss */
 // NOTE: we only need to style the decoratedLabel outer element here, not each segment.
 
 // scss-lint:disable QualifyingElement The div qualifyer is required.
@@ -6,4 +6,4 @@ div.decoratedLabel[data-wc-debugerr],
 div.decoratedLabel[data-wc-debugwarn] {
 	display: inline-block;
 }
-/* end wc.debug.decoratedLabel.css */
+/* end wc.debug.decoratedLabel.scss */

--- a/wcomponents-theme/src/main/sass/wc.dom.html5.reset.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.dom.html5.reset.dt.scss
@@ -1,4 +1,4 @@
-/* wc.dom.html5.reset.css */
+/* wc.dom.html5.reset.scss */
 // HTML 5 elements default styles.
 // DETAILS is in wc.ui.collapsible*.scss
 // SUMMARY is in wc.ui.collapsible*.scss
@@ -15,4 +15,4 @@ nav { // was WMenu, temporarily unused
 	margin: 0;
 	padding: 0;
 }
-/* end wc.dom.html5.reset.css */
+/* end wc.dom.html5.reset.scss */

--- a/wcomponents-theme/src/main/sass/wc.imports.scss
+++ b/wcomponents-theme/src/main/sass/wc.imports.scss
@@ -1,6 +1,6 @@
-/* wc.imports.css */
+/* wc.imports.scss */
 // This is a placeholder file. It is the first file in the build of the CSS and allows the use of @import commands in
 // CSS. If you need to use @import (for example to use a web font) in your implementation then you should over-ride this
 // file. This is probably unnecessary now in the world of SASS but we SASS first then concat so I am leaving it just in
 // case. The CSS file generated from theis SCSS file will be at teh top of the concatenated output.
-/* end wc.imports.css */
+/* end wc.imports.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.backToTop.mob.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.backToTop.mob.scss
@@ -1,6 +1,6 @@
-/* wc.ui.backToTop.css */
+/* wc.ui.backToTop.scss */
 .wc_btt::before {
 	height: 1.5em;
 	width: 1.5em;
 }
-/* wc.ui.backToTop.css */
+/* wc.ui.backToTop.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.checkBox.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.checkBox.ie8.scss
@@ -1,4 +1,4 @@
-/* wc.ui.checkBox.ieAll.css */
+/* wc.ui.checkBox.ieAll.scss */
 .checkbox {
 	&:before {
 		content: url('../images/checkbox-ro.ie8.png');
@@ -8,4 +8,4 @@
 		content: url('../images/checkbox-s-ro.ie8.png');
 	}
 }
-/* end wc.ui.checkBox.ieAll.css */
+/* end wc.ui.checkBox.ieAll.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.checkBox.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.checkBox.scss
@@ -1,4 +1,4 @@
-/* wc.ui.checkBox.css */
+/* wc.ui.checkBox.scss */
 @import 'mixins_common.scss';
 
 .checkbox { //'readOnly' WCheckBox
@@ -11,4 +11,4 @@
 		content: url('../images/checkbox-s-ro.svg');
 	}
 }
-/* end wc.ui.checkBox.css */
+/* end wc.ui.checkBox.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.checkableSelect.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.checkableSelect.scss
@@ -42,4 +42,4 @@
 		}
 	}
 }
-/* end  wc.ui.checkableSelect.css */
+/* end wc.ui.checkableSelect.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.collapsible.mob.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.collapsible.mob.scss
@@ -2,4 +2,4 @@
 summary::before {
 	vertical-align: text-top;
 }
-/*end wc.ui.collapsible.mob.scss*/
+/* end wc.ui.collapsible.mob.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.collapsible.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.collapsible.scss
@@ -69,4 +69,4 @@ details {
 		}
 	}
 }
-/*end wc.ui.collapsible.scss*/
+/* end wc.ui.collapsible.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.collapsibleToggle.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.collapsibleToggle.scss
@@ -24,4 +24,4 @@
 		}
 	}
 }
-/* end wc.ui.collapsibleToggle.scss*/
+/* end wc.ui.collapsibleToggle.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.dateField.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dateField.dt.scss
@@ -42,4 +42,4 @@
 .wc_wdf_cls {
 	display: none;
 }
-/* end wc.ui.dateField.dt.css*/
+/* end wc.ui.dateField.dt.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.dateField.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dateField.ie8.scss
@@ -1,4 +1,4 @@
-/*wc.ui.dateField.ie8.scss */
+/* wc.ui.dateField.ie8.scss */
 @import 'mixins_common.scss';
 
 //scss-lint:disable IdSelector
@@ -15,4 +15,4 @@
 		}
 	}
 }
-/* end wc.ui.dateField.ie8.css */
+/* end wc.ui.dateField.ie8.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.dateField.mob.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dateField.mob.scss
@@ -1,4 +1,4 @@
-/* wc.ui.dateField.mob.css */
+/* wc.ui.dateField.mob.scss */
 @import 'mixins_common.scss';
 // The main purpose of this CSS is to make the pop-up calendar full screen. We make all of the buttons bigger to make
 // them easier for fingers to push and finally add a close button to make up for the lack of an escape key.
@@ -62,4 +62,4 @@
 	height: 100%;
 	width: 100%;
 }
-/* end wc.ui.dateField.mob.css */
+/* end wc.ui.dateField.mob.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.dateField.pattern_ios.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dateField.pattern_ios.scss
@@ -1,4 +1,4 @@
-/* wc.ui.dateField.ios.css */
+/* wc.ui.dateField.ios.scss */
 //scss-lint:disable IdSelector
 #wc-calendar thead button { // TODO: I don't think we need this any more
 	background-image: none;
@@ -6,4 +6,4 @@
 	vertical-align: middle;
 	width: 22px;
 }
-/* end wc.ui.dateField.ios.css */
+/* end wc.ui.dateField.ios.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.dateField.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dateField.scss
@@ -10,7 +10,7 @@
 	display: inline-block;
 	position: relative;
 
-	&[role='combobox'] {/* partial date field or no native support */
+	&[role='combobox'] {//partial date field or no native support
 		@include border($color: $wc-ui-color-border-form-control);
 
 		&[aria-disabled='true'] {
@@ -65,7 +65,7 @@ dialog [role='combobox'] > [role='listbox'] {
 	z-index: 22;
 }
 
-/* calendar launch button */
+// calendar launch button
 .wc_wdf_cal {
 	&:hover,
 	&:focus {
@@ -83,7 +83,7 @@ dialog [role='combobox'] > [role='listbox'] {
 	}
 }
 
-/* This is the calendar container. The important is to override hidden from being inside a closed combo. */
+// This is the calendar container. The important is to override hidden from being inside a closed combo.
 #wc-calbox {
 	background-color: $wc-ui-color-global-bg;
 	white-space: nowrap;
@@ -99,12 +99,12 @@ dialog [role='combobox'] > [role='listbox'] {
 	}
 }
 
-/* The calendar table */
+// The calendar table
 #wc-calendar {
 	thead {
 		@include border($pos: bottom);
 
-		td:last-child { /* container of the close button */
+		td:last-child { // container of the close button
 			padding-right: 0;
 			text-align: right;
 		}
@@ -138,7 +138,7 @@ dialog [role='combobox'] > [role='listbox'] {
 	vertical-align: middle;
 }
 
-/* date picker buttons */
+// date picker buttons
 .wc_wdf_pick {
 	color: $wc-ui-color-global-fg;
 	cursor: pointer;
@@ -165,4 +165,4 @@ dialog [role='combobox'] > [role='listbox'] {
 .wc_wdf_today { // today
 	@include outline();
 }
-/* end wc.ui.dateField.css*/
+/* end wc.ui.dateField.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.definitionList.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.definitionList.scss
@@ -41,7 +41,7 @@ dt {
 		vertical-align: text-top;
 		width: 30%;
 
-		+ dd { /* the first dd does not have the left margin defined below*/
+		+ dd { // the first dd does not have the left margin defined below
 			margin-left: 0;
 		}
 	}

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog.dt.scss
@@ -8,7 +8,7 @@ dialog {
 	min-height: $wc-ui-dialog-min-height;
 	min-width: $wc-ui-dialog-min-width;
 
-	&[open] > [aria-live] { /*dialog content container*/
+	&[open] > [aria-live] { // dialog content container
 		height: 100%;
 	}
 
@@ -37,4 +37,4 @@ dialog {
 		}
 	}
 }
-/*end wc.ui.dialog.dt.css */
+/* end wc.ui.dialog.dt.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog.ie10.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog.ie10.scss
@@ -1,4 +1,4 @@
-/* wc.ui.dialog.ie10.css */
+/* wc.ui.dialog.ie10.scss */
 //scss-lint:disable VendorPrefix
 dialog {
 	&[open] {
@@ -34,4 +34,4 @@ dialog {
 		}
 	}
 }
-/*end wc.ui.dialog.ie10.css */
+/* end wc.ui.dialog.ie10.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog.ie9.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog.ie9.scss
@@ -38,4 +38,4 @@ dialog {
 	}
 }
 
-/* end wc.ui.dialogue.ie9.scss*/
+/* end wc.ui.dialogue.ie9.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog.mob.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog.mob.scss
@@ -1,4 +1,4 @@
-/* wc.ui.dialog.mob.css */
+/* wc.ui.dialog.mob.scss */
 @import 'mixins_common.scss';
 
 dialog {
@@ -15,4 +15,4 @@ dialog {
 		display: none;
 	}
 }
-/* end wc.ui.dialog.mob.css */
+/* end wc.ui.dialog.mob.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog.pattern_ios.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog.pattern_ios.scss
@@ -1,4 +1,4 @@
-/* wc.ui.dialog.ios.css */
+/* wc.ui.dialog.ios.scss */
 @import 'mixins_common.scss';
 
 $wc-color-ios-dialog-bg: #f7f7f7;
@@ -31,4 +31,4 @@ dialog {
 		}
 	}
 }
-/* end wc.ui.dialog.ios.css */
+/* end wc.ui.dialog.ios.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog.pattern_safari.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog.pattern_safari.scss
@@ -1,6 +1,6 @@
-/*wc.ui.dialog.safari.css*/
+/* wc.ui.dialog.safari.scss */
 //scss-lint:disable QualifyingElement
 dialog[open] > [aria-live] {
 	height: auto;
 }
-/* end wc.ui.dialog.safari.css*/
+/* end wc.ui.dialog.safari.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog.scss
@@ -1,8 +1,6 @@
 /* wc.ui.dialog.scss */
-/*
- * the actual dialog. Its position is set on open such that it sits in the middle of the viewport. Margin:auto only
- * works in Chrome and Webkit.
- */
+// The actual dialog. Its position is set on open such that it sits in the middle of the viewport. Margin:auto only
+// works in Chrome and Webkit.
 @import 'wc.ui.dialog_vars.scss';
 
 dialog {
@@ -68,4 +66,4 @@ dialog {
 		background-position: 100% 0;
 	}
 }
-/*end wc.ui.dialog.css */
+/* end wc.ui.dialog.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog_vars.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog_vars.scss
@@ -1,5 +1,5 @@
-/* wc.ui.dialog_vars.scss
- * Override this for some simple colour/size over-rides for dialogs */
+/* wc.ui.dialog_vars.scss */
+// Override this for some simple colour/size over-rides for dialogs
 @import 'mixins_common.scss';
 
 $wc-ui-color-dialog-head-bg: $std-color-primary;

--- a/wcomponents-theme/src/main/sass/wc.ui.feedback.messages.indicators.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.feedback.messages.indicators.scss
@@ -1,16 +1,14 @@
-/*
- * wc.ui.feedback.messages.indicators.scss
- *    WFieldWarningIndicator
- *    WFieldErrorIndicator
- *    WMessageBox/WMessages
- *    WValidationErrors (server side validation)
- *    Client side validation error messages
- *
- * Iconography for inline messages
- * This is split out from the main feedback CSS for ease of overriding as it is a lot of
- * CSS to do a very small job and overriding the whole lot in an implementation would require all
- * this just to turn off the pseudo elements plus the styling needed for the indicators.
-*/
+/* wc.ui.feedback.messages.indicators.scss */
+//    WFieldWarningIndicator
+//    WFieldErrorIndicator
+//    WMessageBox/WMessages
+//    WValidationErrors (server side validation)
+//    Client side validation error messages if plugin enabled
+
+// Iconography for inline messages
+// This is split out from the main feedback CSS for ease of overriding as it is a lot of
+// CSS to do a very small job and overriding the whole lot in an implementation would require all
+// this just to turn off the pseudo elements plus the styling needed for the indicators.
 @import 'mixins_common.scss';
 
 .error,
@@ -63,4 +61,4 @@ ul {
 		color: $wc-ui-color-success-fg;
 	}
 }
-/* end * wc.ui.feedback.messages.indicators.scss */
+/* end wc.ui.feedback.messages.indicators.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.feedback.messages.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.feedback.messages.scss
@@ -1,17 +1,8 @@
-/*
-	wc.ui.feedback.messages.css
-
-	WFieldWarningIndicator
-	WFieldErrorIndicator
-	WMessageBox/WMessages
-	WValidationErrors (server side validation)
-	Client side validation error messages
-*/
+/* wc.ui.feedback.messages.scss */
 
 // Common states for foreground aspects of messages
 // NOTE: the element selector is required here for error messages as we need to differentiate the message from the
 // element in an error state when both have the same class.
-
 ul {
 	&.error,
 	&.info,
@@ -22,4 +13,4 @@ ul {
 		padding: 0;
 	}
 }
-/* end wc.ui.feedback.messages.css */
+/* end wc.ui.feedback.messages.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.scss
@@ -98,4 +98,4 @@ ul.fieldLayout { // field layouts may be an ordered list, in which case we want 
 		width: auto;
 	}
 }
-/* end  wc.ui.fieldLayout.scss */
+/* end wc.ui.fieldLayout.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.fieldset.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fieldset.scss
@@ -1,4 +1,4 @@
-/* wc.ui.fieldset.css */
+/* wc.ui.fieldset.scss */
 
 // Just a few notes regarding fieldset defaults:
 
@@ -23,4 +23,4 @@ fieldset {
 		padding: 0;
 	}
 }
-/* end wc.ui.fieldset.css */
+/* end wc.ui.fieldset.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.heading.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.heading.scss
@@ -19,4 +19,4 @@ section {
 		font-weight: normal;
 	}
 }
-/* end wc.ui.heading.scss  */
+/* end wc.ui.heading.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.label.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.label.scss
@@ -1,4 +1,4 @@
-/* wc.ui.label.css */
+/* wc.ui.label.scss */
 // styles for WLabel and the label emulators
 
 
@@ -15,7 +15,7 @@ span.label {
 	display: inline-block;
 }
 
-/* space between a checkable and its label */
+// space between a checkable and its label
 [type='radio'] + label,
 [type='checkbox'] + label,
 .checkbox + span.label,
@@ -23,7 +23,7 @@ span.label {
 	margin-left: $hgap-small;
 }
 
-/* required markers */
+// required markers
 .wc_req {
 	[type='radio'] + &:before,
 	[type='checkbox'] + &:before {
@@ -57,5 +57,4 @@ label,
 		}
 	}
 }
-
-/* end wc.ui.label.css*/
+/* end wc.ui.label.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.legend.ie11.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.legend.ie11.scss
@@ -1,7 +1,7 @@
-/* wc.ui.fieldset.ie11.css */
+/* wc.ui.fieldset.ie11.scss */
 // IE (up to and including 11) prefer to not wrap text in legends and let the legend width be as big as it needs.
 legend {
 	max-width: 100%;
 }
 
-/* end wc.ui.fieldset.ie11.css  */
+/* end wc.ui.fieldset.ie11.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.legend.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.legend.scss
@@ -20,4 +20,4 @@ legend {
 		content: '';
 	}
 }
-/* END OF wc.ui.legend.scss */
+/* end wc.ui.legend.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.listLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.listLayout.scss
@@ -6,7 +6,7 @@
 ol.listLayout {
 	margin: 0 0 0 2em;
 
-	&.flat {/* flat ordered lists use a pseudo-element with a counter_*/
+	&.flat { // flat ordered lists use a pseudo-element with a counter
 		counter-reset: li;
 
 		> li:before {
@@ -15,7 +15,7 @@ ol.listLayout {
 			margin-right: $hgap-small;
 		}
 
-		&.none > li:before {/* remove the counter if the separator is none */
+		&.none > li:before { // remove the counter if the separator is none
 			content: '';
 		}
 	}
@@ -48,7 +48,7 @@ ul.listLayout {
 			display: inline-block;
 			width: auto;
 
-			> * {/* this rule keeps 'block' components inline in a flat list */
+			> * { // this rule keeps 'block' components inline in a flat list
 				display: inline-block;
 				width: auto;
 			}
@@ -68,13 +68,13 @@ ul.listLayout {
 			}
 		}
 
-		&.dot > li + li:before {/*dot bullets should be default but need pseudo-elements for flat lists. */
+		&.dot > li + li:before { // dot bullets should be default but need pseudo-elements for flat lists.
 			content: '\25cf';
 			margin: 0 $hgap-normal;
 		}
 	}
 
-	&.bar {/* bar bullets */
+	&.bar { // bar bullets
 		> li:before {
 			content: '|';
 			margin-right: $hgap-normal;

--- a/wcomponents-theme/src/main/sass/wc.ui.loading.ie10.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.loading.ie10.scss
@@ -1,4 +1,4 @@
-/* wc.common.loading.ie10.css */
+/* wc.common.loading.ie10.scss */
 @import 'vars_all.scss';
 //scss-lint:disable IdSelector
 #wc_ui_loading div {
@@ -23,4 +23,4 @@
 	background-image: url('../images/loading-dark.gif') !important;
 }
 
-/* end wc.common.loading.ie10.css */
+/* end wc.common.loading.ie10.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.loading.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.loading.scss
@@ -1,4 +1,4 @@
-/* loading.scss */
+/* wc.ui.loading.scss */
 // styling for the loading indicator that appears for page reloads and AJAX regions
 @import 'vars_all.scss';
 
@@ -58,4 +58,4 @@
 		visibility: hidden;
 	}
 }
-/* end wc.common.loading.css */
+/* end wc.ui.loading.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.mediaPlayer.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.mediaPlayer.ie8.scss
@@ -1,7 +1,7 @@
-/* wc.ui.media.player.ie8.css */
+/* wc.ui.media.player.ie8.scss */
 audio,
 video {
 	background: transparent;
 	display: inline-block;
 }
-/* end wc.ui.media.player.ie8.css */
+/* end wc.ui.media.player.ie8.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.mediaPlayer.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.mediaPlayer.scss
@@ -1,6 +1,5 @@
-/* wc.ui.media.player.css
- * styles for WAudio and WVideo when the media is not able to be handled by the
- * user agent natively. */
+/* wc.ui.media.player.scss */
+// styles for WAudio and WVideo when the media is not able to be handled by the user agent natively. */
 @import 'mixins_common.scss';
 
 .wc_av_play,
@@ -44,4 +43,4 @@
 .src + .src {
 	margin-left: $hgap-normal;
 }
-/* end wc.ui.media.player.css */
+/* end wc.ui.media.player.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.bar.pattern_ff.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.bar.pattern_ff.scss
@@ -1,4 +1,4 @@
-/* wc.ui.menu.bar.ff.scss*/
+/* wc.ui.menu.bar.ff.scss */
 @import 'wc.ui.menu_vars.scss';
 
 .menu[role='menubar'] {

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.dt.scss
@@ -1,7 +1,5 @@
-/*
- * wc.ui.menu.barColumn.dt.scss
- * Desktop styles for WMenu type BAR, type FLYOUT, type COLUMN
- */
+/* wc.ui.menu.barColumn.dt.scss */
+// Desktop styles for WMenu type BAR, type FLYOUT, type COLUMN
 @import 'wc.ui.menu_vars.scss';
 
 .submenu {
@@ -19,18 +17,18 @@
 	}
 
 	> [role='menu'][aria-busy] {
-		//scss-lint:disable ImportantRule
-		background-color: $wc-ui-color-menu-bg !important; //override aria-busy transparency
+		// scss-lint:disable ImportantRule
+		background-color: $wc-ui-color-menu-bg !important; // override aria-busy transparency
 		min-height: $line-size;
 	}
 }
 
 [role='menu'] {
-	[role='menu'] { //nested sub-menus
+	[role='menu'] { // nested sub-menus
 		left: 100%;
 		top: 0;
 
-		&.wc_coleast {//nested collisions
+		&.wc_coleast { // nested collisions
 			right: 100%;
 		}
 
@@ -39,7 +37,7 @@
 		}
 	}
 
-	//viewport edge collisions
+	// viewport edge collisions
 	&.wc_coleast {
 		left: auto;
 		right: 0;
@@ -55,4 +53,4 @@
 		top: auto;
 	}
 }
-/* end wc.ui.menu.barColumn.dt.scss*/
+/* end wc.ui.menu.barColumn.dt.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.icon.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.icon.dt.scss
@@ -28,4 +28,4 @@
 		content: url('../images/next-d.png');
 	}
 }
-/* end wc.ui.menu.barColumn.icon.dt.scss*/
+/* end wc.ui.menu.barColumn.icon.dt.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.icon.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.icon.ie8.scss
@@ -1,4 +1,4 @@
-/* wc.ui.menu.barColumn.icon.ie8.css */
+/* wc.ui.menu.barColumn.icon.ie8.scss */
 [role='menubar'] > [aria-expanded] > button {
 	> .decoratedLabel {
 		background-image: url('../images/down.png');
@@ -20,7 +20,7 @@
 		background-position: 100% 50%;
 		background-repeat: no-repeat;
 		box-sizing: border-box;
-		display: table;/* table-row does not allow it to be sized to 100% in ie8 */
+		display: table; // table-row does not allow it to be sized to 100% in ie8
 		padding-right: 6px;
 	}
 
@@ -28,4 +28,4 @@
 		background-image: url('../images/next-d.png');
 	}
 }
-/* end wc.ui.menu.barColumn.icon.ie8.css */
+/* end wc.ui.menu.barColumn.icon.ie8.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.icon.mob.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.icon.mob.scss
@@ -26,4 +26,4 @@
 	content: '\2039';
 	margin-right: 0.5em;
 }
-/* end wc.ui.menu.barColumn.icon.mob.scss*/
+/* end wc.ui.menu.barColumn.icon.mob.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.pattern_ios.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.pattern_ios.scss
@@ -1,4 +1,4 @@
-/* wc.ui.menu.barColumn.ios.css */
+/* wc.ui.menu.barColumn.ios.scss */
 @import 'mixins_common.scss';
 
 [role='menu'],
@@ -39,4 +39,4 @@
 		color: $wc-color-ios-interactive;
 	}
 }
-/* end wc.ui.menu.barColumn.ios.css */
+/* end wc.ui.menu.barColumn.ios.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.scss
@@ -16,4 +16,4 @@
 		}
 	}
 }
-/* end wc.ui.menu.barColumn.scss*/
+/* end wc.ui.menu.barColumn.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.color.scss
@@ -59,4 +59,4 @@
 	background-color: $wc-ui-color-invite-bg;
 	color: $wc-ui-color-invite-fg;
 }
-/* end wc.ui.menu.color.css */
+/* end wc.ui.menu.color.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.scss
@@ -61,4 +61,4 @@
 		display: none;
 	}
 }
-/* end wc.ui.menu.css */
+/* end wc.ui.menu.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.tree.icon.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.tree.icon.scss
@@ -1,4 +1,4 @@
-/* wc.ui.menu,tree.icon.scss */
+/* wc.ui.menu.tree.icon.scss */
 // tree menu branch indicators
 [role='treeitem'] {
 	&[aria-expanded] {
@@ -16,4 +16,4 @@
 		}
 	}
 }
-/* END wc.ui.menu,tree.icon.scss */
+/* end wc.ui.menu.tree.icon.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.tree.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.tree.scss
@@ -1,4 +1,4 @@
-/* wc.ui.menu.tree.css */
+/* wc.ui.menu.tree.scss */
 @import 'wc.ui.menu_vars.scss';
 
 [role='tree'] [role='treeitem'],
@@ -20,4 +20,4 @@
 		background-color: inherit;
 	}
 }
-/* end wc.ui.menu.tree.css*/
+/* end wc.ui.menu.tree.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.multiFormComponent.icons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.multiFormComponent.icons.scss
@@ -29,4 +29,4 @@
 		}
 	}
 }
-/* end wc.ui.multiFormComponent.icons.scss*/
+/* end wc.ui.multiFormComponent.icons.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.multiFormComponent.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.multiFormComponent.scss
@@ -1,8 +1,5 @@
-/*
- * wc.ui.multiFormComponent.scss
- *
- * WMultiTextField and WMultiDropdown
- */
+/* wc.ui.multiFormComponent.scss */
+// WMultiTextField and WMultiDropdown
 @import 'vars_all.scss';
 
 .wc_mfc {

--- a/wcomponents-theme/src/main/sass/wc.ui.multiSelectPair.icons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.multiSelectPair.icons.scss
@@ -1,4 +1,4 @@
-/* wc.ui.multiSelectPair.icons.scss*/
+/* wc.ui.multiSelectPair.icons.scss */
 @import 'mixins_common.scss';
 
 .wc_msp_btncol button {
@@ -40,4 +40,4 @@
 		}
 	}
 }
-/* end wc.ui.multiSelectPair.icons.css*/
+/* end wc.ui.multiSelectPair.icons.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.multiSelectPair.pattern_ff.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.multiSelectPair.pattern_ff.scss
@@ -1,5 +1,5 @@
-/* wc.ui.multiSelectPair.ff.css */
+/* wc.ui.multiSelectPair.ff.scss */
 .multiSelectPair select {
 	min-height: 9em;
 }
-/* end wc.ui.multiSelectPair.ff.css*/
+/* end wc.ui.multiSelectPair.ff.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.multiSelectPair.pattern_ios.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.multiSelectPair.pattern_ios.scss
@@ -1,4 +1,4 @@
-/* wc.ui.multiSelectPair.ios.css */
+/* wc.ui.multiSelectPair.ios.scss */
 @import 'mixins_common.scss';
 
 .wc_msp_btncol button {
@@ -6,4 +6,4 @@
 	border-radius: 3px;
 	padding: 6px;
 }
-/* end wc.ui.multiSelectPair.ios.css*/
+/* end wc.ui.multiSelectPair.ios.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.multiSelectPair.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.multiSelectPair.scss
@@ -43,4 +43,4 @@
 		}
 	}
 }
-/* end wc.ui.multiSelectPair.scss*/
+/* end wc.ui.multiSelectPair.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.borderLayout.ie10.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.borderLayout.ie10.scss
@@ -1,4 +1,4 @@
-/* wc.ui.panel.borderLayout.ie10.css */
+/* wc.ui.panel.borderLayout.ie10.scss */
 //scss-lint:disable VendorPrefix
 .wc_borderLayout_middle {
 	display: -ms-flexbox;
@@ -19,4 +19,4 @@
 		}
 	}
 }
-/* end wc.ui.panel.borderLayout.ie10.css */
+/* end wc.ui.panel.borderLayout.ie10.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.borderLayout.ie9.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.borderLayout.ie9.scss
@@ -1,4 +1,4 @@
-/* wc.ui.panel.borderLayout.ie9.css */
+/* wc.ui.panel.borderLayout.ie9.scss */
 .wc_borderLayout_middle {
 	> div {
 		box-sizing: border-box;
@@ -23,4 +23,4 @@
 		}
 	}
 }
-/* end wc.ui.panel.borderLayout.ie9.css */
+/* end wc.ui.panel.borderLayout.ie9.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.flowLayout.ie10.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.flowLayout.ie10.scss
@@ -1,4 +1,4 @@
-/* wc.ui.panel.flowLayout.ie10.css */
+/* wc.ui.panel.flowLayout.ie10.scss */
 //scss-lint:disable VendorPrefix
 .flowLayout {
 	display: -ms-flexbox;
@@ -23,4 +23,4 @@
 		-ms-flex: 0 1 auto;
 	}
 }
-/* end wc.ui.panel.flowLayout.ie10.css */
+/* end wc.ui.panel.flowLayout.ie10.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.flowLayout.ie9.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.flowLayout.ie9.scss
@@ -1,4 +1,4 @@
-/* wc.ui.panel.flowLayout.ie9.css */
+/* wc.ui.panel.flowLayout.ie9.scss */
 
 
 .flowLayout {
@@ -29,4 +29,4 @@
 		width: initial;
 	}
 }
-/* end wc.ui.panel.flowLayout.ie9.css */
+/* end wc.ui.panel.flowLayout.ie9.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.header.mob.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.header.mob.scss
@@ -25,4 +25,4 @@
 		padding: 0;
 	}
 }
-/*  wc.ui.panel.header.mob.scss */
+/* end wc.ui.panel.header.mob.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.header.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.header.scss
@@ -20,4 +20,4 @@
 		color: $wc-ui-color-panel-header-foreground;
 	}
 }
-/* end  wc.ui.panel.header.scss */
+/* end wc.ui.panel.header.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.scss
@@ -2,12 +2,12 @@
 @import 'wc.ui.panel_vars.scss';
 
 .panel[aria-busy='true'] {
-	min-height: $line-size;//always allow room for a loading indicator
+	min-height: $line-size; // always allow room for a loading indicator
 }
 
-//The flowing divs in flowlayout and border layout. This is here for lame browsers and is rudimentary support only.
-//The max-width is to ensure long non-wrapping content which has word-break applied (read-only input components) will
-//honour that wrapping in a flow layout.
+// The flowing divs in flowlayout and border layout. This is here for lame browsers and is rudimentary support only.
+// The max-width is to ensure long non-wrapping content which has word-break applied (read-only input components) will
+// honour that wrapping in a flow layout.
 div {
 	.flowLayout > &,
 	.wc_borderLayout_middle > & {
@@ -16,7 +16,7 @@ div {
 	}
 }
 
-/* BORDER LAYOUT */
+// BORDER LAYOUT
 .wc_borderLayout_middle {
 	@include flex($justify: space-between);
 	> div {
@@ -58,7 +58,7 @@ div {
 		text-align: $preferred-alignment;
 	}
 
-	&.middle {//vertical align middle of the flow
+	&.middle { // vertical align middle of the flow
 		@include flex-align-items(center);
 	}
 

--- a/wcomponents-theme/src/main/sass/wc.ui.progressBar.ie11.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.progressBar.ie11.scss
@@ -1,4 +1,4 @@
-/* wc.ui.progressBar.ie11.css */
+/* wc.ui.progressBar.ie11.scss */
 
 // IE 10 and 11 like big metro progress bars. This is not necessarily a bad thing. Big is 280px wide, 10px high.
 // If you like big then remove this file in your implementation. It is here to make IEs progress bars the same size as
@@ -11,4 +11,4 @@ progress {
 	vertical-align: -0.2em;
 	width: 10em;
 }
-/* end wc.ui.progressBar.ie11.css */
+/* end wc.ui.progressBar.ie11.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.progressBar.ie9.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.progressBar.ie9.scss
@@ -1,8 +1,5 @@
-/**
- * wc.ui.progressBar.ie9.css
- * Description: Show the fake progress bar spans
- */
-
+/* wc.ui.progressBar.ie9.scss */
+// Description: Show the fake progress bar spans
 @import 'wc.ui.progress_var.scss';
 
 progress {
@@ -38,4 +35,4 @@ progress {
 		background-color: $wc-ui-color-progress-fg;
 	}
 }
-/* END OF  wc.ui.progressBar.ie9.css */
+/* end wc.ui.progressBar.ie9.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.progressBar.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.progressBar.scss
@@ -1,4 +1,4 @@
-/* wc.ui.progressBar.css */
+/* wc.ui.progressBar.scss */
 
 // styling for WProgressBar/ui:progressBar component
 // We use a PROGRESS with a nested faux-progress span
@@ -33,4 +33,4 @@ progress {
 		font-size: 0.67em;
 	}
 }
-/* end wc.ui.progressBar.css */
+/* end wc.ui.progressBar.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.radioButton.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.radioButton.ie8.scss
@@ -1,4 +1,4 @@
-/* wc.ui.radioButton.ie8.css */
+/* wc.ui.radioButton.ie8.scss */
 .radio {
 	&:before {
 		content: url('../images/radio-ro.ie8.png');
@@ -8,4 +8,4 @@
 		content: url('../images/radio-s-ro.ie8.png');
 	}
 }
-/* end wc.ui.radioButton.ie8.css */
+/* end wc.ui.radioButton.ie8.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.radioButton.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.radioButton.scss
@@ -1,4 +1,4 @@
-/* wc.ui.radioButton.css */
+/* wc.ui.radioButton.scss */
 @import 'mixins_common.scss';
 .radio { //'readOnly' WRadioButton
 	&::before {
@@ -10,4 +10,4 @@
 		content: url('../images/radio-s-ro.svg');
 	}
 }
-/* end wc.ui.radioButton.css */
+/* end wc.ui.radioButton.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.resizeable.icons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.resizeable.icons.scss
@@ -1,4 +1,4 @@
-/* wc.ui.resizeable.icons.css */
+/* wc.ui.resizeable.icons.scss */
 //scss-lint:disable QualifyingElement
 .wc_resize,
 button.wc_maxcont { //this button selector is required to prevent styling a max.restore header bar
@@ -35,4 +35,4 @@ button.wc_maxcont {
 		}
 	}
 }
-/* END wc.ui.resizeable.ieAll.css*/
+/* end wc.ui.resizeable.ieAll.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.resizeable.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.resizeable.scss
@@ -2,7 +2,7 @@
 @import 'mixins_common.scss';
 
 .wc_max { // maximised:
-	//scss-lint:disable ImportantRule
+	// scss-lint:disable ImportantRule
 	@include border-box;
 	height: 100% !important;
 	left: 0 !important;
@@ -12,8 +12,8 @@
 	width: 100% !important;
 }
 
-/* the resize handle */
+// the resize handle
 .wc_resize {
 	cursor: se-resize;
 }
-/* end of wc.ui.resizeable.scss */
+/* end wc.ui.resizeable.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.root.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.root.scss
@@ -1,4 +1,4 @@
-/* wc.ui.root.css */
+/* wc.ui.root.scss */
 @import 'mixins_common.scss';
 
 noscript p {
@@ -11,4 +11,4 @@ noscript p {
 	padding: 1em;
 	text-align: center;
 }
-/* end wc.ui.root.css */
+/* end wc.ui.root.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.section.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.section.scss
@@ -1,5 +1,4 @@
-/* wc.ui.section.scss
- * for WSection */
+/* wc.ui.section.scss */
 @import 'mixins_common.scss';
 
 .section {

--- a/wcomponents-theme/src/main/sass/wc.ui.selectToggle.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.selectToggle.ie8.scss
@@ -1,4 +1,4 @@
-/* wc.ui.selectToggle.ie8.css */
+/* wc.ui.selectToggle.ie8.scss */
 .wc_seltog {
 	&[role='checkbox'] {
 		height: 12px;
@@ -23,4 +23,4 @@
 		}
 	}
 }
-/* end wc.ui.selectToggle.ie8.css */
+/* end wc.ui.selectToggle.ie8.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.shuffler.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.shuffler.scss
@@ -1,8 +1,8 @@
-/* wc.ui.shuffler.css */
+/* wc.ui.shuffler.scss */
 // Shuffler is a select element where the option order is able to be changed.
 // we have a bunch of buttons next to this component, we better make the select at least as high as the button tower.
 //scss-lint:disable QualifyingElement
 select.shuffler {
 	min-height: 8em;
 }
-/* end wc.ui.shuffler.css */
+/* end wc.ui.shuffler.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.table.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.ie8.scss
@@ -1,4 +1,4 @@
-/*wc.ui.table.ie8.scss*/
+/* wc.ui.table.ie8.scss */
 @import 'vars_all.scss';
 
 //scss-lint:disable QualifyingElement
@@ -12,4 +12,4 @@ tr.wc_table_stripe { // tr required to differentiate from col
 	max-width: $line-size;
 	width: $line-size;
 }
-/*end wc.ui.table.ie8.scss*/
+/* end wc.ui.table.ie8.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansion.icons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansion.icons.scss
@@ -1,4 +1,4 @@
-/* wc.ui.table.rowExpansion.icons.css */
+/* wc.ui.table.rowExpansion.icons.scss */
 @import 'vars_all.scss';
 
 // ROW EXPANSION iconography and expand/collapse all iconography.
@@ -13,4 +13,4 @@
 		content: url('../images/down.png');
 	}
 }
-/* end wc.ui.table.rowExpansion.icons.css*/
+/* end wc.ui.table.rowExpansion.icons.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansion.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansion.scss
@@ -1,4 +1,4 @@
-/* wc.ui.table.rowExpansion.css */
+/* wc.ui.table.rowExpansion.scss */
 @import 'mixins_common.scss';
 
 thead .rowExpansion {
@@ -38,4 +38,4 @@ thead .rowExpansion {
 [aria-disabled='true'] > .wc_table_rowexp_container button:before {
 	opacity: 0.5;
 }
-/* end wc.ui.table.rowExpansion.css*/
+/* end wc.ui.table.rowExpansion.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.ie9.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.ie9.scss
@@ -1,6 +1,6 @@
-/* wc.ui.table.rowSelection.ie9.css */
+/* wc.ui.table.rowSelection.ie9.scss */
 .wc_table_sel_wrapper::before {
 	height: 12px;
 	width: 16px;
 }
-/* end wc.ui.table.rowSelection.ie9.css */
+/* end wc.ui.table.rowSelection.ie9.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.scss
@@ -1,4 +1,4 @@
-/* wc.ui.table.rowSelection.css */
+/* wc.ui.table.rowSelection.scss */
 @import 'wc.ui.table.rowSelection_vars.scss';
 //scss-lint:disable QualifyingElement
 tr[aria-checked] {
@@ -35,4 +35,4 @@ tr[aria-checked] {
 		opacity: $row-disable-opacity;
 	}
 }
-/* end wc.ui.table.rowSelection.css */
+/* end wc.ui.table.rowSelection.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.table.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.scss
@@ -1,4 +1,4 @@
-/* wc.ui.table.css */
+/* wc.ui.table.scss */
 // This is the core of the table CSS. The other CSS files are used for functional images and other items which are less
 // likely to be implementation specific
 @import 'wc.ui.table_vars.scss';
@@ -15,7 +15,7 @@ table {
 	min-width: 100%;
 }
 
-/* fix the layout of tables where column width is applied */
+// fix the layout of tables where column width is applied
 .wc_table_fix {
 	table-layout: fixed;
 }
@@ -25,7 +25,7 @@ thead {
 	color: $wc-ui-color-table-head-fg;
 
 	[disabled] {
-		//scss-lint:disable ImportantRule
+		// scss-lint:disable ImportantRule
 		color: $wc-ui-color-table-head-disabled !important;
 	}
 }
@@ -70,4 +70,4 @@ col.wc_table_stripe,
 tr.wc_table_stripe {
 	background-color: $wc-ui-color-highlight-bg;
 }
-/*end wc.ui.table.css*/
+/* end wc.ui.table.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.table.separators.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.separators.scss
@@ -1,4 +1,4 @@
-/* wc.ui.table.separators.css */
+/* wc.ui.table.separators.scss */
 // Row and Column Separators
 
 // .wc_table_rowsep is applied to the tbody

--- a/wcomponents-theme/src/main/sass/wc.ui.table.sort.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.sort.color.scss
@@ -1,4 +1,4 @@
-/* wc.ui.table.sort.color.css */
+/* wc.ui.table.sort.color.scss */
 
 // Column sorting relate to the sorting of data in sortable tables.
 // This css covers control elements in the heading cells and the rendering of sorted columns.
@@ -9,4 +9,4 @@ th[aria-sort$='ending'] {
 	background-color: $wc-ui-color-highlight-bg;
 	color: $wc-ui-color-highlight-fg;
 }
-/* end wc.ui.table.sort.color.css */
+/* end wc.ui.table.sort.color.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.tabset.ie10.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.tabset.ie10.scss
@@ -1,4 +1,4 @@
-/* wc.ui.tabset.ie9=10.css */
+/* wc.ui.tabset.ie10.scss */
 //scss-lint:disable VendorPrefix
 .top > [role='tablist'] {
 	display: -ms-flexbox;
@@ -9,4 +9,4 @@
 		-ms-flex: 0 1 auto;
 	}
 }
-/* end wc.ui.tabset.ie10.css */
+/* end wc.ui.tabset.ie10.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.tabset.ie9.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.tabset.ie9.scss
@@ -1,4 +1,4 @@
-/* wc.ui.tabset.ie9.css */
+/* wc.ui.tabset.ie9.scss */
 .top > [role='tablist'] {
 	overflow: hidden;
 	white-space: nowrap;
@@ -8,4 +8,4 @@
 		top: 1px;
 	}
 }
-/* end wc.ui.tabset.ie9.css */
+/* end wc.ui.tabset.ie9.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.timeoutWarn.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.timeoutWarn.scss
@@ -1,14 +1,12 @@
-/* wc.ui.timeoutWarn.css
-
-* NOTES: background-color is needed to make it opaque; z-index needs to be above dialogs.*/
+/* wc.ui.timeoutWarn.scss */
 @import 'vars_all.scss';
 //scss-lint:disable IdSelector
 #wc_session_container {
-	background-color: $wc-ui-color-global-bg;
+	background-color: $wc-ui-color-global-bg; // to make it opaque;
 	bottom: 0;
 	position: fixed;
 	right: 0;
 	width: 35em;
-	z-index: 100;
+	z-index: 100; // z-index needs to be above dialogs
 }
-/* end wc.ui.timeoutWarn.css*/
+/* end wc.ui.timeoutWarn.scss */


### PR DESCRIPTION
Changed the Comment rule.

Sass may now only contain CSS style comments as file markers:

* `/* wc.FOO.scss */` and 
* `/* end wc.FOO.scss */`.

Fixed all current scss files so that previous CSS comments are now Sass comments and the head and tail file markers are consistent.