### PR TITLE
Removed unused dependency

### DIFF
--- a/wcomponents-theme-parent/pom.xml
+++ b/wcomponents-theme-parent/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 
 	<packaging>pom</packaging>
-	
+
 	<properties>
 		<!--
 			We externalize download URLs so that in-house builds can override them to on-prem mirrors.
@@ -264,11 +264,6 @@
 						<groupId>net.sf.saxon</groupId>
 						<artifactId>Saxon-HE</artifactId>
 						<version>9.4</version>
-					</dependency>
-					<dependency>
-						<groupId>batik</groupId>
-						<artifactId>batik-rasterizer</artifactId>
-						<version>1.6-1</version>
 					</dependency>
 					<dependency>
 						<groupId>com.google.javascript</groupId>

--- a/wcomponents-theme/build-images.xml
+++ b/wcomponents-theme/build-images.xml
@@ -35,7 +35,7 @@
 			<fileset dir="${impl.images.rootdir}" includes="*.*" excludes="*.svg"/>
 		</copy>
 		<copy todir="${images.tmp.src.dir}" overwrite="true">
-			<fileset dir="${images.rootdir}" includes="*.svg" excludes="*${wc.ui.icon.svg.src}.svg" excludesfile="${excludesfile}"/><!-- excludes="*.icon.sprite.*.svg"-->
+			<fileset dir="${images.rootdir}" includes="*.svg" excludesfile="${excludesfile}"/>
 			<filterchain>
 				<expandproperties/>
 				<deletecharacters chars="\t"/>
@@ -45,7 +45,7 @@
 			</filterchain>
 		</copy>
 		<copy todir="${images.tmp.src.dir}" overwrite="true">
-			<fileset dir="${impl.images.rootdir}" excludes="${wc.ui.icon.svg.src}.svg,${imp.ui.icon.svg.src}.svg" includes="*.svg"/><!-- excludes="*.icon.sprite.*.svg"-->
+			<fileset dir="${impl.images.rootdir}" includes="*.svg"/>
 			<filterchain>
 				<expandproperties/>
 				<deletecharacters chars="\t"/>


### PR DESCRIPTION
The wcomponent-theme-parent POM held a dependency on apache batik which
has not been used for some time. This dependency was removed. Whilst
checking for residual mentions found that the wcomponent-theme
build-images.xml retained references to an excluded svg file which has
also not existed for many years so these excludes were also removed.