### PR TITLE
Allow configuration of test browsers

### DIFF
--- a/wcomponents-theme/build-test.xml
+++ b/wcomponents-theme/build-test.xml
@@ -108,7 +108,7 @@
 			<local name="unit.test.src.dir.raw"/>
 			<local name="amd.src.dir"/>
 			<local name="test.baseurl"/>
-			<property name="test.default.ua" value="chrome"/>
+			<property name="test.environments" value="{ browserName: 'chrome' }"/>
 			<property name="amd.src.dir" value="@{relativePathToSource}"/>
 			<property name="unit.test.src.dir.raw" location="@{srcDir}"/>
 			<pathconvert targetos="unix" property="unit.test.src.dir">

--- a/wcomponents-theme/src/test/intern.js
+++ b/wcomponents-theme/src/test/intern.js
@@ -15,7 +15,7 @@ define({
 	tunnelOptions: {
 		verbose: 'true'
 	},
-	environments: [ { browserName: '${test.default.ua}' } ],
+	environments: [ ${test.environments} ],
 
 	// Configuration options for the module loader; any AMD configuration options supported by the specified AMD loader
 	// can be used here
@@ -25,8 +25,8 @@ define({
 			wc: '${amd.src.dir}/wc',
 			dojo: '${amd.src.dir}/dojo',
 			sprintf: '${amd.src.dir}/sprintf',
-			Promise: 'target/classes/theme/wcomponents-theme/scripts_debug/promise/Promise.min',
-			compat: 'target/classes/theme/wcomponents-theme/scripts_debug/wc/compat'
+			Promise: '${amd.src.dir}/promise/Promise.min',
+			compat: '${amd.src.dir}/wc/compat'
 		}
 	},
 	// A regular expression matching URLs to files that should not be included in code coverage analysis

--- a/wcomponents-theme/user.xml
+++ b/wcomponents-theme/user.xml
@@ -99,5 +99,14 @@
 
 			values are one of: minified | debug
 		<property name="test.target.mode" value="debug"/>
+		
+		test.environments:
+			Determines which browsers to run tests against.
+			This is written into the intern config file in the "environments" array.
+			By default the value is "{ browserName: 'chrome' }"
+			
+			If you wanted, for example, to test IE11 you could uncomment the line below:
+		
+		<property name="test.environments" value="{ browserName: 'internet explorer', version: '11' }"/>
 	-->
 </project>


### PR DESCRIPTION
Added property `test.environments` which can be used to run unit tests against different browsers.
More info in user.xml file.
