### PR TITLE
Firefox calendar sunday column fix

### DIFF
--- a/wcomponents-theme/src/main/sass/wc.ui.dateField.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dateField.scss
@@ -142,7 +142,8 @@ dialog [role='combobox'] > [role='listbox'] {
 	cursor: pointer;
 	padding: $vgap-small $hgap-small;
 	text-align: center;
-	width: 100%;
+	width: 3em;
+	min-width: 100%;
 
 	&:hover,
 	&:focus {


### PR DESCRIPTION
Fixes issue #237

Quick test in:

Firefox
Chrome / Chrome on iOS
Safari / Safari on iPad
IE8, IE9, IE11
 
Looked good to me.
