### PR TITLE
Update theme build

### DIFF
--- a/wcomponents-theme/build-images.xml
+++ b/wcomponents-theme/build-images.xml
@@ -32,7 +32,7 @@
 			<fileset dir="${images.rootdir}" includes="*.*" excludesfile="${excludesfile}" excludes="*.svg"/>
 		</copy>
 		<copy todir="${images.tmp.src.dir}" overwrite="true">
-			<fileset dir="${impl.images.rootdir}" includes="*.*" excludes="*.svg"/>
+			<fileset dir="${impl.images.rootdir}" includes="*.*" excludes="*.svg" erroronmissingdir="false"/>
 		</copy>
 		<copy todir="${images.tmp.src.dir}" overwrite="true">
 			<fileset dir="${images.rootdir}" includes="*.svg" excludesfile="${excludesfile}"/>
@@ -45,7 +45,7 @@
 			</filterchain>
 		</copy>
 		<copy todir="${images.tmp.src.dir}" overwrite="true">
-			<fileset dir="${impl.images.rootdir}" includes="*.svg"/>
+			<fileset dir="${impl.images.rootdir}" includes="*.svg" erroronmissingdir="false"/>
 			<filterchain>
 				<expandproperties/>
 				<deletecharacters chars="\t"/>

--- a/wcomponents-theme/build-js.xml
+++ b/wcomponents-theme/build-js.xml
@@ -62,17 +62,17 @@
 		</copy>
 		<!-- implementation js -->
 		<copy todir="${script.tmp.src.dir}" overwrite="true">
-			<fileset dir="${impl.script.rootdir}" includes="**/*.js"/>
+			<fileset dir="${impl.script.rootdir}" includes="**/*.js" erroronmissingdir="false"/>
 			<filterchain>
 				<expandproperties/>
 			</filterchain>
 		</copy>
-		
+
 		<!-- i18n -->
 <!--		<copy todir="${script.tmp.src.dir}/i18n" overwrite="true">
 			<fileset dir="${i18n.build.target.dir}" includes="*.js"/>
 		</copy>-->
-		
+
 		<!-- default plugins js -->
 		<copy todir="${script.tmp.src.dir}/${plugins.target.dir.name}" overwrite="true">
 			<fileset dir="${common.src.plugin.dir}" includes="**/${plugin.script.dir.name}/**/*.js" erroronmissingdir="false"/>
@@ -87,7 +87,7 @@
 				<expandproperties/>
 			</filterchain>
 		</copy>
-		
+
 		<javascript.lint jsdir="${script.tmp.src.dir}"/>
 		<javascript.lint jsdir="${common.src.plugin.dir}"/><!-- The plugins may not be included and therefore not checked above so check them explicitly here unless the build changes so they are always built -->
 		<if>
@@ -98,7 +98,7 @@
 		</if>
 		<stopwatch name="copySrc" action="total"/>
 	</target>
-	
+
 	<target name="copyLibs">
 		<!--
 			Syncs directories from "scripts" to "scripts_debug".

--- a/wcomponents-theme/build-test.xml
+++ b/wcomponents-theme/build-test.xml
@@ -24,7 +24,7 @@
 			<fileset dir="${intern.srcdir}" excludesfile="${excludesfile}">
 				<include name="*"/>
 			</fileset>
-			<fileset dir="${impl.intern.srcdir}" excludesfile="${excludesfile}">
+			<fileset dir="${impl.intern.srcdir}" excludesfile="${excludesfile}" erroronmissingdir="false">
 				<include name="*"/>
 			</fileset>
 			<filterset>
@@ -39,14 +39,14 @@
 		<!-- NOTE: the two step copy here is so we do not try to apply filters to binary resources -->
 		<copy todir="${intern.target.dir}/resources">
 			<fileset dir="${intern.srcdir}/resources" excludesfile="${excludesfile}" includes="**/*.xml,**/*.html,**/*.js,**/*.css"/>
-			<fileset dir="${impl.intern.srcdir}/resources" excludesfile="${excludesfile}" includes="**/*.xml,**/*.html,**/*.js,**/*.css"/>
+			<fileset dir="${impl.intern.srcdir}/resources" excludesfile="${excludesfile}" includes="**/*.xml,**/*.html,**/*.js,**/*.css" erroronmissingdir="false"/>
 			<filterchain>
 				<expandproperties/>
 			</filterchain>
 		</copy>
 		<copy todir="${intern.target.dir}/resources">
 			<fileset dir="${intern.srcdir}/resources" excludesfile="${excludesfile}"  excludes="**/*.xml,**/*.html,**/*.js,**/*.css"/>
-			<fileset dir="${impl.intern.srcdir}/resources" excludesfile="${excludesfile}" excludes="**/*.xml,**/*.html,**/*.js,**/*.css"/>
+			<fileset dir="${impl.intern.srcdir}/resources" excludesfile="${excludesfile}" excludes="**/*.xml,**/*.html,**/*.js,**/*.css" erroronmissingdir="false"/>
 		</copy>
 		<javascript.lint jsdir="${intern.target.dir}"/>
 	</target>

--- a/wcomponents-theme/build-xml.xml
+++ b/wcomponents-theme/build-xml.xml
@@ -29,7 +29,7 @@
 			<fileset dir="${common.src.plugin.dir}" includesfile="${plugin.includesfile}" excludesfile="${excludesfile}" erroronmissingdir="false">
 				<filename name="**/${plugin.xml.dir.name}/*.xml" />
 			</fileset>
-			<fileset dir="${impl.xml.rootdir}" includes="*.xml, *.rdf" />
+			<fileset dir="${impl.xml.rootdir}" includes="*.xml, *.rdf"  erroronmissingdir="false"/>
 			<fileset dir="${impl.src.plugin.dir}" includesfile="${plugin.includesfile}" excludesfile="${excludesfile}" erroronmissingdir="false">
 				<filename name="**/${plugin.xml.dir.name}/*.xml" />
 			</fileset>
@@ -48,7 +48,7 @@
 				<exclude name="*.rdf" />
 				<excludesfile name="${excludesfile}" />
 			</fileset>
-			<fileset dir="${impl.xml.rootdir}" excludes="*.xml, *.rdf">
+			<fileset dir="${impl.xml.rootdir}" excludes="*.xml, *.rdf" erroronmissingdir="false">
 				<include name="*" />
 			</fileset>
 		</copy>

--- a/wcomponents-theme/build-xslt.xml
+++ b/wcomponents-theme/build-xslt.xml
@@ -49,7 +49,7 @@
 			<param name="includeUrl" expression="${xsl.target.debug.file.name}"/>
 			<regexpmapper from="^(.*)\.xml" to="${xslt.target.file.name}_\1${debug.target.file.name.suffix}.xsl"/>
 		</xslt>
-		
+
 		<!-- Create a "no locale" version of the default locale XSL -->
 		<copy file="${xslt.build.target.dir}/${xslt.target.file.name}_${default.i18n.locale}${debug.target.file.name.suffix}.xsl"
 			  tofile="${xslt.build.target.dir}/${xslt.target.file.name}${debug.target.file.name.suffix}.xsl"
@@ -129,7 +129,7 @@
 			</filterchain>
 		</copy>
 		<copy todir="${xsl.tmp.src.dir}" overwrite="true">
-			<fileset dir="${impl.xsl.src.dir}" includes="*.xsl"/>
+			<fileset dir="${impl.xsl.src.dir}" includes="*.xsl" erroronmissingdir="false"/>
 			<filterchain>
 				<expandproperties/>
 			</filterchain>

--- a/wcomponents-theme/build.xml
+++ b/wcomponents-theme/build.xml
@@ -282,42 +282,42 @@ chromedriver_cdnurl=${mirror.root}/chromedriver
 					-->
 					<echo>Copying parent implementation files from: ${prototype.dir} to ${merge.impl.dir}</echo>
 					<copy todir="${merge.impl.dir}/src/main/properties/parentImplementation" overwrite="false">
-						<fileset dir="${prototype.dir}/src/main/properties" includes="*">
+						<fileset dir="${prototype.dir}/src/main/properties" includes="*" erroronmissingdir="false">
 							<present present="srconly" targetdir="${merge.impl.dir}/src/main/properties"/>
 						</fileset>
 					</copy>
 					<copy todir="${merge.impl.dir}/src/main/css" overwrite="false">
-						<fileset dir="${prototype.dir}/src/main/css" includes="**/*.css" excludesfile="${impl.src.dir}/excludes.txt">
+						<fileset dir="${prototype.dir}/src/main/css" includes="**/*.css" excludesfile="${impl.src.dir}/excludes.txt" erroronmissingdir="false">
 							<present present="srconly" targetdir="${merge.impl.dir}/src/main/css"/>
 						</fileset>
 					</copy>
 					<copy todir="${merge.impl.dir}/src/main/sass" overwrite="false">
-						<fileset dir="${prototype.dir}/src/main/sass" includes="**/*.scss" excludesfile="${impl.src.dir}/excludes.txt">
+						<fileset dir="${prototype.dir}/src/main/sass" includes="**/*.scss" excludesfile="${impl.src.dir}/excludes.txt" erroronmissingdir="false">
 							<present present="srconly" targetdir="${merge.impl.dir}/src/main/scss"/>
 						</fileset>
 					</copy>
 					<copy todir="${merge.impl.dir}/src/main/xslt" overwrite="false">
-						<fileset dir="${prototype.dir}/src/main/xslt" includes="**/*.xsl" excludesfile="${impl.src.dir}/excludes.txt">
+						<fileset dir="${prototype.dir}/src/main/xslt" includes="**/*.xsl" excludesfile="${impl.src.dir}/excludes.txt" erroronmissingdir="false">
 							<present present="srconly" targetdir="${merge.impl.dir}/src/main/xslt"/>
 						</fileset>
 					</copy>
 					<copy todir="${merge.impl.dir}/src/main/i18n/parentImplementation" overwrite="false">
-						<fileset dir="${prototype.dir}/src/main/i18n" includes="**/*.properties" excludesfile="${impl.src.dir}/excludes.txt">
+						<fileset dir="${prototype.dir}/src/main/i18n" includes="**/*.properties" excludesfile="${impl.src.dir}/excludes.txt" erroronmissingdir="false">
 							<present present="srconly" targetdir="${merge.impl.dir}/src/main/i18n"/>
 						</fileset>
 					</copy>
 					<copy todir="${merge.impl.dir}/src/main/images" overwrite="false">
-							<fileset dir="${prototype.dir}/src/main/images" includes="**/*" excludesfile="${impl.src.dir}/excludes.txt">
+							<fileset dir="${prototype.dir}/src/main/images" includes="**/*" excludesfile="${impl.src.dir}/excludes.txt" erroronmissingdir="false">
 								<present present="srconly" targetdir="${merge.impl.dir}/src/main/images"/>
 							</fileset>
 					</copy>
 					<copy todir="${merge.impl.dir}/src/main/js" overwrite="false">
-						<fileset dir="${prototype.dir}/src/main/js" includes="**/*.js" excludesfile="${impl.src.dir}/excludes.txt">
+						<fileset dir="${prototype.dir}/src/main/js" includes="**/*.js" excludesfile="${impl.src.dir}/excludes.txt" erroronmissingdir="false">
 							<present present="srconly" targetdir="${merge.impl.dir}/src/main/js"/>
 						</fileset>
 					</copy>
 					<copy todir="${merge.impl.dir}/src/main/xml" overwrite="false">
-						<fileset dir="${prototype.dir}/src/main/xml" includes="**/*" excludesfile="${impl.src.dir}/excludes.txt">
+						<fileset dir="${prototype.dir}/src/main/xml" includes="**/*" excludesfile="${impl.src.dir}/excludes.txt" erroronmissingdir="false">
 							<present present="srconly" targetdir="${merge.impl.dir}/src/main/xml"/>
 						</fileset>
 					</copy>


### PR DESCRIPTION
Updated theme build scripts to remove fail on missing directory when copying source files from an implementation. This allows an implementation to only create the directories it requires for its own source.