### PR TITLE
WAbbrText: remove API inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## API Changes
-Method scope issue in WCardManager. Removed "removeAll(flag)" and "remove(child, flag)". (#59)
-"WebUtilities.updateBeanValue(component)" changed to ignore invisible components by default. "WebUtilities.updateBeanValue(component, flag)" added to provide this option. (#46)
+* Updated WAbbrText, WAbbrTextRenderer and associated tests (#157)
+    * Removed WAbbrText.AbbrTextModel This custom component model is completely superfluous. The refactoring of WAbbrText brings the component into line with other WComponents and standardises API calls. **NOTE** If you have extended this model (well stop it you will go blind) you will now have to implement your own component model.
+    * Deprecated WAbbrText.getAbbrText in favour of WAbbrText.getToolTip (inherited from AbstractWComponent) and WAbbrText.setAbbrText in favour of WAbbrText.setToolTIp (inherited from AbstractWComponent).
+    * Updated schema and XSLT for ui:abbr to change attribute `description` to `toolTip` in line with other components.
+* Method scope issue in WCardManager. Removed "removeAll(flag)" and "remove(child, flag)". (#59)
+* "WebUtilities.updateBeanValue(component)" changed to ignore invisible components by default. "WebUtilities.updateBeanValue(component, flag)" added to provide this option. (#46)
+
 ## Enhancements
 
 ## Bug fixes

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WAbbrText.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WAbbrText.java
@@ -4,10 +4,11 @@ import com.github.bordertech.wcomponents.util.Factory;
 import com.github.bordertech.wcomponents.util.LookupTable;
 
 /**
- * <p>
- * The WAbbrText component shows a further textual description for its (abbreviated) text content.</p>
+ * The WAbbrText component represents an abbreviation or acronym and the full textual description for its (abbreviated)
+ * text content.
  *
  * @author Kishan Bisht
+ * @author Mark Reeves
  * @since 1.0.0
  */
 public class WAbbrText extends WText {
@@ -18,80 +19,81 @@ public class WAbbrText extends WText {
 	private static final LookupTable TABLE = Factory.newInstance(LookupTable.class);
 
 	/**
-	 * Holds the extrinsic state information of a WAbbrText.
-	 */
-	public static class AbbrTextModel extends BeanAndProviderBoundComponentModel {
-
-		/**
-		 * The description for the text.
-		 */
-		private String abbr;
-	}
-
-	/**
 	 * Creates an empty WAbbrText.
+	 * 
+	 * An instance of WAbbrText created in this manner must have abbreviated display text and a toolTip (the full text
+	 * represented by the abbreviation) set to be useful.
 	 */
 	public WAbbrText() {
 	}
 
 	/**
-	 * Creates a WAbbrText with the specified text.
+	 * Creates a WAbbrText with the specified abbreviated display text.
+	 * 
+	 * An instance of WAbbrText created in this manner must have a toolTip (the full text represented by the
+	 * abbreviation) set to be useful.
 	 *
-	 * @param text the text to display.
+	 * @param text The abbreviated text to display.
 	 */
 	public WAbbrText(final String text) {
 		super(text);
 	}
 
 	/**
-	 * Creates a WAbbrText with the specified text.
+	 * Creates a WAbbrText with the specified abbreviated display text and toolTip full expansion text.
 	 *
-	 * @param text the text to display.
-	 * @param abbr the tool-tip (abbreviation).
+	 * @param text The abbreviated text to display.
+	 * @param description The full text represented by the abbreviation.
 	 */
-	public WAbbrText(final String text, final String abbr) {
+	public WAbbrText(final String text, final String description) {
 		this(text);
-		getComponentModel().abbr = abbr;
+		setToolTip(description);
 	}
 
 	//================================
 	// Attributes
 	/**
-	 * @return the abbreviated text.
+	 * @return the expanded text represented by the abbreviation.
+	 * @deprecated use getToolTip instead.
 	 */
 	public String getAbbrText() {
-		return getComponentModel().abbr;
+		return getToolTip();
 	}
 
 	/**
-	 * Sets the abbreviated text.
+	 * Sets the full text represented by the abbreviation.
 	 *
-	 * @param abbrText the abbreviated text.
+	 * @param abbrText The full text represented by the abbreviation.
+	 * @deprecated use setToolTip instead.
 	 */
 	public void setAbbrText(final String abbrText) {
-		getOrCreateComponentModel().abbr = abbrText;
+		setToolTip(abbrText);
 	}
 
 	/**
-	 * Loads the abbreviated text component from the given code reference table entry. The text is set to the
-	 * description. The abbreviated text is set to the code.
+	 * Loads the abbreviated text component from the given code reference table entry.
+	 * 
+	 * The display (abbreviated) text is set to the table entry's description. The toolTip is set to the table entry's
+	 * code.
 	 *
 	 * @param entry the CRT entry to use.
 	 */
 	public void setTextWithDesc(final Object entry) {
 		setText(TABLE.getDescription(null, entry));
-		setAbbrText(TABLE.getCode(null, entry));
+		setToolTip(TABLE.getCode(null, entry));
 	}
 
 	/**
-	 * Loads the abbreviated text component from the given code reference table entry. The text is set to the code. The
-	 * abbreviated text is set to the description.
+	 * Loads the abbreviated text component from the given code reference table entry. 
+	 * 
+	 * The display (abbreviated) text is set to the table entry's code. The toolTip is set to the table entry's
+	 * description.
 	 *
 	 * @param entry the CRT entry to use.
 	 */
 	public void setTextWithCode(final Object entry) {
 		setText(TABLE.getCode(null, entry));
-		setAbbrText(TABLE.getDescription(null, entry));
+		setToolTip(TABLE.getDescription(null, entry));
 	}
 
 	/**
@@ -102,37 +104,9 @@ public class WAbbrText extends WText {
 		String text = getText();
 		text = text == null ? "null" : ('"' + text + '"');
 
-		String abbrText = getAbbrText();
-		abbrText = abbrText == null ? "null" : ('"' + abbrText + '"');
+		String expandedText = getToolTip();
+		expandedText = expandedText == null ? "null" : ('"' + expandedText + '"');
 
-		return toString("text=" + text + ", abbrText=" + abbrText);
-	}
-
-	// --------------------------------
-	// Extrinsic state management
-	/**
-	 * Creates a new model appropriate for this component.
-	 *
-	 * @return a new {@link AbbrTextModel}.
-	 */
-	@Override
-	protected AbbrTextModel newComponentModel() {
-		return new AbbrTextModel();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override // For type safety only
-	protected AbbrTextModel getComponentModel() {
-		return (AbbrTextModel) super.getComponentModel();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override // For type safety only
-	protected AbbrTextModel getOrCreateComponentModel() {
-		return (AbbrTextModel) super.getOrCreateComponentModel();
+		return toString("text=" + text + ", toolTip=" + expandedText);
 	}
 }

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WAbbrTextRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WAbbrTextRenderer.java
@@ -26,7 +26,7 @@ final class WAbbrTextRenderer extends AbstractWebXmlRenderer {
 		XmlStringBuilder xml = renderContext.getWriter();
 
 		xml.appendTagOpen("ui:abbr");
-		xml.appendOptionalAttribute("description", abbrText.getAbbrText());
+		xml.appendOptionalAttribute("toolTip", abbrText.getToolTip());
 		xml.appendClose();
 
 		xml.appendEscaped(abbrText.getText());

--- a/wcomponents-core/src/main/resources/schema/ui/v1/abbr.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/abbr.xsd
@@ -8,10 +8,9 @@
 		<xs:complexType>
 			<xs:simpleContent>
 				<xs:extension base="xs:string">
-					<xs:attribute name="description" type="xs:string">
+					<xs:attribute name="toolTip" type="xs:string">
 						<xs:annotation>
-							<xs:documentation>The description attribute contains the expansion of the abbreviation/acronym. This should be required since an
-								abbreviation without an expansion is meaningless.</xs:documentation>
+							<xs:documentation>Provides the expansion of the abbreviation/acronym. This should be required since an abbreviation without an expansion is meaningless.</xs:documentation>
 						</xs:annotation>
 					</xs:attribute>
 				</xs:extension>

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WAbbrText_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WAbbrText_Test.java
@@ -17,7 +17,7 @@ public class WAbbrText_Test extends AbstractWComponentTestCase {
 	public void testDefaultConstructor() {
 		WAbbrText abbr = new WAbbrText();
 		Assert.assertNull("Default text should be null", abbr.getText());
-		Assert.assertNull("Default abbrtext should be null", abbr.getAbbrText());
+		Assert.assertNull("Default abbrtext should be null", abbr.getToolTip());
 	}
 
 	@Test
@@ -26,33 +26,23 @@ public class WAbbrText_Test extends AbstractWComponentTestCase {
 
 		WAbbrText abbr = new WAbbrText(myText);
 		Assert.assertEquals("Incorrect default text", myText, abbr.getText());
-		Assert.assertNull("Default abbrtext should be null", abbr.getAbbrText());
+		Assert.assertNull("Default abbrtext should be null", abbr.getToolTip());
 	}
 
 	@Test
-	public void testTextAbbrConstructor() {
+	public void testTextDescriptionConstructor() {
 		String myText = "WAbbrText_Test.MyText";
-		String myAbbrText = "WAbbrText_Test.MyAbbr";
+		String description = "WAbbrText_Test.MyAbbr";
 
-		WAbbrText abbr = new WAbbrText(myText, myAbbrText);
+		WAbbrText abbr = new WAbbrText(myText, description);
 		Assert.assertEquals("Incorrect default text", myText, abbr.getText());
-		Assert.assertEquals("Incorrect default abbr text", myAbbrText, abbr.getAbbrText());
+		Assert.assertEquals("Incorrect default abbr text", description, abbr.getToolTip());
 	}
 
+	/** @deprecated */
 	@Test
-	public void testSetAbbrText() throws Exception {
-		WAbbrText abbr = new WAbbrText();
-		abbr.setLocked(true);
-
-		String myText = "WAbbrText_Test.MyText";
-
-		// Set test for a users session
-		setActiveContext(createUIContext());
-		abbr.setAbbrText(myText);
-		Assert.assertEquals("Should have session text for session 1", myText, abbr.getAbbrText());
-
-		resetContext();
-		Assert.assertNull("Default text should be null", abbr.getAbbrText());
+	public void testGetSetAbbrText() {
+		assertAccessorsCorrect(new WAbbrText(), "abbrText", null, "toolTip 1", "toolTip 2");
 	}
 
 	@Test
@@ -63,7 +53,7 @@ public class WAbbrText_Test extends AbstractWComponentTestCase {
 
 		abbr.setTextWithDesc(entry);
 		Assert.assertEquals("Incorrect text", entry.getDesc(), abbr.getText());
-		Assert.assertEquals("Incorrect abbr text", entry.getCode(), abbr.getAbbrText());
+		Assert.assertEquals("Incorrect abbr text", entry.getCode(), abbr.getToolTip());
 	}
 
 	@Test
@@ -74,6 +64,6 @@ public class WAbbrText_Test extends AbstractWComponentTestCase {
 
 		abbr.setTextWithCode(entry);
 		Assert.assertEquals("Incorrect text", entry.getCode(), abbr.getText());
-		Assert.assertEquals("Incorrect abbr text", entry.getDesc(), abbr.getAbbrText());
+		Assert.assertEquals("Incorrect abbr text", entry.getDesc(), abbr.getToolTip());
 	}
 }

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WAbbrTextRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WAbbrTextRenderer_Test.java
@@ -25,17 +25,17 @@ public class WAbbrTextRenderer_Test extends AbstractWebXmlRendererTestCase {
 	@Test
 	public void testDoPaint() throws IOException, SAXException, XpathException {
 		String textString = "abbreviated string";
-		String abbrString = "The really long non-abbreviated string";
+		String description = "The really long non-abbreviated string";
 
 		WAbbrText text = new WAbbrText();
 		text.setText(textString);
-		text.setAbbrText(abbrString);
+		text.setToolTip(description);
 
 		// Test with no abbreviation
 		assertSchemaMatch(text);
 
 		assertXpathEvaluatesTo(textString, "//ui:abbr", text);
-		assertXpathEvaluatesTo(abbrString, "//ui:abbr/@description", text);
+		assertXpathEvaluatesTo(description, "//ui:abbr/@toolTip", text);
 	}
 
 	@Test
@@ -45,7 +45,7 @@ public class WAbbrTextRenderer_Test extends AbstractWebXmlRendererTestCase {
 		text.setText(getMaliciousContent());
 		assertSafeContent(text);
 
-		text.setAbbrText(getMaliciousAttribute("ui:abbr"));
+		text.setToolTip(getMaliciousAttribute("ui:abbr"));
 		assertSafeContent(text);
 	}
 }

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WAbbrTextExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WAbbrTextExample.java
@@ -6,7 +6,6 @@ import com.github.bordertech.wcomponents.WAbbrText;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WHeading;
 import com.github.bordertech.wcomponents.WPanel;
-import com.github.bordertech.wcomponents.WStyledText;
 import com.github.bordertech.wcomponents.examples.common.ExplanatoryText;
 import com.github.bordertech.wcomponents.layout.ListLayout;
 import com.github.bordertech.wcomponents.util.Factory;
@@ -52,7 +51,9 @@ public final class WAbbrTextExample extends WContainer {
 		add(new WHeading(HeadingLevel.H2,
 				"Abreviation created from lookup tables using the description as the text"));
 
-		add(new ExplanatoryText("This example shows the dangers of doing code-set conversion and confusing the code and description. Obviously the abbreviation here is NOT the abbreviation we want. We would normally expect the reverse as in the example above."));
+		add(new ExplanatoryText("This example shows the dangers of doing code-set conversion and confusing the code and"
+				+ " description. Obviously the abbreviation here is NOT the abbreviation we want. We would normally"
+				+ " expect the reverse as in the example above."));
 		crtSexPanel.setLayout(new ListLayout(ListLayout.Type.STACKED, ListLayout.Alignment.LEFT,
 				ListLayout.Separator.DOT, false));
 		add(crtSexPanel);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WAbbrTextExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WAbbrTextExample.java
@@ -1,11 +1,13 @@
 package com.github.bordertech.wcomponents.examples;
 
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.WAbbrText;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WHeading;
 import com.github.bordertech.wcomponents.WPanel;
 import com.github.bordertech.wcomponents.WStyledText;
+import com.github.bordertech.wcomponents.examples.common.ExplanatoryText;
 import com.github.bordertech.wcomponents.layout.ListLayout;
 import com.github.bordertech.wcomponents.util.Factory;
 import com.github.bordertech.wcomponents.util.LookupTable;
@@ -37,22 +39,20 @@ public final class WAbbrTextExample extends WContainer {
 	 * Creates a WAbbrTextExample.
 	 */
 	public WAbbrTextExample() {
-		add(new WHeading(WHeading.SECTION, "Abreviation created from strings"));
-		WAbbrText at1 = new WAbbrText("App Id", "Identification number of the visa application");
+		add(new WHeading(HeadingLevel.H2, "Abreviation created from strings"));
+		WAbbrText at1 = new WAbbrText("App Id", "Identification number of the application");
 		add(at1);
 
-		add(new WHeading(WHeading.SECTION,
+		add(new WHeading(HeadingLevel.H2,
 				"Abreviation created from lookup tables using the code as the text"));
 		crtIcaoPanel.setLayout(new ListLayout(ListLayout.Type.STACKED, ListLayout.Alignment.LEFT,
 				ListLayout.Separator.DOT, false));
 		add(crtIcaoPanel);
 
-		add(new WHeading(WHeading.SECTION,
+		add(new WHeading(HeadingLevel.H2,
 				"Abreviation created from lookup tables using the description as the text"));
-		final WStyledText info = new WStyledText(
-				"This example shows the dangers of doing code-set conversion and confusing the code and description. Obviously the abbreviation here is NOT the abbreviation we want. We would normally expect the reverse as in the example above.");
-		add(info);
-		info.setWhitespaceMode(WStyledText.WhitespaceMode.PARAGRAPHS);
+
+		add(new ExplanatoryText("This example shows the dangers of doing code-set conversion and confusing the code and description. Obviously the abbreviation here is NOT the abbreviation we want. We would normally expect the reverse as in the example above."));
 		crtSexPanel.setLayout(new ListLayout(ListLayout.Type.STACKED, ListLayout.Alignment.LEFT,
 				ListLayout.Separator.DOT, false));
 		add(crtSexPanel);

--- a/wcomponents-theme/src/main/xslt/wc.ui.abbr.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.abbr.xsl
@@ -1,20 +1,18 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
 	<!--
-		Make an abbr element. If the component does not have a description make 
+		Make an abbr element. If the component does not have a description make
 		a span because an abbr without a title is worse than useless.
-		
+
 		If the ui:abbr has no content do not output anything.
 	-->
 	<xsl:template match="ui:abbr">
 		<xsl:if test="text()">
 			<xsl:choose>
-				<xsl:when test="@description">
+				<xsl:when test="@toolTip">
 					<xsl:element name="abbr">
-						<xsl:if test="@description">
-							<xsl:attribute name="title">
-								<xsl:value-of select="@description"/>
-							</xsl:attribute>
-						</xsl:if>
+						<xsl:attribute name="title">
+							<xsl:value-of select="@toolTip"/>
+						</xsl:attribute>
 						<xsl:value-of select="."/>
 					</xsl:element>
 				</xsl:when>


### PR DESCRIPTION
Brought API of WAbbrText into line with other components and fixed documentation issues. Fixes #157.

* deprecated get/setAbbrText in favour of get/setToolTip;
* removed WAbbrText.WAbbrTextModel as no longer required;
* Fixed ambiguous documentation in WAbbrText;
* updated WAbbrTextRenderer to output toolTip attribute instead of description attribute for the toolTip;
* updated schema and XSLT to reflect consistent API and therefore more consistent XML attribute names;
* updated all tests.