### PR TITLE
Remove XSLT processor tests

### DIFF
--- a/wcomponents-theme/src/main/xslt/wc.common.registrationScripts.coreRegistrationScripts.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.registrationScripts.coreRegistrationScripts.xsl
@@ -121,11 +121,9 @@
 			<xsl:value-of select="//@defaultFocusId[1]"/>
 			<xsl:text>");});</xsl:text>
 		</xsl:if>
-		<xsl:if test="$isIE=1">
-			<xsl:text>require(["wc/has"], function(has){</xsl:text>
-			<xsl:text>if(has("ie")===8){require(["wc/fix/defaultSubmit_ie8"]);}</xsl:text>
-			<xsl:text>});</xsl:text>
-		</xsl:if>
+		<xsl:text>require(["wc/has"], function(has){</xsl:text>
+		<xsl:text>if(has("ie")===8){require(["wc/fix/defaultSubmit_ie8"]);}</xsl:text>
+		<xsl:text>});</xsl:text>
 		<xsl:call-template name="localRegistrationScripts"/>
 	</xsl:template>
 </xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.constants.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.constants.xsl
@@ -82,33 +82,11 @@
 	XSLT and we do not want it renamed.
 -->
 	<xsl:param name="isDebug" select="1"/>
-<!--
-	This is used to undertake browser specific transformations.
-	Note - this is a param so it can be injected by the transform engine to
-	enable server side transforms.
--->
-	<xsl:param name="xslVendor" select="system-property('xsl:vendor')"/>
 
 <!--
 	Global Variables
-
-	This variable is used as a short hand to determine if the xsl:vendor
-	property is 'Microsoft' which implies Internet Explorer as browser.
-
-	This is still required to provide a means to style some elements by position in IE8.
-
-	TODO: drop this ASAP!
 -->
-	<xsl:variable name="isIE">
-		<xsl:choose>
-			<xsl:when test="$xslVendor='Microsoft'">
-				<xsl:number value="1"/>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:number value="0"/>
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:variable>
+
 <!--
 	This variable is used as a shorthand for testing xs:boolean attribute values
 	as it allows us to further compress the XSLT. We do not need a test for

--- a/wcomponents-theme/src/main/xslt/wc.ui.borderLayout.n.borderLayoutCell.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.borderLayout.n.borderLayoutCell.xsl
@@ -14,7 +14,7 @@
 		<xsl:element name="div">
 			<xsl:attribute name="class">
 				<xsl:value-of select="local-name(.)"/>
-				<xsl:if test="$isIE = 1 and (self::ui:west or self::ui:east or self::ui:center)">
+				<xsl:if test="self::ui:west or self::ui:east or self::ui:center">
 					<!-- IE8 needs more help because it does not know about last child -->
 					<xsl:variable name="colCount" select="count(../ui:west|../ui:east|../ui:center)"/>
 					<xsl:choose>

--- a/wcomponents-theme/src/main/xslt/wc.ui.listLayout.cell.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.listLayout.cell.xsl
@@ -10,12 +10,11 @@
 		<xsl:if test="node()">
 			<xsl:element name="li">
 				<!--
-					Test for InternetExplorer
 					A weakness in IE's (8 and earlier) CSS support prevents us from doing row striping
 					based on the position of the list item in the list. We therefore have to apply
 					a class to every second list item if the listLayout type is striped.
 				-->
-				<xsl:if test="$isIE=1 and ../@type='striped' and position() mod 2 = 0">
+				<xsl:if test="../@type='striped' and position() mod 2 = 0">
 					<xsl:attribute name="class">
 						<xsl:text> wc_iestripe</xsl:text>
 					</xsl:attribute>

--- a/wcomponents-theme/src/main/xslt/wc.ui.root.n.makeRequireConfig.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.root.n.makeRequireConfig.xsl
@@ -48,7 +48,7 @@
 			<xsl:value-of select="concat('baseUrl:&quot;', normalize-space($resourceRoot), $scriptDir, '/&quot;,&#10;')"/>
 			<xsl:value-of select="concat('urlArgs:&quot;', $cacheBuster, '&quot;&#10;')"/>
 			<xsl:text>};&#10;wcconfig = {"wc/xml/xslTransform": {</xsl:text>
-			<xsl:value-of select="concat('xslEngine:&quot;', $xslVendor, '&quot;,&#10;')"/>
+			<xsl:value-of select="concat('xslEngine:&quot;', system-property('xsl:vendor'), '&quot;,&#10;')"/>
 			<!-- Used for testing purposes -->
 			<xsl:value-of select="concat('xslUrl:&quot;', normalize-space($xslPath), '&quot;')"/>
 			<xsl:text>},&#10;"wc/i18n/i18n": {</xsl:text>

--- a/wcomponents-theme/src/main/xslt/wc.ui.root.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.root.xsl
@@ -41,13 +41,11 @@
 				-->
 				<xsl:call-template name="makeRequireConfig"/>
 
-				<xsl:if test="$isIE=1">
-					<!--
-						non-AMD compatible fixes for IE: things that need to be fixed before we can require anything but
-						have to be added after we have included requirejs/require.
-					-->
-					<xsl:call-template name="makeIE8CompatScripts"/>
-				</xsl:if>
+				<!--
+					non-AMD compatible fixes for IE: things that need to be fixed before we can require anything but
+					have to be added after we have included requirejs/require.
+				-->
+				<xsl:call-template name="makeIE8CompatScripts"/>
 
 				<xsl:call-template name="externalScript">
 					<xsl:with-param name="scriptName" select="'requirejs/require'"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.td.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.td.xsl
@@ -27,8 +27,8 @@
 			<xsl:value-of select="$colHeaderElement/@align"/>
 		</xsl:variable>
 		<xsl:variable name="class">
-			
-			<xsl:if test="$isIE = 1 and $myTable/@striping = 'cols' and position() mod 2 = 0">
+			<!-- IE 8- needs more help with striping -->
+			<xsl:if test="$myTable/@striping = 'cols' and position() mod 2 = 0">
 				<xsl:text> wc_table_stripe</xsl:text>
 			</xsl:if>
 			<xsl:choose>


### PR DESCRIPTION
Removed property $isIE and all uses of it from XSLT. This is a
precondition for #174.