### PR TITLE
280 messageBox title

### DIFF
--- a/wcomponents-core/src/main/resources/schema/ui/v1/messageBox.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/messageBox.xsd
@@ -35,6 +35,11 @@ XML schema for messageBox (WMessageBox)
 					<xs:documentation>Provides the ability to pass an HTML class attribute onto the root output element.</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
+			<xs:attribute name="title" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>A human readable title for the messageBox.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
 			<xs:attribute name="type" use="required">
 				<xs:annotation>
 					<xs:documentation>The type of message(s) being displayed.</xs:documentation>

--- a/wcomponents-core/src/main/resources/schema/ui/v1/validationErrors.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/validationErrors.xsd
@@ -37,6 +37,12 @@ XML schema for validationErrors (WValidationErrors)
 					<xs:documentation>Provides the ability to pass an HTML class attribute onto the root output element.</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
+
+			<xs:attribute name="title" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>A human readable title for the validationErrors container.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
 		</xs:complexType>
 	</xs:element>
 </xs:schema>

--- a/wcomponents-theme/src/main/xslt/wc.common.feedback.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.feedback.xsl
@@ -29,6 +29,9 @@
 			</xsl:attribute>
 			<xsl:element name="h1">
 				<xsl:choose>
+					<xsl:when test="@title">
+						<xsl:value-of select="@title"/>
+					</xsl:when>
 					<xsl:when test="$type='error'">
 						<xsl:value-of select="$$${wc.ui.messageBox.title.error}"/>
 					</xsl:when>


### PR DESCRIPTION
Added XSLT to handle a new @title attribute on ui:messageBox (and
ui:validationErrors). Addresses client side aspect of #280.