### PR TITLE
Set initial scale to 1 on mobile

### DIFF
--- a/wcomponents-theme/src/main/js/wc/dom/role.js
+++ b/wcomponents-theme/src/main/js/wc/dom/role.js
@@ -4,7 +4,7 @@
  * @module
  * @requires module:wc/dom/impliedARIA
  */
-define(["wc/dom/impliedARIA"], /** @param {Object} impliedARIA @ignore */function (impliedARIA){
+define(["wc/dom/impliedARIA"], /** @param {Object} impliedARIA @ignore */ function(impliedARIA) {
 	"use strict";
 
 	/**
@@ -17,15 +17,16 @@ define(["wc/dom/impliedARIA"], /** @param {Object} impliedARIA @ignore */functio
 		/**
 		 * Get the role (or implied role) of an element.
 		 *
+		 * @function module:wc/dom/role.get
 		 * @param {Element} element The element to test.
 		 * @param {boolean} [implied] Include getting implied role if true.
 		 * @returns {?String} The WAI-ARIA role of the element, including its implied role if required.
 		 */
 		this.get = function(element, implied) {
 			var role;
-			if(element && element.nodeType === Node.ELEMENT_NODE) {
+			if (element && element.nodeType === Node.ELEMENT_NODE) {
 				role = element.getAttribute("role");
-				if(implied && !role) {
+				if (implied && !role) {
 					role = impliedARIA.getImpliedRole(element);
 				}
 			}
@@ -34,15 +35,16 @@ define(["wc/dom/impliedARIA"], /** @param {Object} impliedARIA @ignore */functio
 
 		/**
 		 * Test if an element has a WAI-ARIA role.
+		 * @function module:wc/dom/role.has
 		 * @param {Element} element The element to test.
 		 * @param {boolean} implied Should we test if the element has an implied role?
-		 * @returns {Boolean} true if the element has a role (or implied role if implied is true).
+		 * @returns {Boolean} true if the element has a role (or implied role if implied is true.
 		 */
 		this.has = function(element, implied) {
 			var result = false;
-			if(element && element.nodeType === Node.ELEMENT_NODE) {
+			if (element && element.nodeType === Node.ELEMENT_NODE) {
 				result = element.hasAttribute("role");
-				if(implied && !result) {
+				if (implied && !result) {
 					result = !!impliedARIA.getImpliedRole(element);
 				}
 			}

--- a/wcomponents-theme/src/main/sass/mixins_respond.scss
+++ b/wcomponents-theme/src/main/sass/mixins_respond.scss
@@ -60,3 +60,15 @@ $large: 2000px;
 		}
 	}
 }
+
+// create a viewport media rule
+@mixin viewport() {
+	@-ms-viewport {
+		@content
+
+	}
+
+	@viewport {
+		@content
+	}
+}

--- a/wcomponents-theme/src/main/sass/wc.common.page.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.page.scss
@@ -110,4 +110,11 @@ a[name],
 input[type='number'][maxlength] {
 	@include outline($color: $wc-ui-color-error-fg);
 }
+
+
+@include viewport {
+	user-zoom: zoom;
+	width: extend-to-zoom;
+	zoom: 1;
+}
 /* end wc.common.page.scss */

--- a/wcomponents-theme/src/main/xslt/wc.ui.root.n.addHeadMetaBeforeTitle.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.root.n.addHeadMetaBeforeTitle.xsl
@@ -1,19 +1,20 @@
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">	
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
 	<xsl:import href="wc.ui.root.n.includeFavicon.xsl"/>
 	<!--
-		There may be occasions when you want to add very early meta elements to the head (such as adding an IE 
+		There may be occasions when you want to add very early meta elements to the head (such as adding an IE
 		compatibility meta). This template is here for EXACTLY that purpose.
-		
-		The format-detection is needed to work around issues in some very popular mobile browsers that will convert
-		"numbers" into phone links (a elements) if they appear to be phone numbers, even if those numbers are the
-		content of buttons or links. This breaks important stuff if you, for example, want to link or submit using
-		a number identifier.
-		
-		If you want a phone number link in these (or any) browser use WPhoneNumberField set readOnly.
 	-->
 	<xsl:template name="addHeadMetaBeforeTitle">
 		<!-- Works more reliably if it is first -->
 		<xsl:call-template name="includeFavicon"/>
+		<!--
+		The format-detection is needed to work around issues in some very popular mobile browsers that will convert
+		"numbers" into phone links (a elements) if they appear to be phone numbers, even if those numbers are the
+		content of buttons or links. This breaks important stuff if you, for example, want to link or submit using
+		a number identifier.
+
+		If you want a phone number link in these (or any) browser use WPhoneNumberField set readOnly.
+		-->
 		<xsl:element name="meta">
 			<xsl:attribute name="name">
 				<xsl:text>format-detection</xsl:text>
@@ -21,6 +22,10 @@
 			<xsl:attribute name="content">
 				<xsl:text>telephone=no</xsl:text>
 			</xsl:attribute>
+		</xsl:element>
+		<xsl:element name="meta">
+			<xsl:attribute name="name"><xsl:text>viewport</xsl:text></xsl:attribute>
+			<xsl:attribute name="content"><xsl:text>initial-scale=1</xsl:text></xsl:attribute>
 		</xsl:element>
 	</xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Added CSS viewport and viewport meta element to set initial scale to 1. Still allow user scaling as this is important to a11y. @ricksbrown please merge to release 1.