### PR TITLE
Updated dep versions and removed unused. Add more intern test browsers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![Build Status](https://travis-ci.org/BorderTech/wcomponents.svg?branch=master)](https://travis-ci.org/BorderTech/wcomponents)
+Travis CI: [![Build Status](https://travis-ci.org/BorderTech/wcomponents.svg?branch=master)](https://travis-ci.org/BorderTech/wcomponents)
+
+Frontend Tests: 
+[![Sauce Test Status](https://saucelabs.com/browser-matrix/javatech.svg)](https://saucelabs.com/u/javatech)
+
 # wcomponents
 Accessible Web UI Framework for Enterprise
 

--- a/wcomponents-theme-parent/pom.xml
+++ b/wcomponents-theme-parent/pom.xml
@@ -154,7 +154,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.7</version>
+				<version>1.8</version>
 				<executions>
 					<execution>
 						<id>compile</id>
@@ -250,7 +250,7 @@
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant</artifactId>
-						<version>1.9.3</version>
+						<version>1.9.6</version>
 					</dependency>
 					<dependency>
 						<groupId>commons-io</groupId>
@@ -262,26 +262,26 @@
 						<artifactId>commons-codec</artifactId>
 						<version>1.4</version>
 					</dependency>
-					<dependency>
+<!--					<dependency>
 						<groupId>rhino</groupId>
 						<artifactId>js</artifactId>
 						<version>1.7R2</version>
-					</dependency>
+					</dependency>-->
 					<dependency>
 						<groupId>net.sf.saxon</groupId>
 						<artifactId>Saxon-HE</artifactId>
 						<version>9.6.0-7</version>
 					</dependency>
-					<dependency>
+<!--					<dependency>
 						<groupId>com.google.javascript</groupId>
 						<artifactId>closure-compiler</artifactId>
 						<version>v20130603</version>
-					</dependency>
-					<dependency>
+					</dependency>-->
+<!--					<dependency>
 						<groupId>com.googlecode.jgenhtml</groupId>
 						<artifactId>jgenhtml</artifactId>
 						<version>1.5</version>
-					</dependency>
+					</dependency>-->
 					<dependency>
 						<groupId>com.github.ricksbrown</groupId>
 						<artifactId>xslmin</artifactId>

--- a/wcomponents-theme/build-test.xml
+++ b/wcomponents-theme/build-test.xml
@@ -108,7 +108,7 @@
 			<local name="unit.test.src.dir.raw"/>
 			<local name="amd.src.dir"/>
 			<local name="test.baseurl"/>
-			<property name="test.environments" value="{ browserName: 'chrome' }"/>
+			<property name="test.environments" value="{ browserName: 'firefox' }, { browserName: 'internet explorer', version: '11.0', platform: 'Windows 10' }, { browserName: 'chrome' }"/>
 			<property name="amd.src.dir" value="@{relativePathToSource}"/>
 			<property name="unit.test.src.dir.raw" location="@{srcDir}"/>
 			<pathconvert targetos="unix" property="unit.test.src.dir">


### PR DESCRIPTION
Removed several unused maven dependencies in wcomponents-theme.

Updated version number of other dependencies.

Added IE11 and Firefox alongside Chrome as default intern test targets.

