### PR TITLE
Closes issue #126

### DIFF
--- a/wcomponents-theme/build-xslt.xml
+++ b/wcomponents-theme/build-xslt.xml
@@ -27,7 +27,7 @@
 	<property name="plugin.xslt.dir.name" value="xslt"/>
 
 	<target name="build"
-		depends="init, copyXslSrc, buildXslt, buildI18nWrappers, minify"
+		depends="init, copyXslSrc, buildI18nWrappers, buildXslt, minify"
 		description="Builds XSLT artifacts then minifies them">
 <!--		<loadJsDebugMap propertyToSet="xsl.debug.js.map"/>
 		<replace dir="${xslt.build.target.dir}" includes="*${debug.target.file.name.suffix}.xsl" token="@JS_DEBUG_MAP@" value="${xsl.debug.js.map}"/>
@@ -44,16 +44,13 @@
 				<expandproperties/>
 			</filterchain>
 		</copy>
-		<xslt basedir="${i18n.build.target.dir}" destdir="${xslt.build.target.dir}"	style="${tmp.dir}/build_i18n_params.xsl">
+		<mkdir dir="${xsl.tmp.src.dir}/i18n"/>
+		<xslt basedir="${i18n.build.target.dir}" destdir="${xsl.tmp.src.dir}/i18n" style="${tmp.dir}/build_i18n_params.xsl">
 			<factory name="net.sf.saxon.TransformerFactoryImpl"/>
 			<param name="includeUrl" expression="${xsl.target.debug.file.name}"/>
 			<regexpmapper from="^(.*)\.xml" to="${xslt.target.file.name}_\1${debug.target.file.name.suffix}.xsl"/>
 		</xslt>
-
-		<!-- Create a "no locale" version of the default locale XSL -->
-		<copy file="${xslt.build.target.dir}/${xslt.target.file.name}_${default.i18n.locale}${debug.target.file.name.suffix}.xsl"
-			  tofile="${xslt.build.target.dir}/${xslt.target.file.name}${debug.target.file.name.suffix}.xsl"
-			  overwrite="true"/>
+		
 		<!--
 			Seems to be a bug in ant 1.8.2 where it gets confused by the backslash in the \1 matched group ref
 		-->
@@ -61,7 +58,24 @@
 	</target>
 
 	<target name="buildXslt">
-		<buildXSLTPattern pattern="*" targetFile="${xsl.target.debug.file.name}"/>
+		<for param="file">
+			<fileset dir="${xsl.tmp.src.dir}/i18n">
+				<include name="*.xsl"/>
+			</fileset>
+			<sequential>
+				<var name="base.name" unset="true"/>
+				<basename property="base.name" file="@{file}"/><!-- base.name is now the file name without the path -->
+				<echo>Building ${base.name}</echo>
+				<copy file="@{file}"
+					todir="${xsl.tmp.src.dir}"
+					overwrite="true"/>
+				<buildXSLTPattern pattern="*" targetFile="${base.name}"/>
+				<delete file="${xsl.tmp.src.dir}/${base.name}"/>
+			</sequential>
+		</for>
+		<copy file="${xslt.build.target.dir}/${xslt.target.file.name}_${default.i18n.locale}${debug.target.file.name.suffix}.xsl"
+			  tofile="${xslt.build.target.dir}/${xslt.target.file.name}${debug.target.file.name.suffix}.xsl"
+			  overwrite="true"/>
 	</target>
 
 	<macrodef name="buildXSLTPattern">
@@ -71,9 +85,9 @@
 			<concat destfile="${tmp.dir}/${xsl.target.intermediate.file.name}" fixlastline="yes" ignoreempty="false">
 				<header filtering="no">&lt;concat&gt;</header>
 				<footer filtering="no">&lt;/concat&gt;</footer>
-				<fileset dir="${xsl.tmp.src.dir}" includes="@{pattern}.xsl" excludesfile="${excludesfile.dynamic}"/>
+				<fileset dir="${xsl.tmp.src.dir}" includes="@{pattern}.xsl"/>
 			</concat>
-			<simpleAddPatternToExcludes pattern="@{pattern}" destfile="${excludesfile.dynamic}"/>
+
 			<if>
 				<available file="${tmp.dir}/${xsl.target.intermediate.file.name}"/>
 				<then>
@@ -92,12 +106,7 @@
 		</sequential>
 	</macrodef>
 
-<!--	<macrodef name="addXSLTPatternToExcludes">
-		<attribute name="pattern"/>
-		<sequential>
-			<echo message="${line.separator}@{pattern}" append="true" file="${excludesfile.dynamic}"/>
-		</sequential>
-	</macrodef>-->
+
 	<!--
 		Make a copy of the source which the rest of the build will use.
 		This also allows the implementation files to overwrite the core files
@@ -200,8 +209,6 @@
 		<mkdir dir="${xslt.build.target.dir}"/>
 		<mkdir dir="${xsl.tmp.src.dir}"/>
 		<available file="${tmp.dir}/${xsl.target.intermediate.file.name}" property=""/>
-		<!-- make an empty dynamic excludes file -->
-		<tempfile property="excludesfile.dynamic" destdir="${tmp.dir}" createfile="true" deleteonexit="true"/>
 	</target>
 
 </project>

--- a/wcomponents-theme/build_i18n_params.xsl
+++ b/wcomponents-theme/build_i18n_params.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:x="https://github.com/bordertech/wcomponents/namespace/ui/dummy" version="2.0">
 	<xsl:namespace-alias stylesheet-prefix="x" result-prefix="xsl" />
-	<xsl:output method="xml" indent="yes" omit-xml-declaration="no" />
+	<xsl:output method="xml" indent="yes" omit-xml-declaration="yes" />
 	<xsl:param name="includeUrl" />
 	<!-- To be injected by caller.
 		Do NOT include a querystring - in order to make server side


### PR DESCRIPTION
Work around mobile safari's inability to reliably handle `xsl:include` calls.

This has been poorly implemented in webkit browsers since forever and it's finally time to give up on a good idea and take the (actually rather insignificant) hit of not splitting up the XSLT.
