### PR TITLE
Add WAI-ARIA role helper module

### DIFF
--- a/wcomponents-theme/src/main/js/wc/dom/ariaGroup.js
+++ b/wcomponents-theme/src/main/js/wc/dom/ariaGroup.js
@@ -5,16 +5,17 @@
  * @requires module:wc/array/toArray
  * @requires module:wc/dom/aria
  * @requires module:wc/dom/Widget
- * @requires module:wc/dom/impliedARIA
+ * @requires module:wc/dom/role
+ * @requires
  *
  * @todo document private members, clean up code.
  */
 define(["wc/array/toArray",
 		"wc/dom/aria",
 		"wc/dom/Widget",
-		"wc/dom/impliedARIA"],
-	/** @param toArray wc/array/toArray @param aria wc/dom/aria @param Widget wc/dom/Widget @param impliedAria wc/dom/impliedARIA @ignore */
-	function(toArray, aria, Widget, impliedAria) {
+		"wc/dom/role"],
+	/** @param toArray wc/array/toArray @param aria wc/dom/aria @param Widget wc/dom/Widget @param $role wc/dom/r4ole @ignore */
+	function(toArray, aria, Widget, $role) {
 		"use strict";
 
 		/**
@@ -82,7 +83,7 @@ define(["wc/array/toArray",
 			 */
 			this.getGroup = function (element, role, ignoreInnerGroups) {
 				var container,
-					_role = role || getRole(element),
+					_role = role || $role.get(element, true),
 					containerWd,
 					scopedRoles,
 					candidates,
@@ -109,7 +110,7 @@ define(["wc/array/toArray",
 				if (container) {
 
 					if (rescope) {
-						_role = getRole(container);
+						_role = $role.get(container, true);
 						scopedRoles = aria.getMustContain(_role);
 						if (!scopedRoles.length) {
 							scopedRoles = aria.getScopedTo(_role);
@@ -164,7 +165,7 @@ define(["wc/array/toArray",
 					if (containerWd) {
 						result = containerWd.findAncestor(element);
 					}
-					else if ((role = getRole(element))) {
+					else if ((role = $role.get(element, true))) {
 						scope = aria.getScope(role);
 						if (!(scope && scope.length)) {
 							scope = aria.getScopedBy(role);
@@ -215,23 +216,6 @@ define(["wc/array/toArray",
 					});
 				}
 				return widgets;
-			}
-
-			/**
-			 * Get the role of an element. This will return the implied role of an element with a native equivalent.
-			 *
-			 * @function
-			 * @private
-			 * @param {Element} element The element from which to get the role.
-			 * @returns {String} The role.
-			 *
-			 * @example  // given an element (el) with role 'tab'
-			 * getRole(el);  // returns "tab"
-			 * @example  // Implied role: given an input element (el) with type "text":
-			 * getRole(el);  // returns "textbox"
-			 */
-			function getRole(element) {
-				return element.getAttribute("role") || impliedAria.getImpliedRole(element);
 			}
 		}
 		return /** @alias module:wc/dom/ariaGroup */ new AriaGroup();

--- a/wcomponents-theme/src/main/js/wc/dom/group.js
+++ b/wcomponents-theme/src/main/js/wc/dom/group.js
@@ -16,13 +16,13 @@
  * @module
  * @requires module:wc/dom/tag
  * @requires module:wc/array/toArray
- * @requires module:wc/dom/Widget
  * @requires module:wc/dom/getAncestorOrSelf
  * @requires module:wc/dom/ariaGroup
+ * @requires module:wc/dom/role
  */
-define(["wc/dom/tag", "wc/array/toArray", "wc/dom/Widget", "wc/dom/getAncestorOrSelf", "wc/dom/ariaGroup"],
-	/** @param tag wc/dom/tag @param toArray wc/array/toArray @param Widget wc/dom/Widget @param getAncestorOrSelf wc/dom/getAncestorOrSelf @param ariaGroup wc/dom/ariaGroup @ignore */
-	function(tag, toArray, Widget, getAncestorOrSelf, ariaGroup) {
+define(["wc/dom/tag", "wc/array/toArray",  "wc/dom/getAncestorOrSelf", "wc/dom/ariaGroup", "wc/dom/role"],
+	/** @param tag wc/dom/tag @param toArray wc/array/toArray @param getAncestorOrSelf wc/dom/getAncestorOrSelf @param ariaGroup wc/dom/ariaGroup @param $role wc/dom/role @ignore */
+	function(tag, toArray, getAncestorOrSelf, ariaGroup, $role) {
 		"use strict";
 		/**
 		 * @constructor
@@ -83,7 +83,7 @@ define(["wc/dom/tag", "wc/array/toArray", "wc/dom/Widget", "wc/dom/getAncestorOr
 					}
 				}
 				// if all else fails get an aria based group
-				if (!(group && group.length) && (role = element.getAttribute("role"))) {
+				if (!(group && group.length) && (role = $role.get(element))) {
 					group = ariaGroup.getGroup(element, role, ignoreInnerGroups);
 				}
 

--- a/wcomponents-theme/src/main/js/wc/dom/role.js
+++ b/wcomponents-theme/src/main/js/wc/dom/role.js
@@ -1,0 +1,54 @@
+/**
+ * Utility class for dealing with WAI-ARIA role or implied role of elements.
+ *
+ * @module
+ * @requires module:wc/dom/impliedARIA
+ */
+define(["wc/dom/impliedARIA"], /** @param {Object} impliedARIA @ignore */function (impliedARIA){
+	"use strict";
+
+	/**
+	 * @constructor
+	 * @alias wc/dom/role~Role
+	 * @private
+	 */
+	function Role() {
+
+		/**
+		 * Get the role (or implied role) of an element.
+		 *
+		 * @param {Element} element The element to test.
+		 * @param {boolean} [implied] Include getting implied role if true.
+		 * @returns {?String} The WAI-ARIA role of the element, including its implied role if required.
+		 */
+		this.get = function(element, implied) {
+			var role;
+			if(element && element.nodeType === Node.ELEMENT_NODE) {
+				role = element.getAttribute("role");
+				if(implied && !role) {
+					role = impliedARIA.getImpliedRole(element);
+				}
+			}
+			return role;
+		};
+
+		/**
+		 * Test if an element has a WAI-ARIA role.
+		 * @param {Element} element The element to test.
+		 * @param {boolean} implied Should we test if the element has an implied role?
+		 * @returns {Boolean} true if the element has a role (or implied role if implied is true).
+		 */
+		this.has = function(element, implied) {
+			var result = false;
+			if(element && element.nodeType === Node.ELEMENT_NODE) {
+				result = element.hasAttribute("role");
+				if(implied && !result) {
+					result = !!impliedARIA.getImpliedRole(element);
+				}
+			}
+			return result;
+		};
+	}
+
+	return /** @alias wc/dom/role */ new Role();
+});

--- a/wcomponents-theme/src/main/js/wc/dom/role.js
+++ b/wcomponents-theme/src/main/js/wc/dom/role.js
@@ -4,7 +4,7 @@
  * @module
  * @requires module:wc/dom/impliedARIA
  */
-define(["wc/dom/impliedARIA"], /** @param {Object} impliedARIA @ignore */function (impliedARIA){
+define(["wc/dom/impliedARIA"], /** @param {Object} impliedARIA @ignore */ function(impliedARIA) {
 	"use strict";
 
 	/**
@@ -17,15 +17,16 @@ define(["wc/dom/impliedARIA"], /** @param {Object} impliedARIA @ignore */functio
 		/**
 		 * Get the role (or implied role) of an element.
 		 *
+		 * @function module:wc/dom/role.get
 		 * @param {Element} element The element to test.
 		 * @param {boolean} [implied] Include getting implied role if true.
 		 * @returns {?String} The WAI-ARIA role of the element, including its implied role if required.
 		 */
 		this.get = function(element, implied) {
 			var role;
-			if(element && element.nodeType === Node.ELEMENT_NODE) {
+			if (element && element.nodeType === Node.ELEMENT_NODE) {
 				role = element.getAttribute("role");
-				if(implied && !role) {
+				if (implied && !role) {
 					role = impliedARIA.getImpliedRole(element);
 				}
 			}
@@ -34,15 +35,16 @@ define(["wc/dom/impliedARIA"], /** @param {Object} impliedARIA @ignore */functio
 
 		/**
 		 * Test if an element has a WAI-ARIA role.
+		 * @function module:wc/dom/role.has
 		 * @param {Element} element The element to test.
 		 * @param {boolean} implied Should we test if the element has an implied role?
-		 * @returns {Boolean} true if the element has a role (or implied role if implied is true).
+		 * @returns {Boolean} true if the element has a role (or implied role if implied is true.
 		 */
 		this.has = function(element, implied) {
 			var result = false;
-			if(element && element.nodeType === Node.ELEMENT_NODE) {
+			if (element && element.nodeType === Node.ELEMENT_NODE) {
 				result = element.hasAttribute("role");
-				if(implied && !result) {
+				if (implied && !result) {
 					result = !!impliedARIA.getImpliedRole(element);
 				}
 			}

--- a/wcomponents-theme/src/main/js/wc/dom/shed.js
+++ b/wcomponents-theme/src/main/js/wc/dom/shed.js
@@ -31,6 +31,7 @@
  * @requires module:wc/dom/tag
  * @requires module:wc/dom/Widget
  * @requires module:wc/dom/getLabelsForElement
+ * @requires module:wc/dom/role
  *
  * @todo re-order code, document private methods.
  */
@@ -41,9 +42,10 @@ define(["wc/Observer",
 		"wc/dom/disabledLink",
 		"wc/dom/tag",
 		"wc/dom/Widget",
-		"wc/dom/getLabelsForElement"],
-	/** @param Observer wc/Observer @param aria wc/dom/aria @param impliedAria wc/dom/impliedARIA @param classList wc/dom/classList @param disabledLink wc/dom/disabledLink @param tag wc/dom/tag @param Widget wc/dom/Widget @param getLabelsForElement wc/dom/getLabelsForElement @ignore */
-	function(Observer, aria, impliedAria, classList, disabledLink, tag, Widget, getLabelsForElement) {
+		"wc/dom/getLabelsForElement",
+		"wc/dom/role"],
+	/** @param Observer wc/Observer @param aria wc/dom/aria @param impliedAria wc/dom/impliedARIA @param classList wc/dom/classList @param disabledLink wc/dom/disabledLink @param tag wc/dom/tag @param Widget wc/dom/Widget @param getLabelsForElement wc/dom/getLabelsForElement @param $role wc/dom/role @ignore */
+	function(Observer, aria, impliedAria, classList, disabledLink, tag, Widget, getLabelsForElement, $role) {
 		"use strict";
 
 		/**
@@ -93,7 +95,7 @@ define(["wc/Observer",
 				var _nativeState = NATIVE_STATE[STATE],
 					_ariaState = ARIA_STATE[STATE],
 					nativeSupported = impliedAria.supportsNativeState(element, STATE),
-					role = getRole(element),
+					role = $role.get(element, true),
 					supported,
 					ariaSupported,
 					kids,
@@ -139,7 +141,7 @@ define(["wc/Observer",
 							if (!reverse) {
 								element.tabIndex = -1;
 							}
-							else if (element.getAttribute("role")) {
+							else if ($role.get(element)) {
 								element.tabIndex = 0;
 							}
 							else {
@@ -188,18 +190,6 @@ define(["wc/Observer",
 			 */
 			function expandWithOpen(element) {
 				return element.tagName === tag.DETAILS;
-			}
-
-			/**
-			 * Gets a WAI-ARIA role for a given element. This includes implicit roles such as the role of "button" on a
-			 * HTML BUTTON element with no role attribute.
-			 * @function
-			 * @private
-			 * @param {Element} element The element to test.
-			 * @returns {String} A WAI-ARIA role.
-			 */
-			function getRole(element) {
-				return element.getAttribute("role") || impliedAria.getImpliedRole(element);
 			}
 
 			/**
@@ -355,7 +345,7 @@ define(["wc/Observer",
 			function selectHelper(action, element) {
 				var preferred, i, len,
 					supported,
-					role = getRole(element),
+					role = $role.get(element, true),
 					mixed = (action === instance.state.MIXED);
 
 				if (role && !(impliedAria.supportsNativeState(element, ANY_SEL_STATE))) {
@@ -690,7 +680,7 @@ define(["wc/Observer",
 					result = true;
 				}
 				else {
-					role = getRole(element);
+					role = $role.get(element, true);
 					if ((supported = aria.getSupported(role))) {
 						supported = ARIA_STATE[SELECTED].filter(function(attr) {
 							return (supported[attr] === aria.SUPPORTED || supported[attr] === aria.REQUIRED);
@@ -724,7 +714,7 @@ define(["wc/Observer",
 					nextResult,
 					level,
 					supported,
-					role = getRole(element);
+					role = $role.get(element, true);
 				if (role && !(impliedAria.supportsNativeState(element, ANY_SEL_STATE))) {
 					supported = aria.getSupported(role);
 					for (i = (ARIA_STATE[SELECTED].length - 1); i >= 0; i--) {

--- a/wcomponents-theme/src/main/js/wc/ui/collapsible.js
+++ b/wcomponents-theme/src/main/js/wc/ui/collapsible.js
@@ -14,6 +14,7 @@
  * @requires module:wc/timers
  * @requires module:wc/dom/isEventInLabel
  * @requires module:wc/dom/isAcceptableTarget
+ * @requires module:wc/dom/role
  */
 define(["wc/dom/event",
 		"wc/dom/attribute",
@@ -25,9 +26,10 @@ define(["wc/dom/event",
 		"wc/dom/shed",
 		"wc/timers",
 		"wc/dom/isEventInLabel",
-		"wc/dom/isAcceptableTarget"],
-	/** @param event wc/dom/event @param attribute wc/dom/attribute @param focus wc/dom/focus @param formUpdateManager wc/dom/formUpdateManager @param has wc/has @param initialise wc/dom/initialise @param Widget wc/dom/Widget @param shed wc/dom/shed @param timers wc/timers @param isEventInLabel wc/dom/isEventInLabel @param isAcceptableEventTarget wc/dom/isAcceptableTarget @ignore */
-	function(event, attribute, focus, formUpdateManager, has, initialise, Widget, shed, timers, isEventInLabel, isAcceptableEventTarget) {
+		"wc/dom/isAcceptableTarget",
+		"wc/dom/role"],
+	/** @param event wc/dom/event @param attribute wc/dom/attribute @param focus wc/dom/focus @param formUpdateManager wc/dom/formUpdateManager @param has wc/has @param initialise wc/dom/initialise @param Widget wc/dom/Widget @param shed wc/dom/shed @param timers wc/timers @param isEventInLabel wc/dom/isEventInLabel @param isAcceptableEventTarget wc/dom/isAcceptableTarget @param $role wc/dom/role @ignore */
+	function(event, attribute, focus, formUpdateManager, has, initialise, Widget, shed, timers, isEventInLabel, isAcceptableEventTarget, $role) {
 		"use strict";
 
 		/**
@@ -213,7 +215,7 @@ define(["wc/dom/event",
 							shed.enable(header, true);
 						}
 					}
-					else if (header.getAttribute("role") === "button") {
+					else if ($role.get(header) === "button") {
 						header.setAttribute("aria-expanded", action === shed.actions.EXPAND ? TRUE : FALSE);
 					}
 				}

--- a/wcomponents-theme/src/main/js/wc/ui/dialog.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dialog.js
@@ -23,6 +23,7 @@
  * @requires module:wc/ui/resizeable
  * @requires module:wc/ui/positionable
  * @requires module:wc/ui/draggable
+ * @requires module:wc/dom/role
  *
  * @todo Re-order source, document private members.
  */
@@ -43,10 +44,11 @@ define(["wc/dom/classList",
 		"wc/has",
 		"wc/ui/resizeable",
 		"wc/ui/positionable",
-		"wc/ui/draggable"],
-	/** @param classList wc/dom/classList @param event wc/dom/event @param focus wc/dom/focus @param initialise wc/dom/initialise @param shed wc/dom/shed @param Widget wc/dom/Widget @param i18n wc/i18n/i18n @param loader wc/loader/resource @param sprintf sprintf/sprintf @param ajaxRegion wc/ui/ajaxRegion @param processResponse wc/ui/ajax/processResponse @param modalShim wc/ui/modalShim @param timers wc/timers @param eagerLoader wc/ui/containerload @param has wc/has @param resizeable wc/ui/resizeable @param positionable wc/ui/positionable @ignore */
+		"wc/ui/draggable",
+		"wc/dom/role"],
+	/** @param classList wc/dom/classList @param event wc/dom/event @param focus wc/dom/focus @param initialise wc/dom/initialise @param shed wc/dom/shed @param Widget wc/dom/Widget @param i18n wc/i18n/i18n @param loader wc/loader/resource @param sprintf sprintf/sprintf @param ajaxRegion wc/ui/ajaxRegion @param processResponse wc/ui/ajax/processResponse @param modalShim wc/ui/modalShim @param timers wc/timers @param eagerLoader wc/ui/containerload @param has wc/has @param resizeable wc/ui/resizeable @param positionable wc/ui/positionable @param $role wc/dom/role @ignore */
 	function(classList, event, focus, initialise, shed, Widget, i18n, loader, sprintf, ajaxRegion, processResponse,
-		modalShim, timers, eagerLoader, has, resizeable, positionable) {
+		modalShim, timers, eagerLoader, has, resizeable, positionable, $role) {
 		"use strict";
 
 		/*
@@ -152,7 +154,7 @@ define(["wc/dom/classList",
 			function isModal(dialog) {
 				var content,
 					result = false;
-				if ((content = getContent(dialog)) && content.getAttribute("role") === "alertdialog") {
+				if ((content = getContent(dialog)) && $role.get(content) === "alertdialog") {
 					result = true;
 				}
 				return result;

--- a/wcomponents-theme/src/main/js/wc/ui/label.js
+++ b/wcomponents-theme/src/main/js/wc/ui/label.js
@@ -13,6 +13,7 @@
  * @requires module:wc/ui/ajax/processResponse
  * @requires module:wc/i18n/i18n
  * @requires module:wc/ui/internalLink
+ * @requires module:wc/dom/role
  */
 define(["wc/dom/classList",
 		"wc/dom/initialise",
@@ -22,9 +23,10 @@ define(["wc/dom/classList",
 		"wc/dom/getLabelsForElement",
 		"wc/ui/ajax/processResponse",
 		"wc/i18n/i18n",
-		"wc/ui/internalLink"],
-	/** @param classList wc/dom/classList @param initialise wc/dom/initialise @param shed wc/dom/shed @param tag wc/dom/tag @param Widget wc/dom/Widget @param getLabelsForElement wc/dom/getLabelsForElement @param processResponse wc/ui/ajax/processResponse @param i18n wc/i18n/i18n @ignore */
-	function(classList, initialise, shed, tag, Widget, getLabelsForElement, processResponse, i18n) {
+		"wc/ui/internalLink",
+		"wc/dom/role"],
+	/** @param classList wc/dom/classList @param initialise wc/dom/initialise @param shed wc/dom/shed @param tag wc/dom/tag @param Widget wc/dom/Widget @param getLabelsForElement wc/dom/getLabelsForElement @param processResponse wc/ui/ajax/processResponse @param i18n wc/i18n/i18n @param $role wc/dom/role @ignore */
+	function(classList, initialise, shed, tag, Widget, getLabelsForElement, processResponse, i18n, $role) {
 		"use strict";
 		/*
 		 * Implicit dependencies:
@@ -99,7 +101,7 @@ define(["wc/dom/classList",
 			function shedMandatorySubscriber(element, action) {
 				if (element && !(element.tagName === tag.INPUT && element.type === "radio")) {
 					// this does not apply to making a radio button mandatory (that just leads to confusion)
-					if (TAGS.indexOf(element.tagName) > -1 || element.getAttribute("role")) {
+					if (TAGS.indexOf(element.tagName) > -1 || $role.has(element)) {
 						// read-only components should not be mandatory/optional
 						mungeLabels(element, (action === shed.actions.OPTIONAL ? "remove" : "add"), "wc_req");
 					}


### PR DESCRIPTION
We had a bunch of getting and checking of the role attribute scattered around, some of which then required knowing how and when to get an implied role for a control. These have been replaced with a call to a helper wc/dom/role which has (currently) two public methods: get and has.