### PR TITLE
HTML class property xslt

### DIFF
--- a/wcomponents-theme/src/main/xslt/wc.common.collapsibleToggle.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.collapsibleToggle.xsl
@@ -55,7 +55,13 @@
 		<xsl:variable name="toggleClass">
 			<xsl:value-of select="local-name(.)"/>
 		</xsl:variable>
-		<ul id="{$id}" role="radiogroup" class="{local-name(.)}">
+		<ul id="{$id}" role="radiogroup">
+			<xsl:attribute name="class">
+				<xsl:value-of select="local-name()"/>
+				<xsl:if test="@class">
+					<xsl:value-of select="concat(' ', @class)"/>
+				</xsl:if>
+			</xsl:attribute>
 			<xsl:if test="self::ui:rowExpansion">
 				<xsl:call-template name="disabledElement">
 					<xsl:with-param name="field" select=".."/>

--- a/wcomponents-theme/src/main/xslt/wc.common.media.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.media.xsl
@@ -22,6 +22,12 @@
 			</xsl:choose>
 		</xsl:variable>
 		<span id="{@id}">
+			<xsl:attribute name="class">
+				<xsl:value-of select="local-name(.)"/>
+				<xsl:if test="@class">
+					<xsl:value-of select="concat(' ', @class)"/>
+				</xsl:if>
+			</xsl:attribute>
 			<xsl:if test="@toolTip">
 				<xsl:attribute name="title">
 					<xsl:value-of select="normalize-space(@toolTip)"/>

--- a/wcomponents-theme/src/main/xslt/wc.common.message.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.message.xsl
@@ -14,6 +14,12 @@
 	-->
 	<xsl:template match="ui:message">
 		<xsl:element name="li">
+			<xsl:attribute name="class">
+				<xsl:value-of select="local-name(.)"/>
+				<xsl:if test="@class">
+					<xsl:value-of select="concat(' ', @class)"/>
+				</xsl:if>
+			</xsl:attribute>
 			<xsl:apply-templates/>
 		</xsl:element>
 	</xsl:template>

--- a/wcomponents-theme/src/main/xslt/wc.common.separator.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.separator.xsl
@@ -9,6 +9,12 @@
 			<xsl:attribute name="role">
 				<xsl:text>separator</xsl:text>
 			</xsl:attribute>
+			<xsl:attribute name="class">
+				<xsl:value-of select="local-name(.)"/>
+				<xsl:if test="@class">
+					<xsl:value-of select="concat(' ', @class)"/>
+				</xsl:if>
+			</xsl:attribute>
 			<xsl:call-template name="separatorOrientation"/>
 		</xsl:element>
 	</xsl:template>

--- a/wcomponents-theme/src/main/xslt/wc.ui.abbr.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.abbr.xsl
@@ -7,19 +7,21 @@
 	-->
 	<xsl:template match="ui:abbr">
 		<xsl:if test="text()">
-			<xsl:choose>
-				<xsl:when test="@toolTip">
-					<xsl:element name="abbr">
-						<xsl:attribute name="title">
-							<xsl:value-of select="@toolTip"/>
-						</xsl:attribute>
-						<xsl:value-of select="."/>
-					</xsl:element>
-				</xsl:when>
-				<xsl:otherwise>
-					<xsl:value-of select="."/>
-				</xsl:otherwise>
-			</xsl:choose>
+			<xsl:variable name="element">
+				<xsl:choose>
+					<xsl:when test="@toolTip">abbr</xsl:when>
+					<xsl:otherwise>span</xsl:otherwise>
+				</xsl:choose>
+			</xsl:variable>
+			<xsl:element name="{$element}">
+				<xsl:attribute name="class">
+					<xsl:value-of select="local-name(.)"/>
+					<xsl:if test="@class">
+						<xsl:value-of select="concat(' ', @class)"/>
+					</xsl:if>
+				</xsl:attribute>
+				<xsl:value-of select="."/>
+			</xsl:element>
 		</xsl:if>
 	</xsl:template>
 </xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.ui.collapsible.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.collapsible.xsl
@@ -21,6 +21,12 @@
 			<xsl:attribute name="id">
 				<xsl:value-of select="@id"/>
 			</xsl:attribute>
+			<xsl:attribute name="class">
+				<xsl:value-of select="local-name(.)"/>
+				<xsl:if test="@class">
+					<xsl:value-of select="concat(' ', @class)"/>
+				</xsl:if>
+			</xsl:attribute>
 			<xsl:if test="$collapsed != 1">
 				<xsl:attribute name="open">
 					<xsl:text>open</xsl:text>

--- a/wcomponents-theme/src/main/xslt/wc.ui.dateField.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.dateField.xsl
@@ -47,10 +47,13 @@
 				<xsl:element name="{$tagName}">
 					<xsl:call-template name="commonAttributes"/>
 					<xsl:attribute name="class">
-						<xsl:text>wc_datero wc_ro</xsl:text>
-						<xsl:if test="@class">
-							<xsl:value-of select="concat(' ', @class)"/>
-						</xsl:if>
+						<xsl:attribute name="class">
+							<xsl:value-of select="local-name(.)"/>
+							<xsl:if test="@class">
+								<xsl:value-of select="concat(' ', @class)"/>
+							</xsl:if>
+						</xsl:attribute>
+						<xsl:text> wc_datero wc_ro</xsl:text>
 					</xsl:attribute>
 					<xsl:if test="$myLabel">
 						<xsl:attribute name="aria-labelledby">
@@ -103,7 +106,7 @@
 						<xsl:with-param name="isControl" select="0"/>
 					</xsl:call-template>
 					<xsl:attribute name="class">
-						<xsl:text>dateField</xsl:text>
+						<xsl:value-of select="local-name(.)"/>
 						<xsl:if test="@class">
 							<xsl:value-of select="concat(' ', @class)"/>
 						</xsl:if>

--- a/wcomponents-theme/src/main/xslt/wc.ui.field.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.field.xsl
@@ -47,12 +47,13 @@
 			<xsl:variable name="isCheckRadio">
 				<xsl:call-template name="fieldIsCheckRadio" />
 			</xsl:variable>
-			<li id="{@id}" class="{local-name()}">
+			<li id="{@id}">
 				<xsl:attribute name="id">
 					<xsl:value-of select="@id" />
 				</xsl:attribute>
+
 				<xsl:attribute name="class">
-					<xsl:text>field</xsl:text>
+					<xsl:value-of select="local-name(.)"/>
 					<xsl:if test="@class">
 						<xsl:value-of select="concat(' ', @class)"/>
 					</xsl:if>

--- a/wcomponents-theme/src/main/xslt/wc.ui.fieldindicator.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.fieldindicator.xsl
@@ -28,7 +28,7 @@
 				<xsl:value-of select="@id"/>
 			</xsl:attribute>
 			<xsl:attribute name="class">
-				<xsl:value-of select="@type"/>
+				<xsl:value-of select="concat(local-name(), ' ', @type)"/>
 				<xsl:if test="@class">
 					<xsl:value-of select="concat(' ', @class)"/>
 				</xsl:if>

--- a/wcomponents-theme/src/main/xslt/wc.ui.heading.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.heading.xsl
@@ -17,6 +17,12 @@
 			<xsl:attribute name="id">
 				<xsl:value-of select="@id"/>
 			</xsl:attribute>
+			<xsl:attribute name="class">
+				<xsl:value-of select="local-name(.)"/>
+				<xsl:if test="@class">
+					<xsl:value-of select="concat(' ', @class)"/>
+				</xsl:if>
+			</xsl:attribute>
 			<xsl:call-template name="ajaxTarget"/>
 			<xsl:apply-templates select="ui:margin"/>
 			<xsl:choose>

--- a/wcomponents-theme/src/main/xslt/wc.ui.image.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.image.xsl
@@ -10,6 +10,12 @@
 			<xsl:attribute name="id">
 				<xsl:value-of select="@id"/>
 			</xsl:attribute>
+			<xsl:attribute name="class">
+				<xsl:value-of select="local-name(.)"/>
+				<xsl:if test="@class">
+					<xsl:value-of select="concat(' ', @class)"/>
+				</xsl:if>
+			</xsl:attribute>
 			<xsl:attribute name="src">
 				<xsl:value-of select="@src"/>
 			</xsl:attribute>

--- a/wcomponents-theme/src/main/xslt/wc.ui.link.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.link.xsl
@@ -63,7 +63,7 @@
 					<xsl:attribute name="class">
 						<xsl:value-of select="local-name()"/>
 						<xsl:if test="@imagePosition">
-							<xsl:value-of select="concat('wc_btn_img',@imagePosition)"/>
+							<xsl:value-of select="concat(' wc_btn_img',@imagePosition)"/>
 						</xsl:if>
 						<xsl:if test="@class">
 							<xsl:value-of select="concat(' ', @class)"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.listLayout.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.listLayout.xsl
@@ -34,7 +34,7 @@
 			<xsl:attribute name="class">
 				<xsl:value-of select="normalize-space(concat('listLayout ',@type,' ', @align))"/>
 				<xsl:if test="not(@align)">
-					<xsl:text> ${wc.common.align.std}</xsl:text>
+					<xsl:text>${wc.common.align.std}</xsl:text>
 				</xsl:if>
 				<xsl:choose>
 					<xsl:when test="@ordered=$t and (not(@separator) or @separator='none')">

--- a/wcomponents-theme/src/main/xslt/wc.ui.menuItem.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.menuItem.xsl
@@ -54,22 +54,6 @@
 			</xsl:choose>
 		</xsl:variable>
 
-		<xsl:variable name="class">
-			<xsl:text>menuItem</xsl:text>
-			<xsl:if test="$type &gt; 0">
-				<xsl:text> wc_btn_nada</xsl:text>
-				<xsl:if test="@cancel">
-					<xsl:text> wc_btn_cancel</xsl:text>
-				</xsl:if>
-				<xsl:if test="@unsavedChanges">
-					<xsl:text> wc_unsaved</xsl:text>
-				</xsl:if>
-			</xsl:if>
-			<xsl:if test="@class">
-				<xsl:value-of select="concat(' ', @class)"/>
-			</xsl:if>
-		</xsl:variable>
-
 		<xsl:variable name="isButton">
 			<xsl:choose>
 				<xsl:when test="$type=0">
@@ -81,11 +65,25 @@
 			</xsl:choose>
 		</xsl:variable>
 
-		<xsl:element name="{$menuItemElement}" class="{$class">
+		<xsl:element name="{$menuItemElement}">
 			<xsl:attribute name="id">
 				<xsl:value-of select="$id"/>
 			</xsl:attribute>
-			
+			<xsl:attribute name="classs">
+				<xsl:text>menuItem</xsl:text>
+				<xsl:if test="$type &gt; 0">
+					<xsl:text> wc_btn_nada</xsl:text>
+					<xsl:if test="@cancel">
+						<xsl:text> wc_btn_cancel</xsl:text>
+					</xsl:if>
+					<xsl:if test="@unsavedChanges">
+						<xsl:text> wc_unsaved</xsl:text>
+					</xsl:if>
+				</xsl:if>
+				<xsl:if test="@class">
+					<xsl:value-of select="concat(' ', @class)"/>
+				</xsl:if>
+			</xsl:attribute>
 			<xsl:if test="@toolTip">
 				<xsl:attribute name="title">
 					<xsl:value-of select="normalize-space(@toolTip)"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.menuItem.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.menuItem.xsl
@@ -55,8 +55,9 @@
 		</xsl:variable>
 
 		<xsl:variable name="class">
+			<xsl:text>menuItem</xsl:text>
 			<xsl:if test="$type &gt; 0">
-				<xsl:text>wc_btn_nada</xsl:text>
+				<xsl:text> wc_btn_nada</xsl:text>
 				<xsl:if test="@cancel">
 					<xsl:text> wc_btn_cancel</xsl:text>
 				</xsl:if>
@@ -80,15 +81,11 @@
 			</xsl:choose>
 		</xsl:variable>
 
-		<xsl:element name="{$menuItemElement}">
+		<xsl:element name="{$menuItemElement}" class="{$class">
 			<xsl:attribute name="id">
 				<xsl:value-of select="$id"/>
 			</xsl:attribute>
-			<xsl:if test="$class!=''">
-				<xsl:attribute name="class">
-					<xsl:value-of select="normalize-space($class)"/>
-				</xsl:attribute>
-			</xsl:if>
+			
 			<xsl:if test="@toolTip">
 				<xsl:attribute name="title">
 					<xsl:value-of select="normalize-space(@toolTip)"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.menuItem.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.menuItem.xsl
@@ -69,7 +69,7 @@
 			<xsl:attribute name="id">
 				<xsl:value-of select="$id"/>
 			</xsl:attribute>
-			<xsl:attribute name="classs">
+			<xsl:attribute name="class">
 				<xsl:text>menuItem</xsl:text>
 				<xsl:if test="$type &gt; 0">
 					<xsl:text> wc_btn_nada</xsl:text>

--- a/wcomponents-theme/src/main/xslt/wc.ui.row.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.row.xsl
@@ -6,6 +6,12 @@
 	-->
 	<xsl:template match="ui:row">
 		<div id="{@id}" class="{local-name(.)} wc_row">
+			<xsl:attribute name="class">
+				<xsl:text>row wc_row</xsl:text>
+				<xsl:if test="@class">
+					<xsl:value-of select="concat(' ', @class)"/>
+				</xsl:if>
+			</xsl:attribute>
 			<xsl:call-template name="ajaxTarget"/>
 			<xsl:apply-templates select="ui:margin"/>
 			<xsl:apply-templates select="ui:column">

--- a/wcomponents-theme/src/main/xslt/wc.ui.suggestions.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.suggestions.xsl
@@ -14,6 +14,12 @@
 			<xsl:attribute name="id">
 				<xsl:value-of select="@id"/>
 			</xsl:attribute>
+			<xsl:attribute name="class">
+				<xsl:value-of select="local-name(.)"/>
+				<xsl:if test="@class">
+					<xsl:value-of select="concat(' ', @class)"/>
+				</xsl:if>
+			</xsl:attribute>
 			<xsl:attribute name="role">
 				<xsl:text>listbox</xsl:text>
 			</xsl:attribute>

--- a/wcomponents-theme/src/main/xslt/wc.ui.tabContent.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.tabContent.xsl
@@ -21,18 +21,19 @@
 				<xsl:text>tabpanel</xsl:text>
 			</xsl:attribute>
 			<xsl:attribute name="class">
+				<xsl:text>tabContent</xsl:text>
 				<xsl:if test="$mode='server'">
-					<xsl:text>wc_lame </xsl:text>
+					<xsl:text> wc_lame</xsl:text>
 				</xsl:if>
 				<xsl:choose>
 					<xsl:when test="$open=1">
 						<xsl:if test="$mode='dynamic'">
-							<xsl:text>wc_magic wc_dynamic</xsl:text>
+							<xsl:text> wc_magic wc_dynamic</xsl:text>
 						</xsl:if>
 					</xsl:when>
 					<xsl:otherwise>
 						<xsl:if test="($mode='lazy') or ($mode='eager') or ($mode='dynamic')">
-							<xsl:text>wc_magic</xsl:text>
+							<xsl:text> wc_magic</xsl:text>
 							<xsl:if test="$mode='dynamic'">
 								<xsl:text> wc_dynamic</xsl:text>
 							</xsl:if>

--- a/wcomponents-theme/src/main/xslt/wc.ui.validationErrors.error.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.validationErrors.error.xsl
@@ -4,20 +4,17 @@
  in an error state.
 -->
 	<xsl:template match="ui:error">
-		<xsl:element name="li">
-			<xsl:element name="a">
-				<xsl:attribute name="href">
-					<xsl:value-of select="concat('#',@for)"/>
-				</xsl:attribute>
+		<li class="error">
+			<a href="{concat('#',@for)}">
 				<xsl:apply-templates/>
-			</xsl:element>
-		</xsl:element>
+			</a>
+		</li>
 	</xsl:template>
 	
 	<!-- The inline error output for each ui:error for a component in a error state. -->
 	<xsl:template match="ui:error" mode="inline">
-		<xsl:element name="li">
+		<li class="error">
 			<xsl:apply-templates/>
-		</xsl:element>
+		</li>
 	</xsl:template>
 </xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.ui.video.track_link.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.video.track_link.xsl
@@ -3,13 +3,7 @@
  Output an A element linking to a track file.
 -->
 	<xsl:template match="ui:track" mode="link">
-		<xsl:element name="a">
-			<xsl:attribute name="href">
-				<xsl:value-of select="@src"/>
-			</xsl:attribute>
-			<xsl:attribute name="class">
-				<xsl:text>track</xsl:text>
-			</xsl:attribute>
+		<a href="{@src}" class="track">
 			<xsl:if test="@lang">
 				<xsl:attribute name="lang">
 					<xsl:value-of select="@lang"/>
@@ -26,7 +20,7 @@
 				<xsl:value-of select="@kind"/>
 				<xsl:text> )</xsl:text>
 			</xsl:if>
-		</xsl:element>
+		</a>
 		<xsl:if test="position()!=last()">
 			<xsl:value-of select="' '"/>
 		</xsl:if>


### PR DESCRIPTION
Some components were missing the inclusion of @class in the XSLT for
their class attribute. This fixes these issues. Addresses #172.