### PR TITLE
Theme inheritance

### DIFF
--- a/wcomponents-theme/build.xml
+++ b/wcomponents-theme/build.xml
@@ -233,15 +233,60 @@ chromedriver_cdnurl=${mirror.root}/chromedriver
 			<property name="impl.src.dir" location="@{rootDir}/@{implName}"/>
 			<var name="prototype.name" unset="true"/>
 			<loadfile property="prototype.name" srcFile="${impl.src.dir}/inherit.txt"/>
+
+			<var name="prototype.dir" unset="true"/>
+			<var name="merge.impl.dir" unset="true"/>
+			<var name="prototype.src.dir" unset="true"/>
+
+			<if>
+				<isset property="prototype.name"/>
+				<then>
+					<if>
+						<and>
+							<available file="${prototype.name}" type="file"/>
+							<matches string="${prototype.name}" pattern="\.zip$" casesensitive="false"/>
+						</and>
+						<then>
+							<echo>Found prototype zip file ${prototype.name}</echo>
+							<delete dir="${tmp.dir}/parent"/>
+							<!-- unzip the zip and set the path -->
+							<unzip src="${prototype.name}" dest="${tmp.dir}/parent" overwrite="true" failOnEmptyArchive="true">
+								<patternset>
+									<include name="*/**"/>
+								</patternset>
+							</unzip>
+							<property name="prototype.dir" location="${tmp.dir}/parent"/>
+						</then>
+						<elseif>
+							<and>
+								<matches string="${prototype.name}" pattern="\/"/>
+								<available file="${prototype.name}" type="dir"/>
+							</and>
+							<then>
+								<echo>Found prototype directory named ${prototype.name}</echo>
+								<property name="prototype.dir" location="${prototype.name}"/>
+							</then>
+						</elseif>
+						<elseif>
+							<available file="${impl.src.rootdir}/${prototype.name}" type="dir"/>
+							<then>
+								<echo>Using simple fallback prototype ${impl.src.rootdir}/${prototype.name}</echo>
+								<property name="prototype.dir" location="${impl.src.rootdir}/${prototype.name}"/>
+							</then>
+						</elseif>
+						<else>
+							<fail message="Could not find prototype implementation ${prototype.name}"/>
+						</else>
+					</if>
+				</then>
+			</if>
+
 			<if>
 				<and>
-					<isset property="prototype.name"/>
-					<available file="${impl.src.rootdir}/${prototype.name}" type="dir"/>
+					<isset property="prototype.dir"/>
+					<available file="${prototype.dir}" type="dir"/>
 				</and>
 				<then>
-					<var name="prototype.dir" unset="true"/>
-					<var name="merge.impl.dir" unset="true"/>
-					<property name="prototype.dir" location="${impl.src.rootdir}/${prototype.name}"/>
 					<property name="merge.impl.dir" location="${sub.impl.dir}/@{implName}"/>
 					<delete dir="${merge.impl.dir}"/>
 					<echo>Copying sub-implementation files from: ${impl.src.dir} to ${merge.impl.dir}</echo>
@@ -307,9 +352,9 @@ chromedriver_cdnurl=${mirror.root}/chromedriver
 						</fileset>
 					</copy>
 					<copy todir="${merge.impl.dir}/src/main/images" overwrite="false">
-							<fileset dir="${prototype.dir}/src/main/images" includes="**/*" excludesfile="${impl.src.dir}/excludes.txt" erroronmissingdir="false">
-								<present present="srconly" targetdir="${merge.impl.dir}/src/main/images"/>
-							</fileset>
+						<fileset dir="${prototype.dir}/src/main/images" includes="**/*" excludesfile="${impl.src.dir}/excludes.txt" erroronmissingdir="false">
+							<present present="srconly" targetdir="${merge.impl.dir}/src/main/images"/>
+						</fileset>
 					</copy>
 					<copy todir="${merge.impl.dir}/src/main/js" overwrite="false">
 						<fileset dir="${prototype.dir}/src/main/js" includes="**/*.js" excludesfile="${impl.src.dir}/excludes.txt" erroronmissingdir="false">
@@ -323,9 +368,12 @@ chromedriver_cdnurl=${mirror.root}/chromedriver
 					</copy>
 					<delete file="${merge.impl.dir}/inherit.txt"/><!-- EEEK! Make sure to prevent infinite looping -->
 				</then>
-				<else>
-					<fail message="Could not find prototype implementation ${prototype.name}"/>
-				</else>
+				<elseif>
+					<isset property="prototype.dir"/>
+					<then>
+						<fail message="Could not find prototype directory ${prototype.dir}"/>
+					</then>
+				</elseif>
 			</if>
 		</sequential>
 	</macrodef>

--- a/wcomponents-theme/build.xml
+++ b/wcomponents-theme/build.xml
@@ -247,14 +247,14 @@ chromedriver_cdnurl=${mirror.root}/chromedriver
 						</and>
 						<then>
 							<echo>Found prototype zip file ${prototype.name}</echo>
-							<delete dir="${tmp.dir}/parent"/>
+							<property name="prototype.dir" location="${tmp.dir}/parent"/>
+							<delete dir="${prototype.dir}"/>
 							<!-- unzip the zip and set the path -->
-							<unzip src="${prototype.name}" dest="${tmp.dir}/parent" overwrite="true" failOnEmptyArchive="true">
+							<unzip src="${prototype.name}" dest="${prototype.dir}" overwrite="true" failOnEmptyArchive="true">
 								<patternset>
 									<include name="*/**"/>
 								</patternset>
 							</unzip>
-							<property name="prototype.dir" location="${tmp.dir}/parent"/>
 						</then>
 						<elseif>
 							<and>
@@ -269,8 +269,8 @@ chromedriver_cdnurl=${mirror.root}/chromedriver
 						<elseif>
 							<available file="${impl.src.rootdir}/${prototype.name}" type="dir"/>
 							<then>
-								<echo>Using simple fallback prototype ${impl.src.rootdir}/${prototype.name}</echo>
 								<property name="prototype.dir" location="${impl.src.rootdir}/${prototype.name}"/>
+								<echo>Using simple fallback prototype ${prototype.dir}</echo>
 							</then>
 						</elseif>
 						<else>

--- a/wcomponents-theme/build.xml
+++ b/wcomponents-theme/build.xml
@@ -236,7 +236,6 @@ chromedriver_cdnurl=${mirror.root}/chromedriver
 
 			<var name="prototype.dir" unset="true"/>
 			<var name="merge.impl.dir" unset="true"/>
-			<var name="prototype.src.dir" unset="true"/>
 
 			<if>
 				<isset property="prototype.name"/>


### PR DESCRIPTION
Updated sub-theme merging so that `inherit.txt` can contain one of:

1. a simple string without “/“ which is a theme in the current source
root (the currently supported scenario); or
2. the path to the root directory of the theme to be inherited; or
3. the path to a theme sources zip file.

Fixes #173