### PR TITLE
Fix multi file upload bootstrapping

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/multiFileUploader.js
+++ b/wcomponents-theme/src/main/js/wc/ui/multiFileUploader.js
@@ -142,6 +142,7 @@ define(["wc/dom/attribute",
 				var fileInfo, container, trigger, proceed,
 					element = $event.target;
 				if (!$event.defaultPrevented) {
+					initialiseFileInput(element);
 					fileInfo = fileInfoWd.findAncestor(element);
 					if (fileInfo) {
 						if (removeButtonWd.isOneOfMe(element)) {


### PR DESCRIPTION
Fixed a bootstrapping issue in multiFileUpload caused by Firefox not
focusing the file upload before a click event on the browse button. The
fix is to make sure the file upload is initialised during the click
event. This has the overhead of an extra function call but the
initialisation function is self-testing so the overhead is negligible.

Fixes #245