### PR TITLE
Update ComponentModel API so that it manages its own internal List of children

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWComponent.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWComponent.java
@@ -568,11 +568,10 @@ public abstract class AbstractWComponent implements WComponent {
 		// Prepare this component.
 		preparePaintComponent(request);
 
-		// Prepare its children.
-		final ArrayList<WComponent> children = (ArrayList<WComponent>) getComponentModel().
-				getChildren();
+		if (getComponentModel().hasChildren()) {
 
-		if (children != null) {
+			// Prepare its children.
+			final ArrayList<WComponent> children = (ArrayList<WComponent>) getComponentModel().getChildren();
 			final int size = children.size();
 
 			for (int i = 0; i < size; i++) {
@@ -668,10 +667,11 @@ public abstract class AbstractWComponent implements WComponent {
 			Renderer templateRenderer = UIManager.getTemplateRenderer(renderContext);
 			templateRenderer.render(this, renderContext);
 		} else if (renderer == null) {
-			// Default is juxtaposition
-			List<WComponent> children = getComponentModel().getChildren();
 
-			if (children != null) {
+			if (getComponentModel().hasChildren()) {
+
+				// Default is juxtaposition
+				List<WComponent> children = getComponentModel().getChildren();
 				final int size = children.size();
 
 				for (int i = 0; i < size; i++) {
@@ -721,11 +721,10 @@ public abstract class AbstractWComponent implements WComponent {
 		// Validate this component.
 		validateComponent(diags);
 
-		// Validate children
-		List<WComponent> children = getComponentModel().getChildren();
+		if (getComponentModel().hasChildren()) {
 
-		if (children != null) {
-			final int size = children.size();
+			// Validate children
+			List<WComponent> children = getComponentModel().getChildren();			final int size = children.size();
 
 			for (int i = 0; i < size; i++) {
 				children.get(i).validate(diags);
@@ -776,11 +775,10 @@ public abstract class AbstractWComponent implements WComponent {
 			// Show indicators for this component.
 			showErrorIndicatorsForComponent(diags);
 
-			// Show indicators for its children.
-			List<WComponent> children = getComponentModel().getChildren();
+			if (getComponentModel().hasChildren()) {
 
-			if (children != null) {
-				final int size = children.size();
+				// Show indicators for its children.
+				List<WComponent> children = getComponentModel().getChildren();				final int size = children.size();
 
 				for (int i = 0; i < size; i++) {
 					children.get(i).showErrorIndicators(diags);
@@ -811,11 +809,11 @@ public abstract class AbstractWComponent implements WComponent {
 			// Show indicators for this component.
 			showWarningIndicatorsForComponent(diags);
 
-			// Show indicators for its children.
-			List<WComponent> children = getComponentModel().getChildren();
+			if (getComponentModel().hasChildren()) {
 
-			if (children != null) {
-				final int size = children.size();
+				// Show indicators for its children.
+				List<WComponent> children = getComponentModel().getChildren();
+                        	final int size = children.size();
 
 				for (int i = 0; i < size; i++) {
 					children.get(i).showWarningIndicators(diags);
@@ -1243,9 +1241,9 @@ public abstract class AbstractWComponent implements WComponent {
 		if (uic != null) {
 			tidyUpUIContext();
 
-			List<WComponent> children = getComponentModel().getChildren();
+			if (getComponentModel().hasChildren()) {
 
-			if (children != null) {
+				List<WComponent> children = getComponentModel().getChildren();				
 				final int size = children.size();
 
 				for (int i = 0; i < size; i++) {
@@ -1279,7 +1277,7 @@ public abstract class AbstractWComponent implements WComponent {
 	 */
 	int getChildCount() {
 		ComponentModel model = getComponentModel();
-		return (model.getChildren() == null ? 0 : model.getChildren().size());
+		return (model.hasChildren() ? 0 : model.getChildren().size());
 	}
 
 	/**
@@ -1301,9 +1299,8 @@ public abstract class AbstractWComponent implements WComponent {
 	 */
 	int getIndexOfChild(final WComponent childComponent) {
 		ComponentModel model = getComponentModel();
-		List<WComponent> children = model.getChildren();
 
-		return children == null ? -1 : children.indexOf(childComponent);
+		return !model.hasChildren() ? -1 : model.getChildren().indexOf(childComponent);
 	}
 
 	/**
@@ -1344,13 +1341,7 @@ public abstract class AbstractWComponent implements WComponent {
 			throw new UnsupportedOperationException("Components can only be added to a container");
 		}
 
-		ComponentModel model = getOrCreateComponentModel();
-
-		if (model.getChildren() == null) {
-			model.setChildren(new ArrayList<WComponent>(1));
-		}
-
-		model.getChildren().add(component);
+		getOrCreateComponentModel().addChild(component);
 
 		if (isLocked()) {
 			component.setLocked(true);
@@ -1392,15 +1383,11 @@ public abstract class AbstractWComponent implements WComponent {
 	void remove(final WComponent aChild) {
 		ComponentModel model = getOrCreateComponentModel();
 
-		if (model.getChildren() == null) {
+		if (!model.hasChildren()) {
 			model.setChildren(copyChildren(getComponentModel().getChildren()));
 		}
 
-		if (model.getChildren().remove(aChild)) {
-			// Deallocate children list if possible, to reduce session size.
-			if (model.getChildren().isEmpty()) {
-				model.setChildren(null);
-			}
+		if (model.removeChild(aChild)) {
 
 			// The child component has been successfully removed so clean up the context.
 			aChild.reset();

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWComponent.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWComponent.java
@@ -571,18 +571,12 @@ public abstract class AbstractWComponent implements WComponent {
 		if (getComponentModel().hasChildren()) {
 
 			// Prepare its children.
-			final ArrayList<WComponent> children = (ArrayList<WComponent>) getComponentModel().getChildren();
+			final List<WComponent> children = getComponentModel().getChildren();
 			final int size = children.size();
 
 			for (int i = 0; i < size; i++) {
 				children.get(i).preparePaint(request);
 			}
-
-			// Chances are that the WComponent tree is fairly stable now, so take
-			// the opportunity to trim the child list to size if we have one.
-			// This is just a memory optimization - it won't prevent adding more
-			// children later, of course.
-			children.trimToSize();
 		}
 	}
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWComponent.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWComponent.java
@@ -718,7 +718,8 @@ public abstract class AbstractWComponent implements WComponent {
 		if (getComponentModel().hasChildren()) {
 
 			// Validate children
-			List<WComponent> children = getComponentModel().getChildren();			final int size = children.size();
+			List<WComponent> children = getComponentModel().getChildren();
+			final int size = children.size();
 
 			for (int i = 0; i < size; i++) {
 				children.get(i).validate(diags);
@@ -772,7 +773,8 @@ public abstract class AbstractWComponent implements WComponent {
 			if (getComponentModel().hasChildren()) {
 
 				// Show indicators for its children.
-				List<WComponent> children = getComponentModel().getChildren();				final int size = children.size();
+				List<WComponent> children = getComponentModel().getChildren();
+				final int size = children.size();
 
 				for (int i = 0; i < size; i++) {
 					children.get(i).showErrorIndicators(diags);
@@ -1271,7 +1273,7 @@ public abstract class AbstractWComponent implements WComponent {
 	 */
 	int getChildCount() {
 		ComponentModel model = getComponentModel();
-		return (model.hasChildren() ? 0 : model.getChildren().size());
+		return (!model.hasChildren() ? 0 : model.getChildren().size());
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/ComponentModel.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/ComponentModel.java
@@ -434,9 +434,14 @@ public class ComponentModel implements WebModel, Externalizable {
 
 		if (children != null) {
 			isRemoved = children.remove(child);
+                        
+                        // Trim the children
+                        if(isRemoved){
+                            ((ArrayList<?>) children).trimToSize();
+                        }
 		}
 
-		if (children.isEmpty()) {
+		if (children != null && children.isEmpty()) {
 			children = null;
 		}
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/ComponentModel.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/ComponentModel.java
@@ -407,17 +407,65 @@ public class ComponentModel implements WebModel, Externalizable {
 	}
 
 	/**
-	 * @return Returns the children.
+	 * Adds a child to this component.
+         * 
+	 * @param child the child to add to this component.
+	 * @return <tt>true</tt> if child was added
+	 */
+	protected boolean addChild(final WComponent child) {
+
+		if (children == null) {
+			children = new ArrayList<>();
+		}
+
+		return children.add(child);
+	}
+        
+	/**
+	 * Removes a child from this component.
+         * 
+	 * @param child the child to remove from this component.
+	 * @return <tt>true</tt> if this component contained the 
+         * specified child
+	 */
+	protected boolean removeChild(final WComponent child) {
+
+		boolean isRemoved = false;
+
+		if (children != null) {
+			isRemoved = children.remove(child);
+		}
+
+		if (children.isEmpty()) {
+			children = null;
+		}
+
+		return isRemoved;
+        }
+
+	/**
+	 * @return <tt>true</tt> if this component has any child components
+	 */
+	protected boolean hasChildren() {
+		return children != null && !children.isEmpty();
+	}
+        
+	/**
+	 * @return an unmodifiable list of the children, or an empty 
+         * list if there are no children.
 	 */
 	protected List<WComponent> getChildren() {
-		return children;
+		return children == null 
+			? Collections.<WComponent>emptyList()
+			: Collections.unmodifiableList(children);
 	}
 
 	/**
 	 * @param children The children to set.
 	 */
 	protected void setChildren(final List<WComponent> children) {
-		this.children = children;
+		
+		this.children = new ArrayList<>(children);
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/ComponentModel.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/ComponentModel.java
@@ -436,17 +436,17 @@ public class ComponentModel implements WebModel, Externalizable {
 			isRemoved = children.remove(child);
                         
                         // Trim the children
-                        if(isRemoved){
+                        if (isRemoved) {
                             ((ArrayList<?>) children).trimToSize();
                         }
-		}
-
-		if (children != null && children.isEmpty()) {
-			children = null;
+                        
+			if (children.isEmpty()) {
+				children = null;	
+			}
 		}
 
 		return isRemoved;
-        }
+	}
 
 	/**
 	 * @return <tt>true</tt> if this component has any child components
@@ -454,10 +454,10 @@ public class ComponentModel implements WebModel, Externalizable {
 	protected boolean hasChildren() {
 		return children != null && !children.isEmpty();
 	}
-        
+
 	/**
 	 * @return an unmodifiable list of the children, or an empty 
-         * list if there are no children.
+	 * list if there are no children.
 	 */
 	protected List<WComponent> getChildren() {
 		return children == null 
@@ -469,7 +469,6 @@ public class ComponentModel implements WebModel, Externalizable {
 	 * @param children The children to set.
 	 */
 	protected void setChildren(final List<WComponent> children) {
-		
 		this.children = new ArrayList<>(children);
 	}
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/ComponentModel.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/ComponentModel.java
@@ -469,7 +469,9 @@ public class ComponentModel implements WebModel, Externalizable {
 	 * @param children The children to set.
 	 */
 	protected void setChildren(final List<WComponent> children) {
-		this.children = new ArrayList<>(children);
+		this.children = (children == null || children.isEmpty())
+			? null 
+			: new ArrayList<>(children);
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WCardManager.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WCardManager.java
@@ -200,7 +200,7 @@ public class WCardManager extends AbstractMutableContainer {
 	public String toString() {
 		int index = getCardContainer().getIndexOfChild(getVisible());
 		List<WComponent> cards = getCardContainer().getComponentModel().getChildren();
-		WComponent[] children = cards == null ? new WComponent[0] : cards.toArray(
+		WComponent[] children = cards.isEmpty() ? new WComponent[0] : cards.toArray(
 				new WComponent[cards.size()]);
 
 		return toString("active=" + index, -1, -1) + childrenToString(children);

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WDefinitionList.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WDefinitionList.java
@@ -140,10 +140,9 @@ public class WDefinitionList extends AbstractNamingContextContainer implements A
 		Map<String, Duplet<String, List<WComponent>>> componentsByTerm = new HashMap<>();
 		List<Duplet<String, List<WComponent>>> result = new ArrayList<>();
 
-		List<WComponent> childList = content.getComponentModel().getChildren();
-
-		if (childList != null) {
-			for (int i = 0; i < childList.size(); i++) {
+		if (content.getComponentModel().hasChildren()) {
+			List<WComponent> childList = content.getComponentModel().getChildren();
+                    for (int i = 0; i < childList.size(); i++) {
 				WComponent child = childList.get(i);
 				String term = child.getTag();
 
@@ -170,10 +169,10 @@ public class WDefinitionList extends AbstractNamingContextContainer implements A
 	 * @return the child components for the given term, may be empty.
 	 */
 	private List<WComponent> getComponentsForTerm(final String term) {
-		List<WComponent> childList = content.getComponentModel().getChildren();
 		List<WComponent> result = new ArrayList<>();
 
-		if (childList != null) {
+		if (content.getComponentModel().hasChildren()) {
+			List<WComponent> childList = content.getComponentModel().getChildren();
 			for (int i = 0; i < childList.size(); i++) {
 				WComponent child = childList.get(i);
 

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/ComponentModel_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/ComponentModel_Test.java
@@ -1,0 +1,74 @@
+package com.github.bordertech.wcomponents;
+
+import java.util.ArrayList;
+import java.util.List;
+import static junit.framework.Assert.fail;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author javapod@github.com
+ * @since release2
+ */
+public class ComponentModel_Test {
+
+	@Test    
+	public void testComponentModel_AddAndRemoveChild() {
+
+		final ComponentModel model = new ComponentModel();
+                final WContainer child = new WContainer();
+
+		model.addChild(child);
+
+		Assert.assertTrue("Expected model to have children", model.hasChildren());
+
+		model.removeChild(child);
+
+		Assert.assertFalse("Expected model to have no children", model.hasChildren());
+	}
+        
+	@Test
+	public void testComponentModel_GetChildren() {
+
+		final ComponentModel model = new ComponentModel();
+                final List<WComponent> children = model.getChildren();
+
+		Assert.assertTrue("Expected children to be empty", children.isEmpty());
+
+		try {
+			children.add(new WContainer());
+			fail("Expected add to throw UnsupportedOperationException.");
+		} catch (UnsupportedOperationException e) {
+
+		}
+	}
+
+	@Test
+	public void testComponentModel_SetChildren() {
+
+		final ComponentModel model = new ComponentModel();
+                final List<WComponent> children = new ArrayList<>();
+
+		Assert.assertTrue("Expected children to be empty", children.isEmpty());
+
+                model.setChildren(children);
+
+		Assert.assertFalse("Expected model to have no children", model.hasChildren());
+
+		model.setChildren(null);
+
+		Assert.assertFalse("Expected model to have no children", model.hasChildren());
+
+		final WContainer child = new WContainer();
+		children.add(child);
+		model.setChildren(children);
+		children.remove(child);
+
+		Assert.assertTrue("Expected model to have children", model.hasChildren());
+                
+		model.removeChild(child);
+
+		Assert.assertFalse("Expected model to have no children", model.hasChildren());
+        }
+}

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/ComponentModel_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/ComponentModel_Test.java
@@ -14,10 +14,10 @@ import org.junit.Test;
 public class ComponentModel_Test {
 
 	@Test    
-	public void testComponentModel_AddAndRemoveChild() {
+	public void testComponentModelAddAndRemoveChild() {
 
 		final ComponentModel model = new ComponentModel();
-                final WContainer child = new WContainer();
+		final WContainer child = new WContainer();
 
 		model.addChild(child);
 
@@ -27,12 +27,12 @@ public class ComponentModel_Test {
 
 		Assert.assertFalse("Expected model to have no children", model.hasChildren());
 	}
-        
+
 	@Test
-	public void testComponentModel_GetChildren() {
+	public void testComponentModelGetChildren() {
 
 		final ComponentModel model = new ComponentModel();
-                final List<WComponent> children = model.getChildren();
+		final List<WComponent> children = model.getChildren();
 
 		Assert.assertTrue("Expected children to be empty", children.isEmpty());
 
@@ -45,10 +45,10 @@ public class ComponentModel_Test {
 	}
 
 	@Test
-	public void testComponentModel_SetChildren() {
+	public void testComponentModelSetChildren() {
 
 		final ComponentModel model = new ComponentModel();
-                final List<WComponent> children = new ArrayList<>();
+		final List<WComponent> children = new ArrayList<>();
 
 		Assert.assertTrue("Expected children to be empty", children.isEmpty());
 

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/ComponentModel_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/ComponentModel_Test.java
@@ -19,12 +19,9 @@ public class ComponentModel_Test {
 		final ComponentModel model = new ComponentModel();
 		final WContainer child = new WContainer();
 
-		model.addChild(child);
-
+		Assert.assertTrue("Expected child to be added",model.addChild(child));
 		Assert.assertTrue("Expected model to have children", model.hasChildren());
-
-		model.removeChild(child);
-
+		Assert.assertTrue("Expected child to be removed", model.removeChild(child));
 		Assert.assertFalse("Expected model to have no children", model.hasChildren());
 	}
 


### PR DESCRIPTION
Currently ComponentModel allows its internal state to be directly modified externally. This PR proposes to modify the API so that ComponentModel fully encapsulates its internal list of children and not allow this internal list to be directly accessible or modifiable externally.

The API will be changed so that:
_addChild(WComponent child)_ is used to add children to the model. If the internal children list is null then create a new list and add the child. Return true if the child was added.

_removeChild(WComponent child)_ is used to remove a child from the model. If the children list is null, then return false. If the child was removed, and the children list is now empty, then deallocate the list to save memory. If the child was removed and there are other children present, then trim the list to save memory. Return true if the child was removed.

_hasChildren()_ is a convenience method that helps to hide the implementation of how the children are stored.

_getChildren()_ returns an unmodifiable List<WComponent> that prevents the internal list from being modified.

_setChildren(List<WComponent> children)_ creates a defensive copy of the list passed in to prevent the internal state from leaking out. If the parameter is null or an empty list then the internal children list is assigned to null, to save memory.