### PR TITLE
ReadOnly fix

### DIFF
--- a/wcomponents-theme/src/main/sass/wc.common.checkRadio.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.checkRadio.scss
@@ -1,25 +1,21 @@
 /* wc.common.checkRadio.scss */
 @import 'mixins_common.scss';
 
-// readonly WCheckBox and WRadioButton
+.checkbox, // 'readOnly' WCheckBox
+.radio {
+	@include background-image($url: '../images/checkbox-ro.png', $height: 1em, $width: 1em);
+	@include make-box($width: 1em, $height: 1em);
+}
+
+.checkbox.wc_ro_sel {
+	background-image: url('../images/checkbox-s-ro.png');
+}
 
 
-[aria-readonly="true"] { // NOTE: this is ARIA 1.1
-	&[role="checkbox"],
-	&[role="radio"] {
-		@include background-image($url: '../images/checkbox-ro.png', $height: 1em, $width: 1em);
-		@include make-box($width: 1em, $height: 1em);
+.radio { // 'readOnly' WRadioButton
+	background-image: url('../images/radio-ro.png');
 
-		&[aria-checked="true"] {
-			background-image: url('../images/checkbox-s-ro.png');
-		}
-	}
-
-	&[role="radio"] {
-		background-image: url('../images/radio-ro.png');
-
-		&[aria-checked="true"] {
-			background-image: url('../images/radio-s-ro.png');
-		}
+	&.wc_ro_sel {
+		background-image: url('../images/radio-s-ro.png');
 	}
 }

--- a/wcomponents-theme/src/main/xslt/wc.common.attributeSets.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.attributeSets.xsl
@@ -58,7 +58,7 @@
 		<xsl:if test="$isError and $isError !=''">
 			<xsl:call-template name="invalid"/>
 		</xsl:if>
-		
+
 		<xsl:variable name="class">
 			<xsl:value-of select="concat(local-name(), ' ', @class)"/>
 			<xsl:if test="@submitOnChange and not(@list)">
@@ -68,7 +68,7 @@
 		<xsl:attribute name="class">
 			<xsl:value-of select="normalize-space($class)"/>
 		</xsl:attribute>
-		
+
 		<xsl:call-template name="requiredElement"/>
 		<xsl:call-template name="ajaxController">
 			<xsl:with-param name="id">
@@ -125,7 +125,7 @@
 			<xsl:value-of select="local-name()"/>
 			<xsl:if test="not(@readOnly)">
 				<xsl:text> notext noborder</xsl:text>
-				<xsl:if test="@required and not(self::ui:radioButtonSelect)">
+				<xsl:if test="@required">
 					<xsl:text> wc_req</xsl:text>
 				</xsl:if>
 			</xsl:if>

--- a/wcomponents-theme/src/main/xslt/wc.common.checkableInput.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.checkableInput.xsl
@@ -52,6 +52,11 @@
 		<xsl:choose>
 			<xsl:when test="@readOnly">
 				<xsl:call-template name="readOnlyControl">
+					<xsl:with-param name="class">
+						<xsl:if test="@selected">
+							<xsl:text>wc_ro_sel</xsl:text>
+						</xsl:if>
+					</xsl:with-param>
 					<xsl:with-param name="toolTip">
 						<xsl:choose>
 							<xsl:when test="@selected">
@@ -80,7 +85,7 @@
 						<xsl:with-param name="myLabel" select="$myLabel[1]"/>
 					</xsl:call-template>
 					<!-- Fortunately commonControlAttributes will only output a value attribute if
-						the XSL element has a value attribute; so we can add the ui:checkBox value
+						the XML element has a value attribute; so we can add the ui:checkBox value
 						here without changing the called template. -->
 					<xsl:if test="self::ui:checkBox">
 						<xsl:attribute name="value">

--- a/wcomponents-theme/src/main/xslt/wc.common.checkableSelect.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.checkableSelect.xsl
@@ -137,13 +137,6 @@
 							</xsl:if>
 						</xsl:with-param>
 					</xsl:call-template>
-					<xsl:if test="$readOnly=0">
-						<xsl:if test="$inputType = 'radio'">
-							<xsl:call-template name="requiredElement">
-								<xsl:with-param name="useNative" select="0"/>
-							</xsl:call-template>
-						</xsl:if>
-					</xsl:if>
 
 					<xsl:if test="$title!=''">
 						<xsl:attribute name="title">

--- a/wcomponents-theme/src/main/xslt/wc.common.readOnly.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.readOnly.xsl
@@ -71,12 +71,12 @@
 				<xsl:with-param name="title" select="$toolTip"/>
 			</xsl:call-template>
 			<xsl:attribute name="class">
-				<xsl:text>wc_ro</xsl:text>
+				<xsl:value-of select="concat(local-name(), ' wc_ro')"/>
 				<xsl:if test="@class">
 					<xsl:value-of select="concat(' ', @class)"/>
 				</xsl:if>
 				<xsl:if test="$class != ''">
-					<xsl:value-of select="concat(' ',$class)"/>
+					<xsl:value-of select="concat(' ', $class)"/>
 				</xsl:if>
 			</xsl:attribute>
 			<xsl:if test="$style!=''">
@@ -87,21 +87,6 @@
 			<xsl:if test="$label">
 				<xsl:attribute name="aria-labelledby">
 					<xsl:value-of select="$label/@id"/>
-				</xsl:attribute>
-			</xsl:if>
-			<xsl:if test="self::ui:checkBox or self::ui:radioButton">
-				<xsl:attribute name="role">
-					<xsl:choose>
-						<xsl:when test="self::ui:checkBox">checkbox</xsl:when>
-						<xsl:otherwise>radio</xsl:otherwise>
-					</xsl:choose>
-				</xsl:attribute>
-				<xsl:attribute name="aria-readonly">true</xsl:attribute><!-- NOTE: this is ARIA 1.1 -->
-				<xsl:attribute name="aria-checked">
-					<xsl:choose>
-						<xsl:when test="@selected">true</xsl:when>
-						<xsl:otherwise>false</xsl:otherwise>
-					</xsl:choose>
 				</xsl:attribute>
 			</xsl:if>
 			<xsl:if test="$linkWithText=1">


### PR DESCRIPTION
WRadioButtonSelect was setting aria-required on the fieldset wrapper.
No longer.

Reversed readOnly WRadio and WCheckBox changes to no longer use WAI-ARIA roles and properties due to inconsistencies in the 1.1 spec.