### PR TITLE
WTab WTabSet Subordinate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,7 @@
 * "WebUtilities.updateBeanValue(component)" changed to ignore invisible components by default. "WebUtilities.updateBeanValue(component, flag)" added to provide this option. (#46)
 
 ## Enhancements
+* WTabSet implements SubordinateTarget. (#159)
+* WTab implements SubordinateTarget. (#158)
 
 ## Bug fixes

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTab.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTab.java
@@ -11,7 +11,7 @@ import java.text.MessageFormat;
  * @author Yiannis Paschalidis
  * @since 1.0.0
  */
-public class WTab extends AbstractNamingContextContainer implements Disableable {
+public class WTab extends AbstractNamingContextContainer implements Disableable, SubordinateTarget {
 
 	/**
 	 * The tab label.

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
@@ -35,7 +35,7 @@ import java.util.List;
  * @since 1.0.0
  */
 public class WTabSet extends AbstractNamingContextContainer implements Disableable, AjaxTarget,
-		Marginable {
+		Marginable, SubordinateTarget {
 
 	/**
 	 * The available types of client-side tab sets.

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WTabExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WTabExample.java
@@ -1,7 +1,10 @@
 package com.github.bordertech.wcomponents.examples.theme;
 
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.Request;
+import com.github.bordertech.wcomponents.WCheckBox;
 import com.github.bordertech.wcomponents.WDecoratedLabel;
+import com.github.bordertech.wcomponents.WFieldLayout;
 import com.github.bordertech.wcomponents.WHeading;
 import com.github.bordertech.wcomponents.WHorizontalRule;
 import com.github.bordertech.wcomponents.WImage;
@@ -11,6 +14,7 @@ import com.github.bordertech.wcomponents.WTabSet;
 import com.github.bordertech.wcomponents.WTabSet.TabMode;
 import com.github.bordertech.wcomponents.WText;
 import com.github.bordertech.wcomponents.examples.common.ExplanatoryText;
+import com.github.bordertech.wcomponents.subordinate.builder.SubordinateBuilder;
 import java.util.Date;
 
 /**
@@ -23,7 +27,12 @@ public class WTabExample extends WPanel {
 	/**
 	 * Sample Long Text.
 	 */
-	private static final String LONG_TEXT = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Praesent lectus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Phasellus et turpis. Aenean convallis eleifend elit. Donec venenatis justo id nunc. Sed at purus vel quam mattis elementum. Sed ultrices lobortis orci. Pellentesque enim urna, volutpat at, sagittis id, faucibus sed, lectus. Integer dapibus nulla semper mi. Nunc posuere molestie augue. Aliquam varius libero in tortor. Sed nibh. Nunc erat nunc, pellentesque at, sodales vel, dapibus sit amet, tortor.";
+	private static final String LONG_TEXT = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Praesent lectus."
+			+ " Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Phasellus"
+			+ " et turpis. Aenean convallis eleifend elit. Donec venenatis justo id nunc. Sed at purus vel quam mattis"
+			+ " elementum. Sed ultrices lobortis orci. Pellentesque enim urna, volutpat at, sagittis id, faucibus sed,"
+			+ " lectus. Integer dapibus nulla semper mi. Nunc posuere molestie augue. Aliquam varius libero in tortor."
+			+ " Sed nibh. Nunc erat nunc, pellentesque at, sodales vel, dapibus sit amet, tortor.";
 
 	/**
 	 * a tab with dynamic content.
@@ -56,11 +65,11 @@ public class WTabExample extends WPanel {
 	 */
 	public WTabExample() {
 		super();
-		add(new WHeading(WHeading.MAJOR, "Examples of WTab properties"));
-		add(new WHeading(WHeading.SECTION, "Tab Modes."));
+		add(new WHeading(HeadingLevel.H2, "Examples of WTab properties"));
+		add(new WHeading(HeadingLevel.H3, "Tab Modes."));
 		explanationWithTimeStamp = new ExplanatoryText(
-				"The tabs in the following example each display the time at which the tab content was fetched. The time the page was rendered was " + (new Date()).
-				toString());
+				"The tabs in the following example each display the time at which the tab content was fetched. The time"
+					+ " the page was rendered was " + (new Date()).toString());
 		add(explanationWithTimeStamp);
 
 		WTabSet tabset1 = new WTabSet();
@@ -76,17 +85,18 @@ public class WTabExample extends WPanel {
 		tabset1.setMargin(new com.github.bordertech.wcomponents.Margin(0, 0, 24, 0));
 		add(tabset1);
 
-		add(new WHeading(WHeading.SECTION, "One tab disabled."));
+		add(new WHeading(HeadingLevel.H3, "One tab disabled."));
 		WTabSet tabset2 = new SampleTabSet();
-		/*NOTE: you should do a null check on the tab but we are taking a shortcut knowing the structure of the tabset */
+		/* you should do a null check on the tab but we are taking a shortcut knowing the structure of the tabset */
 		tabset2.getTab(1).setDisabled(true);
 		tabset2.getTab(1).setText("Disabled tab");
 		add(tabset2);
 		add(new WHorizontalRule());
 
-		add(new WHeading(WHeading.SECTION, "Active tab."));
+		add(new WHeading(HeadingLevel.H3, "Active tab."));
 		add(new ExplanatoryText(
-				"If a tab is not set active explicitly then the first visible tab is open by default unless the user has previously set a different tab open in this session."));
+				"If a tab is not set active explicitly then the first visible tab is open by default unless the user "
+					+ "has previously set a different tab open in this session."));
 
 		WTabSet tabset3 = new SampleTabSet(1);
 		add(tabset3);
@@ -95,7 +105,7 @@ public class WTabExample extends WPanel {
 		 * TODO: this is stupid! setActiveTab should use the WTab not its content! */
 		/*tabset3.setActiveTab(tabset3.getTab(1).getContent());*/
 
-		add(new WHeading(WHeading.SECTION, "Active tab disabled."));
+		add(new WHeading(HeadingLevel.H3, "Active tab disabled."));
 		WTabSet tabset4 = new SampleTabSet(1);
 		add(tabset4);
 		tabset4.getTab(tabset4.getActiveIndex()).setDisabled(true);
@@ -104,19 +114,20 @@ public class WTabExample extends WPanel {
 		add(new WHorizontalRule());
 
 		/* NOTE: if the WTabSet is of TYPE_ACCORDION then several tabs may be open at the same time. */
-		add(new WHeading(WHeading.SECTION, "Tabs with access keys"));
+		add(new WHeading(HeadingLevel.H3, "Tabs with access keys"));
 		WTabSet tabset5 = new WTabSet();
 		add(tabset5);
 		tabset5.setMargin(new com.github.bordertech.wcomponents.Margin(0, 0, 24, 0));
-		//It would be normal to use the first letter of the tab text as the access key but 'F' is problematic for some browsers.
+
 		tabset5.addTab(new ExplanatoryText("Some content should go into here."), "First tab",
 				WTabSet.TAB_MODE_CLIENT, 'T');
 		tabset5.addTab(new ExplanatoryText(LONG_TEXT), "Second tab", WTabSet.TAB_MODE_CLIENT, 'S');
+
 		//access key does not have to be in the tab's text label
 		tabset5.addTab(new ExplanatoryText("Some other content should go into here."), "Third tab",
 				WTabSet.TAB_MODE_CLIENT, 'X');
 
-		add(new WHeading(WHeading.SECTION, "Creating a Tab with non-text content."));
+		add(new WHeading(HeadingLevel.H3, "Creating a Tab with non-text content."));
 		WTabSet tabset7 = new WTabSet();
 		add(tabset7);
 
@@ -140,8 +151,40 @@ public class WTabExample extends WPanel {
 		tabset7.addTab(new WText("Some content for the flagged tab"), new WDecoratedLabel(imageTab3,
 				new WText("Flagged Items"), null),
 				WTabSet.TAB_MODE_CLIENT, '3');
+
 		tabset7.addTab(new WText("Some content for the help tab"), new WDecoratedLabel(imageTab4),
 				WTabSet.TAB_MODE_CLIENT, '4');
+
+
+
+		add(new WHorizontalRule());
+
+		add(new WHeading(HeadingLevel.H2, "Using WSubordinateControl"));
+		WTabSet targetTabset = new SampleTabSet();
+		add(targetTabset);
+
+		WTab targetTab = targetTabset.getTab(1);
+
+		WFieldLayout layout = new WFieldLayout(WFieldLayout.LAYOUT_STACKED);
+		add(layout);
+		final WCheckBox disabledControllerCb = new WCheckBox();
+		final WCheckBox hiddenControllerCb = new WCheckBox();
+		layout.addField("disable second tab", disabledControllerCb);
+		layout.addField("hide  second tab", hiddenControllerCb);
+
+
+		// Build & add the subordinate
+		SubordinateBuilder builder = new SubordinateBuilder();
+		builder.condition().equals(hiddenControllerCb, String.valueOf(true));
+		builder.whenTrue().hide(targetTab);
+		builder.whenFalse().show(targetTab);
+		add(builder.build());
+
+		builder = new SubordinateBuilder();
+		builder.condition().equals(disabledControllerCb, String.valueOf(true));
+		builder.whenTrue().disable(targetTab);
+		builder.whenFalse().enable(targetTab);
+		add(builder.build());
 	}
 
 	/**
@@ -149,23 +192,22 @@ public class WTabExample extends WPanel {
 	 */
 	@Override
 	protected void preparePaintComponent(final Request request) {
-		explanationWithTimeStamp.setText("The time the page was rendered was " + (new Date()).
-				toString());
+		explanationWithTimeStamp.setText("The time the page was rendered was " + (new Date()).toString());
 		tabset1TabClient.setContent(new ExplanatoryText(
-				"This content was present when the page first rendered at " + (new Date()).
-				toString()));
+				"This content was present when the page first rendered at " + (new Date()).toString()));
 		tabset1TabServer.setContent(new ExplanatoryText(
-				"This is the content of tab two. It should be noted that mode SERVER is deprecated.\nThis mode poses a number of usability problems and should not be used.\n This content was created at " + (new Date()).
-				toString()));
+				"This is the content of tab two. It should be noted that mode SERVER is deprecated.\nThis mode poses a"
+					+ " number of usability problems and should not be used.\n This content was created at "
+					+ (new Date()).toString()));
 		tabset1TabLazy.setContent(new ExplanatoryText(
-				"This tab content is rendered when the tab opens then remains static. Check the date stamp: " + (new Date()).
-				toString()));
+				"This tab content is rendered when the tab opens then remains static. Check the date stamp: "
+					+ (new Date()).toString()));
 		tabset1TabDynamic.setContent(new ExplanatoryText(
-				"This tab content refreshes each time it is opened. Check the date stamp: " + (new Date()).
-				toString()));
+				"This tab content refreshes each time it is opened. Check the date stamp: "
+					+ (new Date()).toString()));
 		tabset1TabEager.setContent(new ExplanatoryText(
-				"This tab content is fetched once asynchronously then remains static. Check the date stamp: " + (new Date()).
-				toString()));
+				"This tab content is fetched once asynchronously then remains static. Check the date stamp: "
+					+ (new Date()).toString()));
 	}
 
 	/**

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WTabSetExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WTabSetExample.java
@@ -1,6 +1,10 @@
 package com.github.bordertech.wcomponents.examples.theme;
 
+import com.github.bordertech.wcomponents.HeadingLevel;
+import com.github.bordertech.wcomponents.WCheckBox;
+import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WDecoratedLabel;
+import com.github.bordertech.wcomponents.WFieldLayout;
 import com.github.bordertech.wcomponents.WHeading;
 import com.github.bordertech.wcomponents.WHorizontalRule;
 import com.github.bordertech.wcomponents.WImage;
@@ -11,6 +15,7 @@ import com.github.bordertech.wcomponents.WText;
 import com.github.bordertech.wcomponents.examples.common.ExplanatoryText;
 import com.github.bordertech.wcomponents.layout.FlowLayout;
 import com.github.bordertech.wcomponents.layout.FlowLayout.Alignment;
+import com.github.bordertech.wcomponents.subordinate.builder.SubordinateBuilder;
 import java.util.Date;
 
 /**
@@ -20,12 +25,17 @@ import java.util.Date;
  * @author Mark Reeves
  * @since 1.0.0
  */
-public class WTabSetExample extends WPanel {
+public class WTabSetExample extends WContainer {
 
 	/**
-	 * Sample Long Text.
+	 * Sample long text for tab content.
 	 */
-	private static final String LONG_TEXT = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Praesent lectus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Phasellus et turpis. Aenean convallis eleifend elit. Donec venenatis justo id nunc. Sed at purus vel quam mattis elementum. Sed ultrices lobortis orci. Pellentesque enim urna, volutpat at, sagittis id, faucibus sed, lectus. Integer dapibus nulla semper mi. Nunc posuere molestie augue. Aliquam varius libero in tortor. Sed nibh. Nunc erat nunc, pellentesque at, sodales vel, dapibus sit amet, tortor.";
+	private static final String LONG_TEXT = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Praesent lectus."
+			+ " Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Phasellus "
+			+ "et turpis. Aenean convallis eleifend elit. Donec venenatis justo id nunc. Sed at purus vel quam mattis "
+			+ "elementum. Sed ultrices lobortis orci. Pellentesque enim urna, volutpat at, sagittis id, faucibus sed, "
+			+ "lectus. Integer dapibus nulla semper mi. Nunc posuere molestie augue. Aliquam varius libero in tortor. "
+			+ "Sed nibh. Nunc erat nunc, pellentesque at, sodales vel, dapibus sit amet, tortor.";
 	/**
 	 * Example content height for tall tabsets.
 	 */
@@ -39,35 +49,41 @@ public class WTabSetExample extends WPanel {
 	 * Construct WTabSet examples.
 	 */
 	public WTabSetExample() {
-		super(Type.PLAIN);
-
-		add(new WHeading(WHeading.MAJOR, "Examples showing TabSet Type property."));
-		add(new WHeading(WHeading.SECTION, "Tabs at the top"));
+		constructExample();
+	}
+	
+	/**
+	 * Helper to do the work of the constructor since we do not really want to call over-rideable methods in a 
+	 * constructor.
+	 */
+	private void constructExample() {
+		add(new WHeading(HeadingLevel.H2, "Examples showing TabSet Type property."));
+		add(new WHeading(HeadingLevel.H3, "Tabs at the top"));
 		WTabSet tabset0 = new SampleWTabset();
 		add(tabset0);
 
-		add(new WHeading(WHeading.SECTION, "Tabs at the top with explicit TYPE"));
+		add(new WHeading(HeadingLevel.H3, "Tabs at the top with explicit TYPE"));
 		/* Explicitly setting TYPE_TOP is superfluous */
 		WTabSet tabset1 = new SampleWTabset(WTabSet.TYPE_TOP);
 		add(tabset1);
 
-		add(new WHeading(WHeading.SECTION, "Tabs on the LEFT"));
+		add(new WHeading(HeadingLevel.H3, "Tabs on the LEFT"));
 		WTabSet tabset1a = new SampleWTabset(WTabSet.TYPE_LEFT);
 		add(tabset1a);
 
-		add(new WHeading(WHeading.SECTION, "Tabs on the RIGHT"));
+		add(new WHeading(HeadingLevel.H3, "Tabs on the RIGHT"));
 		WTabSet tabset1b = new SampleWTabset(WTabSet.TYPE_RIGHT);
 		add(tabset1b);
 
-		add(new WHeading(WHeading.SECTION, "ACCORDION tabs"));
+		add(new WHeading(HeadingLevel.H3, "ACCORDION tabs"));
 		WTabSet tabset1c = new SampleWTabset(TabSetType.ACCORDION);
 		add(tabset1c);
 
 		add(new WHorizontalRule());
 
 		/* Content height */
-		add(new WHeading(WHeading.MAJOR, "Examples showing content height property."));
-		add(new WHeading(WHeading.SECTION, "Tall content."));
+		add(new WHeading(HeadingLevel.H2, "Examples showing content height property."));
+		add(new WHeading(HeadingLevel.H3, "Tall content."));
 		WTabSet htabset1 = new SampleWTabset();
 		htabset1.setContentHeight(TALL_CONTENT);
 		add(htabset1);
@@ -84,7 +100,7 @@ public class WTabSetExample extends WPanel {
 		htabset1c.setContentHeight(TALL_CONTENT);
 		add(htabset1c);
 
-		add(new WHeading(WHeading.SECTION, "Short content."));
+		add(new WHeading(HeadingLevel.H3, "Short content."));
 		WTabSet htabset1d = new SampleWTabset();
 		htabset1d.setContentHeight(SHORT_CONTENT);
 		add(htabset1d);
@@ -102,7 +118,7 @@ public class WTabSetExample extends WPanel {
 		add(htabset1g);
 
 		add(new WHorizontalRule());
-		add(new WHeading(WHeading.MAJOR, "Examples showing disabled property."));
+		add(new WHeading(HeadingLevel.H2, "Examples showing disabled property."));
 
 		/* NOTE: WTabSet does not currently implement SubordinateTarget therefore one cannot create a subordinate
 		 * control to disable/enable a WTabSet.
@@ -115,8 +131,8 @@ public class WTabSetExample extends WPanel {
 
 		/* NOTE: no example of the hidden property because WTabSet is not a subordinate target. This is inconsistent
 		 * with the schema. */
-		add(new WHeading(WHeading.MAJOR, "Setting the initially active tab"));
-		add(new WHeading(WHeading.SECTION,
+		add(new WHeading(HeadingLevel.H2, "Setting the initially active tab"));
+		add(new WHeading(HeadingLevel.H3,
 				"Server side with tabs on the left, with second tab initially active."));
 		WTabSet tabset3 = new WTabSet(WTabSet.TYPE_LEFT);
 		tabset3.setContentHeight("10em");
@@ -142,7 +158,7 @@ public class WTabSetExample extends WPanel {
 		tabset3.setActiveIndex(1);
 		add(tabset3);
 
-		add(new WHeading(WHeading.SECTION,
+		add(new WHeading(HeadingLevel.H3,
 				"Client side with tabs on the right and the third tab initially active."));
 		WText thirdContent = new WText("Some more content should go into here.");
 		WTabSet tabset4 = new WTabSet(WTabSet.TYPE_RIGHT);
@@ -156,7 +172,7 @@ public class WTabSetExample extends WPanel {
 		tabset4.setActiveTab(thirdContent);
 		add(tabset4);
 
-		add(new WHeading(WHeading.SECTION, "Client side with showing lots of tabs."));
+		add(new WHeading(HeadingLevel.H3, "Client side with showing lots of tabs."));
 		add(new ExplanatoryText(
 				"This will effectively show what happens when tabs need to wrap. You should do everything possible to avoid this situation."));
 		WTabSet tabset5 = new WTabSet();
@@ -176,6 +192,34 @@ public class WTabSetExample extends WPanel {
 		tabset5.addTab(new WText("Tab 14."), "Fourteenth tab", WTabSet.TAB_MODE_CLIENT);
 		tabset5.addTab(new WText("Tab 15."), "Fifteenth tab", WTabSet.TAB_MODE_CLIENT);
 		add(tabset5);
+				
+		add(new WHorizontalRule());
+		
+		add(new WHeading(HeadingLevel.H2, "Using WSubordinateControl"));
+		WTabSet targetTabset = new SampleWTabset();
+		add(targetTabset);
+		
+		WFieldLayout layout = new WFieldLayout(WFieldLayout.LAYOUT_STACKED);
+		add(layout);
+		final WCheckBox disabledControllerCb = new WCheckBox();
+		final WCheckBox hiddenControllerCb = new WCheckBox();
+		layout.addField("disable tabset", disabledControllerCb);
+		layout.addField("hide tabset", hiddenControllerCb);
+		
+		
+		// Build & add the subordinate
+		SubordinateBuilder builder = new SubordinateBuilder();
+		builder.condition().equals(hiddenControllerCb, String.valueOf(true));
+		builder.whenTrue().hide(targetTabset);
+		builder.whenFalse().show(targetTabset);
+		add(builder.build());
+		
+		builder = new SubordinateBuilder();
+		builder.condition().equals(disabledControllerCb, String.valueOf(true));
+		builder.whenTrue().disable(targetTabset);
+		builder.whenFalse().enable(targetTabset);
+		add(builder.build());
+		
 	}
 
 	/**


### PR DESCRIPTION
* Implement SubordinateTarget on WTabSet (fixes #159)
* Implement SubordinateTarget on WTab (fixes #158)
* Fixed a problem in wc/ui/tabset.js where disabling a tabset would not
disable the tab control buttons as role tabset supports aria-disabled.
* Updated WTabSetExample and WTabExample to include Subordinate
examples.