### PR TITLE
Table a11y

### DIFF
--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/table/WTableOptionsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/table/WTableOptionsExample.java
@@ -139,6 +139,11 @@ public class WTableOptionsExample extends WBeanContainer {
 	private final WCheckBox chbRowsPerPageOptions = new WCheckBox();
 
 	/**
+	 * Caption text.
+	 */
+	private final WTextField tfCaption = new WTextField();
+
+	/**
 	 * Construct the example.
 	 */
 	public WTableOptionsExample() {
@@ -178,6 +183,7 @@ public class WTableOptionsExample extends WBeanContainer {
 		layout.addField("Column order", columnOrder);
 		WField fieldRows = layout.addField("Rows per page", numRowsPerPage);
 		WField fieldRowsOptions = layout.addField("Rows per page options", chbRowsPerPageOptions);
+		layout.addField("Caption", tfCaption);
 
 		WSubordinateControl pagRowsPerPage = new WSubordinateControl();
 		Rule rule = new Rule();
@@ -433,6 +439,13 @@ public class WTableOptionsExample extends WBeanContainer {
 		table.setShowColumnHeaders(showColHeaders.isSelected());
 		table.setExpandAll(expandAll.isSelected());
 		table.setEditable(chbEditable.isSelected());
+
+		// Caption
+		if(null != tfCaption.getText()) {
+			table.setCaption(tfCaption.getText());
+		} else {
+			table.setCaption("");
+		}
 
 		// Pagination
 		table.setPaginationMode(rbsPaging.getSelected());

--- a/wcomponents-theme/src/main/sass/wc.ui.table.caption.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.caption.scss
@@ -1,28 +1,9 @@
 /* wc.ui.table.caption.scss */
+// NOTE: this is a stub - override it as you see fit.
+
 @import 'mixins_common.scss';
 
 caption {
-
-	// > span {
-	// 	//this is the actual caption if any is set.
-	// 	text-align: center; //Chrome default for captions
-	// }
-
-	> div { //row contaier for select all and expand all controls.
-		text-align: left;
-
-		> div {
-			width: 50%;
-
-			&:first-child:last-child { // only one of the control sets is needed.
-				width: 100%;
-			}
-		}
-	}
-}
-
-@include respond(phonelike) {
-	caption > div > div {
-		width: 100%;
-	}
+	margin-bottom: $hgap-normal;
+	text-align: left;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.table.caption.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.caption.scss
@@ -1,0 +1,28 @@
+/* wc.ui.table.caption.scss */
+@import 'mixins_common.scss';
+
+caption {
+
+	// > span {
+	// 	//this is the actual caption if any is set.
+	// 	text-align: center; //Chrome default for captions
+	// }
+
+	> div { //row contaier for select all and expand all controls.
+		text-align: left;
+
+		> div {
+			width: 50%;
+
+			&:first-child:last-child { // only one of the control sets is needed.
+				width: 100%;
+			}
+		}
+	}
+}
+
+@include respond(phonelike) {
+	caption > div > div {
+		width: 100%;
+	}
+}

--- a/wcomponents-theme/src/main/sass/wc.ui.table.pagination.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.pagination.scss
@@ -2,7 +2,6 @@
 @import 'mixins_common.scss';
 
 .wc_table_pag_cont {
-	text-align: right;
 	white-space: nowrap;
 
 	label,

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansion.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansion.scss
@@ -1,12 +1,16 @@
 /* wc.ui.table.rowExpansion.scss */
 @import 'mixins_common.scss';
 
-thead .rowExpansion {
+.rowExpansion {
 	&[role='radiogroup'] {
 		list-style-type: none;
 		margin: 0;
 		padding: 0;
 		text-align: right;
+
+		@include respond(phonelike) {
+			text-align: left;
+		}
 	}
 
 	> li {
@@ -18,24 +22,24 @@ thead .rowExpansion {
 		}
 
 	}
-}
 
-// ROW EXPANSION iconography and expand/collapse all iconography.
-// .wc_table_rowexp_container is the expandable row's expander holding cell or header*/
-.rowExpansion button {
-	&:before {
-		@include use-symbol-font;
-		content: '\229e';
-		font-size: 1.25em;
-		line-height: 0;
+	// ROW EXPANSION iconography and expand/collapse all iconography.
+	// .wc_table_rowexp_container is the expandable row's expander holding cell or header
+	button {
+		&:before {
+			@include use-symbol-font;
+			content: '\229e';
+			font-size: 1.25em;
+			line-height: 0;
 
-		@include reset-large-screen {
-			font-size: 1em;
+			@include reset-large-screen {
+				font-size: 1em;
+			}
 		}
-	}
 
-	&[data-wc-value='collapse']:before {
-		content: '\229f';
+		&[data-wc-value='collapse']:before {
+			content: '\229f';
+		}
 	}
 }
 

--- a/wcomponents-theme/src/main/sass/wc.ui.table.topControls.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.topControls.scss
@@ -1,0 +1,50 @@
+/* wc.ui.table.caption.scss */
+@import 'mixins_common.scss';
+
+.wc_table_top_controls { //row container for select all and expand all controls.
+	@include flex($justify: space-between); // ($direction: row, $wrap: nowrap, $justify: flex-start, $align-items: stretch, $align-content: stretch)
+	margin-bottom: $hgap-small;
+
+	> div {
+		@include flex-grow(1);
+		display: inline-block;
+
+		&:last-child {
+			@include flex-justify-content(flex-end);
+			text-align: right;
+		}
+	}
+
+	> .wc_table_sel_cont:last-child {
+		@include flex-justify-content(flex-start); //always put the selection controls at the start
+		text-align: left;
+	}
+	//
+	// > .wc_table_pag_cont {
+	//
+	// }
+	//
+	//> .wc_table_exp_cont {
+	//
+	//}
+}
+
+@include respond(phonelike) {
+	.wc_table_top_controls {
+		display: block;
+
+		> div {
+			display: block;
+			text-align: left;
+			width: 100%;
+
+			+ div {
+				margin-top: $hgap-small;
+			}
+		}
+
+		> .wc_table_exp_cont {
+			text-align: left;
+		}
+	}
+}

--- a/wcomponents-theme/src/main/xslt/wc.common.makeLegend.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.makeLegend.xsl
@@ -1,5 +1,6 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
 	<xsl:import href="wc.constants.xsl"/>
+	<xsl:import href="wc.common.offscreenSpan.xsl"/>
 	<!--
 	Helper template to make a fieldset legend. Used by the following components:
 		WCheckBoxSelect
@@ -8,21 +9,21 @@
 		WMultiSelectPair
 		WMultiTextField
 		WRadioButtonSelect
-	
+
 	Creates a legend element. If the component has a WLabel associated with it then
 	the legend is created by the transform for that WLabel using the explicit param.
-	
+
 	Otherwise a legend element is created and populated as follows:
-	
+
 		1 if the element has its accessibleText property set then the legend uses
 		this text as its content and is moved out of viewport; otherwise
-		
-		2 the legend has the default label text as its content and is left on 
-		screen as this is an error state for WComponents as it contravenes our 
-		attempts to implement accessibility guidelines. Whilst a fieldset is not a 
-		labellable element it does require a legend (in HTML5) and the most 
+
+		2 the legend has the default label text as its content and is left on
+		screen as this is an error state for WComponents as it contravenes our
+		attempts to implement accessibility guidelines. Whilst a fieldset is not a
+		labellable element it does require a legend (in HTML5) and the most
 		appropriate means to create a legend is by using a WLabel.
-	
+
 	param myLabel: the WLabel "for" the calling component, if any. This will have already
 	been determined before calling this template so we do not have to re-interrogate the
 	label key.
@@ -64,9 +65,11 @@
 		<legend class="wc_off">
 			<xsl:value-of select="$content"/>
 			<xsl:if test="@required">
-				<span class="wc_off">
-					<xsl:value-of select="$$${wc.common.i18n.requiredPlaceholder}"/>
-				</span>
+				<xsl:call-template name="offscreenSpan">
+					<xsl:with-param name="text">
+						<xsl:value-of select="$$${wc.common.i18n.requiredPlaceholder}"/>
+					</xsl:with-param>
+				</xsl:call-template>
 			</xsl:if>
 		</legend>
 	</xsl:template>

--- a/wcomponents-theme/src/main/xslt/wc.common.offscreenSpan.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.offscreenSpan.xsl
@@ -1,7 +1,8 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
 	<!--
-		Output an out of viewport span for accessible column headings
+		Output an out of viewport span
 		param text The text content of the off screen span.
+		param [class] Optional extra class(es) to add to the span.
 	-->
 	<xsl:template name="offscreenSpan">
 		<xsl:param name="text"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.fieldSet.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.fieldSet.xsl
@@ -5,25 +5,26 @@
 	<xsl:import href="wc.common.invalid.xsl"/>
 	<xsl:import href="wc.common.required.xsl"/>
 	<xsl:import href="wc.common.accessKey.xsl"/>
+	<xsl:import href="wc.common.offscreenSpan.xsl"/>
 	<!--
 		Transform for ui:fieldSet which is the XML output of WFieldSet.
-	
+
 		Child Elements
 		* ui:decoratedLabel
 		* ui:content
-		
+
 		Base element:
-		
+
 		If the WFieldset has @readOnly="true" it transforms to a HTML div element; otherwise it transforms
 		to a HTML fieldset element.
-		
+
 		Heading element:
 		A fieldset has a mandatory legend child element. When the fieldset transforms
-		to a div we test whether a heading style element is required and if so 
+		to a div we test whether a heading style element is required and if so
 		(that is @frame != notext or none) we output a HTML div element.
-		
-		
-		
+
+
+
 		This template determines the appropriate HTML element and outputs it. If the
 		frame attribute indicates there should not be a border or if the fieldSet is
 		'in error' (see {{{Error}Error State}}) then classes are set to style
@@ -69,13 +70,13 @@
 				<xsl:call-template name="invalid"/>
 			</xsl:if>
 			<xsl:call-template name="hideElementIfHiddenSet"/>
-			
+
 			<xsl:call-template name="ajaxTarget"/>
 			<!--
 				The Legend/Label/Heading
 
 				The fieldset should be labelled with a HTML LEGEND element.
-			
+
 				In HTML5 a FIELDSET must have a LEGEND child element. This legend provides
 				context to the form controls contained within the fieldset. For more details see
 				{{{./fieldsets.html}using fieldsets and WFieldSet}}. The WDecoratedLabel of the
@@ -83,21 +84,21 @@
 				argument or by using one of the setTitle functions) is the content of the legend.
 				It MUST be meaningful and, if setTitle(WComponent title) is used then the
 				WComponent used <<must>> meet the following conditions:
-				
+
 				[[1]] The component must not be an interactive form component
-				
+
 				[[2]] The component must not be empty or null, including an empty string or
 				WContainer;
-				
+
 				[[3]] The component must output some content which is perceivable as text
 				either as a text node or a title attribute on transformed output; and
-				
+
 				[[4]] The perceivable text content must add context to the components
 				contained within the fieldset.
-				
+
 				When readOnly the heading element may not be output at all, depending upon the
 				value of the frame property.
-				
+
 				The legend will always be output but may be rendered out of viewport by the frame attribute.
 			-->
 			<xsl:element name="legend">
@@ -107,12 +108,14 @@
 					<xsl:value-of select="$$${wc.common.i18n.requiredLabel}"/>
 				</xsl:if>
 				<xsl:if test="@required">
-					<span class="wc_off">
-						<xsl:value-of select="$$${wc.common.i18n.requiredPlaceholder}"/>
-					</span>
+					<xsl:call-template name="offscreenSpan">
+						<xsl:with-param name="text">
+							<xsl:value-of select="$$${wc.common.i18n.requiredPlaceholder}"/>
+						</xsl:with-param>
+					</xsl:call-template>
 				</xsl:if>
 			</xsl:element>
-			
+
 			<xsl:apply-templates select="ui:content"/>
 			<xsl:if test="$isError">
 				<xsl:call-template name="inlineError">

--- a/wcomponents-theme/src/main/xslt/wc.ui.fileUpload.file.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.fileUpload.file.xsl
@@ -44,9 +44,11 @@
 			</xsl:choose>
 			<xsl:if test="not($readOnly=$t)">
 				<button type="button" class="wc_btn_nada" title="{$removeTxt}">
-					<span class="wc_off">
-						<xsl:value-of select="$removeTxt"/>
-					</span>
+					<xsl:call-template name="offscreenSpan">
+						<xsl:with-param name="text">
+							<xsl:value-of select="$removeTxt"/>
+						</xsl:with-param>
+					</xsl:call-template>
 				</button>
 			</xsl:if>
 		</xsl:element>

--- a/wcomponents-theme/src/main/xslt/wc.ui.label.n.makeLabel.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.label.n.makeLabel.xsl
@@ -4,39 +4,39 @@
 	<xsl:import href="wc.ui.label.n.labelClassHelper.xsl"/>
 	<xsl:import href="wc.ui.label.n.labelCommonAttributes.xsl"/>
 	<xsl:import href="wc.ui.label.n.labelHintHelper.xsl"/>
-	
+
 	<!--
 		Basic helper template to make a label for a labelable element.
-		
+
 		In the past this template and the template now called makeFauxLabel
 		were part of the transfrom of ui:label. This lead to a lot of complex
-		template switching and retesting. 
-		
+		template switching and retesting.
+
 		By splitting the templates out and setting up a few common helpers we
-		have a little bit of XSLT redundancy but the number of computations 
+		have a little bit of XSLT redundancy but the number of computations
 		of labelled element and element types is significantly reduced.
-		
+
 		This has lead to a bit of a performance gain in the XLST Processor phase
 		but more importantly has made the label transform much easier to maintain
 		by making it almost intelligible.
-		
-		param labelableElement: the element the label is 'for' this is 
+
+		param labelableElement: the element the label is 'for' this is
 		pre-calculated before calling this template so can never be null and is
 		always a component which transforms to a labellable element.
-		
+
 		param style: passed in ultimately from the transform for ui:field. See
 		wc.ui.field.xsl.
 	-->
 	<xsl:template name="makeLabel">
 		<xsl:param name="labelableElement"/>
 		<xsl:param name="style"/>
-		
+
 		<xsl:variable name="readOnly">
 			<xsl:if test="$labelableElement/@readOnly">
 				<xsl:number value="1"/>
 			</xsl:if>
 		</xsl:variable>
-		
+
 		<xsl:variable name="elementType">
 			<xsl:choose>
 				<xsl:when test="$readOnly=1">
@@ -47,13 +47,13 @@
 				</xsl:otherwise>
 			</xsl:choose>
 		</xsl:variable>
-		
+
 		<xsl:element name="{$elementType}">
 			<xsl:call-template name="labelCommonAttributes">
 				<xsl:with-param name="element" select="$labelableElement"/>
 				<xsl:with-param name="style" select="$style"/>
 			</xsl:call-template>
-			
+
 			<xsl:choose>
 				<xsl:when test="$elementType='label'">
 					<xsl:if test="@for and @for!=''"><!-- this is an explicit 'for' and not for implied by nesting -->
@@ -74,28 +74,30 @@
 					</xsl:attribute>
 				</xsl:otherwise>
 			</xsl:choose>
-			
+
 			<xsl:call-template name="labelClassHelper">
 				<xsl:with-param name="element" select="$labelableElement"/>
 				<xsl:with-param name="readOnly" select="$readOnly"/>
 				<xsl:with-param name="elementType" select="$elementType"/>
 			</xsl:call-template>
-					
+
 			<xsl:if test="$elementType='label'">
 				<xsl:call-template name="accessKey"/>
 			</xsl:if>
-					
+
 			<xsl:apply-templates/>
 			<xsl:if test="normalize-space(.)='' and not(.//ui:image)">
 				<xsl:value-of select="$$${wc.common.i18n.requiredLabel}"/>
 			</xsl:if>
-			
+
 			<xsl:if test="$elementType='label' and $labelableElement/@required">
-				<span class="wc_off">
-					<xsl:value-of select="$$${wc.common.i18n.requiredPlaceholder}"/>
-				</span>
+				<xsl:call-template name="offscreenSpan">
+					<xsl:with-param name="text">
+						<xsl:value-of select="$$${wc.common.i18n.requiredPlaceholder}"/>
+					</xsl:with-param>
+				</xsl:call-template>
 			</xsl:if>
-			
+
 			<xsl:call-template name="labelHintHelper">
 				<xsl:with-param name="element" select="$labelableElement"/>
 				<xsl:with-param name="readOnly" select="$readOnly"/>
@@ -103,11 +105,11 @@
 		</xsl:element>
 		<!--
 			test for radio button and checkbox errors
-			
-			This determines whether the forElement is a component which will transform to a 
-			checkbox or radio button. This is used in conjunction with the error state 
-			check to output inline error messages because they have to be output after the 
-			label for those element types whereas they are normally output after the actual 
+
+			This determines whether the forElement is a component which will transform to a
+			checkbox or radio button. This is used in conjunction with the error state
+			check to output inline error messages because they have to be output after the
+			label for those element types whereas they are normally output after the actual
 			control.
 		-->
 		<xsl:if test="name($labelableElement) = 'ui:checkBox' or name($labelableElement) = 'ui:radioButton'">

--- a/wcomponents-theme/src/main/xslt/wc.ui.label_legend.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.label_legend.xsl
@@ -2,15 +2,15 @@
 	<xsl:import href="wc.common.accessKey.xsl"/>
 	<xsl:import href="wc.constants.xsl"/>
 	<xsl:import href="wc.ui.label.n.WLabelHint.xsl"/>
-	
+
 	<!--
-		This is used to generate a legend for a component which has a fieldset wrapper. The component element is passed 
+		This is used to generate a legend for a component which has a fieldset wrapper. The component element is passed
 		in as the forElement. This is not called if the component is in a read only state.
-		
+
 		The ui:label is aso transformed in-situ as a faux-label so we MUST NOT output the label ID in this legend. We do
 		output accessKey because accesskey is an allowed and functional attribute on a legend element.
-		
-		param: labelableELement: the component being labelled. This is always known and does not need to be calculated 
+
+		param: labelableELement: the component being labelled. This is always known and does not need to be calculated
 		so it is MUCH cheaper to pass it in as a param.
 	-->
 	<xsl:template match="ui:label" mode="legend">
@@ -43,9 +43,11 @@
 				<xsl:with-param name="submitNotAjaxTrigger" select="$submitNotAjaxTrigger"/>
 			</xsl:call-template>
 			<xsl:if test="$labelableElement and $labelableElement/@required">
-				<span class="wc_off">
-					<xsl:value-of select="$$${wc.common.i18n.requiredPlaceholder}"/>
-				</span>
+				<xsl:call-template name="offscreenSpan">
+					<xsl:with-param name="text">
+						<xsl:value-of select="$$${wc.common.i18n.requiredPlaceholder}"/>
+					</xsl:with-param>
+				</xsl:call-template>
 			</xsl:if>
 		</legend>
 	</xsl:template>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.n.caption.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.n.caption.xsl
@@ -1,0 +1,42 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
+	<!--
+		Creates a caption element if required. Called from the transform for ui:table.
+	-->
+	<xsl:template name="caption">
+		<xsl:param name="hasRowSelection" select="0"/>
+		<xsl:param name="hasExpandAll" select="0"/>
+		<xsl:if test="@caption or ($hasExpandAll + $hasRowSelection &gt; 0)">
+			<caption>
+				<xsl:if test="@caption">
+					<span>
+						<xsl:value-of select="@caption"/>
+					</span>
+				</xsl:if>
+				<xsl:if test="$hasExpandAll + $hasRowSelection &gt; 0">
+					<div class="wc_row">
+						<xsl:choose>
+							<xsl:when test="$hasExpandAll + $hasRowSelection = 2">
+								<div>
+									<xsl:apply-templates select="ui:rowSelection"/>
+								</div>
+								<div>
+									<xsl:apply-templates select="ui:rowExpansion"/>
+								</div>
+							</xsl:when>
+							<xsl:when test="$hasRowSelection = 1">
+								<div>
+									<xsl:apply-templates select="ui:rowSelection"/>
+								</div>
+							</xsl:when>
+							<xsl:otherwise>
+								<div>
+									<xsl:apply-templates select="ui:rowExpansion"/>
+								</div>
+							</xsl:otherwise>
+						</xsl:choose>
+					</div>
+				</xsl:if>
+			</caption>
+		</xsl:if>
+	</xsl:template>
+</xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.n.caption.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.n.caption.xsl
@@ -3,39 +3,9 @@
 		Creates a caption element if required. Called from the transform for ui:table.
 	-->
 	<xsl:template name="caption">
-		<xsl:param name="hasRowSelection" select="0"/>
-		<xsl:param name="hasExpandAll" select="0"/>
-		<xsl:if test="@caption or ($hasExpandAll + $hasRowSelection &gt; 0)">
+		<xsl:if test="@caption">
 			<caption>
-				<xsl:if test="@caption">
-					<span>
-						<xsl:value-of select="@caption"/>
-					</span>
-				</xsl:if>
-				<xsl:if test="$hasExpandAll + $hasRowSelection &gt; 0">
-					<div class="wc_row">
-						<xsl:choose>
-							<xsl:when test="$hasExpandAll + $hasRowSelection = 2">
-								<div>
-									<xsl:apply-templates select="ui:rowSelection"/>
-								</div>
-								<div>
-									<xsl:apply-templates select="ui:rowExpansion"/>
-								</div>
-							</xsl:when>
-							<xsl:when test="$hasRowSelection = 1">
-								<div>
-									<xsl:apply-templates select="ui:rowSelection"/>
-								</div>
-							</xsl:when>
-							<xsl:otherwise>
-								<div>
-									<xsl:apply-templates select="ui:rowExpansion"/>
-								</div>
-							</xsl:otherwise>
-						</xsl:choose>
-					</div>
-				</xsl:if>
+				<xsl:value-of select="@caption"/>	
 			</caption>
 		</xsl:if>
 	</xsl:template>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.n.topControls.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.n.topControls.xsl
@@ -37,7 +37,8 @@
 			</xsl:choose>
 		</xsl:variable>
 			
-		<xsl:if test="$hasExpandAll + $hasRowSelection + $hasPagination &gt; 0">
+		<!-- xsl:if test="$hasExpandAll + $hasRowSelection + $hasPagination &gt; 0" -->
+		<xsl:if test="$hasExpandAll + $hasRowSelection &gt; 0">
 			<div class="wc_table_top_controls">
 				<xsl:if test="$hasRowSelection = 1">
 					<div class="wc_table_sel_cont">

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.n.topControls.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.n.topControls.xsl
@@ -1,0 +1,62 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
+	<xsl:import href="wc.constants.xsl"/>
+	<!--
+		Creates the text-mode row select all/none and the expand all/none controls if required. Called from the 
+		transform for ui:table.
+	-->
+	<xsl:template name="topControls">
+		<xsl:variable name="id" select="@id"/>
+		<xsl:variable name="hasExpandAll">
+			<xsl:choose>
+				<xsl:when test="ui:rowExpansion/@expandAll=$t and .//ui:subTr[ancestor::ui:table[1]/@id=$id]">
+					<xsl:number value="1"/>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:number value="0"/>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+		<!--<xsl:variable name="hasPagination">
+			<xsl:choose>
+				<xsl:when test="ui:pagination">
+					<xsl:number value="1"/>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:number value="0"/>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>-->
+		<xsl:variable name="hasRowSelection">
+			<xsl:choose>
+				<xsl:when test="ui:rowSelection[@selectAll='text'] and ..//ui:tr[not(@unselectable=$t) and ancestor::ui:table[1]/@id=$id]">
+					<xsl:number value="1"/>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:number value="0"/>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+			
+		<xsl:if test="$hasExpandAll + $hasRowSelection + $hasPagination &gt; 0">
+			<div class="wc_table_top_controls">
+				<xsl:if test="$hasRowSelection = 1">
+					<div class="wc_table_sel_cont">
+						<xsl:apply-templates select="ui:rowSelection"/>
+					</div>
+				</xsl:if>
+				<!--<xsl:if test="$hasPagination = 1">
+					<div class="wc_table_pag_cont">
+						<xsl:apply-templates select="ui:pagination">
+							<xsl:with-param name="idSuffix" select="'top'"/>
+						</xsl:apply-templates>
+					</div>
+				</xsl:if>-->
+				<xsl:if test="$hasExpandAll = 1">
+					<div class="wc_table_exp_cont">
+						<xsl:apply-templates select="ui:rowExpansion"/>
+					</div>
+				</xsl:if>
+			</div>
+		</xsl:if>
+	</xsl:template>
+</xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.pagination.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.pagination.xsl
@@ -9,9 +9,13 @@
 		Pagination controls consist of a labelled SELECT element and four buttons.
 	-->
 	<xsl:template match="ui:pagination">
+		<xsl:param name="idSuffix"/>
 		<xsl:variable name="tableId" select="../@id"/>
 		<xsl:variable name="name">
 			<xsl:value-of select="concat($tableId, '.page')"/>
+		</xsl:variable>
+		<xsl:variable name="id">
+			<xsl:value-of select="concat($name, $idSuffix)"/>
 		</xsl:variable>
 		<xsl:variable name="pages">
 			<xsl:choose>
@@ -27,13 +31,13 @@
 			<xsl:call-template name="paginationDescription"/>
 			<xsl:element name="label">
 				<xsl:attribute name="for">
-					<xsl:value-of select="$name"/>
+					<xsl:value-of select="$id"/>
 				</xsl:attribute>
 				<xsl:value-of select="$$${wc.ui.table.string.pagination.page}"/>
 			</xsl:element>
 			<xsl:element name="select">
 				<xsl:attribute name="id">
-					<xsl:value-of select="$name"/>
+					<xsl:value-of select="$id"/>
 				</xsl:attribute>
 				<xsl:attribute name="class">
 					<xsl:text>wc_table_pag_select</xsl:text>
@@ -84,6 +88,7 @@
 			<!-- rows per page chooser -->
 			<xsl:apply-templates select="ui:rowsSelect">
 				<xsl:with-param name="tableId" select="$tableId"/>
+				<xsl:with-param name="idSuffix" select="$idSuffix"/>
 			</xsl:apply-templates>
 			
 			<!-- buttons to change page -->
@@ -101,7 +106,7 @@
 			<xsl:call-template name="paginationButton">
 				<xsl:with-param name="title" select="$$${wc.ui.table.pagination.message.button.first}"/>
 				<xsl:with-param name="type" select="$buttonType"/>
-				<xsl:with-param name="idSuffix" select="'1'"/>
+				<xsl:with-param name="idSuffix" select="concat($idSuffix,'1')"/>
 				<xsl:with-param name="disabled">
 					<xsl:if test="$pages=1 or @currentPage = 0">
 						<xsl:number value="1"/>
@@ -111,7 +116,7 @@
 			<xsl:call-template name="paginationButton">
 				<xsl:with-param name="title" select="$$${wc.ui.table.pagination.message.button.previous}"/>
 				<xsl:with-param name="type" select="$buttonType"/>
-				<xsl:with-param name="idSuffix" select="'2'"/>
+				<xsl:with-param name="idSuffix" select="concat($idSuffix,'2')"/>
 				<xsl:with-param name="disabled">
 					<xsl:if test="$pages=1 or @currentPage = 0">
 						<xsl:number value="1"/>
@@ -121,7 +126,7 @@
 			<xsl:call-template name="paginationButton">
 				<xsl:with-param name="title" select="$$${wc.ui.table.pagination.message.button.next}"/>
 				<xsl:with-param name="type" select="$buttonType"/>
-				<xsl:with-param name="idSuffix" select="'3'"/>
+				<xsl:with-param name="idSuffix" select="concat($idSuffix,'3')"/>
 				<xsl:with-param name="disabled">
 					<xsl:if test="$pages=1 or @currentPage = $pages -1">
 						<xsl:number value="1"/>
@@ -131,7 +136,7 @@
 			<xsl:call-template name="paginationButton">
 				<xsl:with-param name="title" select="$$${wc.ui.table.pagination.message.button.last}"/>
 				<xsl:with-param name="type" select="$buttonType"/>
-				<xsl:with-param name="idSuffix" select="'4'"/>
+				<xsl:with-param name="idSuffix" select="concat($idSuffix,'4')"/>
 				<xsl:with-param name="disabled">
 					<xsl:if test="$pages=1 or @currentPage = $pages -1">
 						<xsl:number value="1"/>
@@ -152,7 +157,6 @@
 		param disabled: 1 if the button should be disabled based on the current page displayed.
 	-->
 	<xsl:template name="paginationButton">
-		<xsl:param name="name"/>
 		<xsl:param name="title"/>
 		<xsl:param name="type"/>
 		<xsl:param name="idSuffix"/>
@@ -175,11 +179,6 @@
 			<xsl:attribute name="class">
 				<xsl:text>wc_ibtn</xsl:text>
 			</xsl:attribute>
-			<xsl:if test="$name">
-				<xsl:attribute name="name">
-					<xsl:value-of select="$name"/>
-				</xsl:attribute>
-			</xsl:if>
 			<xsl:choose>
 				<xsl:when test = "$disabled = 1">
 					<xsl:attribute name="disabled">
@@ -224,60 +223,5 @@
 				<xsl:with-param name="current" select="$current"/>
 			</xsl:call-template>
 		</xsl:if>
-	</xsl:template>
-	
-	<xsl:template match="ui:rowsSelect">
-		<xsl:param name="tableId"/>
-		<xsl:variable name="rppChooserName">
-			<xsl:value-of select="concat($tableId,'.rows')"/>
-		</xsl:variable>
-		<xsl:element name="label">
-			<xsl:attribute name="for">
-				<xsl:value-of select="$rppChooserName"/>
-			</xsl:attribute>
-			<xsl:value-of select="$$${wc.ui.table.string.pagination.label.chooseRowsPerPage}"/>
-		</xsl:element>
-		<xsl:element name="select">
-			<xsl:attribute name="id">
-				<xsl:value-of select="$rppChooserName"/>
-			</xsl:attribute>
-			<!-- NOTE: do not use name or data-wc-name as we do not want to trigger an unsaved changes warning -->
-			<xsl:attribute name="class">
-				<xsl:text>wc_table_pag_rpp</xsl:text>
-			</xsl:attribute>
-			<xsl:call-template name="tableAjaxController">
-				<xsl:with-param name="tableId" select="$tableId"/>
-			</xsl:call-template>
-			<xsl:call-template name="disabledElement">
-				<xsl:with-param name="field" select="ancestor::ui:table[1]"/>
-				<xsl:with-param name="isControl" select="1"/>
-			</xsl:call-template>
-			<xsl:apply-templates mode="rowsPerPage">
-				<xsl:with-param name="rowsPerPage" select="../@rowsPerPage"/>
-			</xsl:apply-templates>
-		</xsl:element>
-	</xsl:template>
-	
-	<xsl:template match="ui:option" mode="rowsPerPage">
-		<xsl:param name="rowsPerPage"/>
-		<xsl:variable name="value" select="@value"/>
-		<xsl:element name="option">
-			<xsl:attribute name="value">
-				<xsl:value-of select="$value"/>
-			</xsl:attribute>
-			<xsl:if test="$rowsPerPage=$value">
-				<xsl:attribute name="selected">
-					<xsl:text>selected</xsl:text>
-				</xsl:attribute>
-			</xsl:if>
-			<xsl:choose>
-				<xsl:when test="$value='0'">
-					<xsl:value-of select="$$${wc.ui.table.string.pagination.label.chooseAllRowsPerPage}"/>
-				</xsl:when>
-				<xsl:otherwise>
-					<xsl:value-of select="$value"/>
-				</xsl:otherwise>
-			</xsl:choose>
-		</xsl:element>
 	</xsl:template>
 </xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.rowsSelect.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.rowsSelect.xsl
@@ -1,0 +1,61 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
+	<xsl:import href="wc.ui.table.pagination.n.paginationDescription.xsl"/>
+	<xsl:import href="wc.ui.table.n.xsl"/>
+	<xsl:import href="wc.common.disabledElement.xsl"/>
+	
+	<xsl:template match="ui:rowsSelect">
+		<xsl:param name="tableId"/>
+		<xsl:param name="idSuffix"/>
+		<xsl:variable name="rppChooserName">
+			<xsl:value-of select="concat($tableId,'.rows', $idSuffix)"/>
+		</xsl:variable>
+		<xsl:element name="label">
+			<xsl:attribute name="for">
+				<xsl:value-of select="$rppChooserName"/>
+			</xsl:attribute>
+			<xsl:value-of select="$$${wc.ui.table.string.pagination.label.chooseRowsPerPage}"/>
+		</xsl:element>
+		<xsl:element name="select">
+			<xsl:attribute name="id">
+				<xsl:value-of select="$rppChooserName"/>
+			</xsl:attribute>
+			<!-- NOTE: do not use name or data-wc-name as we do not want to trigger an unsaved changes warning -->
+			<xsl:attribute name="class">
+				<xsl:text>wc_table_pag_rpp</xsl:text>
+			</xsl:attribute>
+			<xsl:call-template name="tableAjaxController">
+				<xsl:with-param name="tableId" select="$tableId"/>
+			</xsl:call-template>
+			<xsl:call-template name="disabledElement">
+				<xsl:with-param name="field" select="ancestor::ui:table[1]"/>
+				<xsl:with-param name="isControl" select="1"/>
+			</xsl:call-template>
+			<xsl:apply-templates mode="rowsPerPage">
+				<xsl:with-param name="rowsPerPage" select="../@rowsPerPage"/>
+			</xsl:apply-templates>
+		</xsl:element>
+	</xsl:template>
+	
+	<xsl:template match="ui:option" mode="rowsPerPage">
+		<xsl:param name="rowsPerPage"/>
+		<xsl:variable name="value" select="@value"/>
+		<xsl:element name="option">
+			<xsl:attribute name="value">
+				<xsl:value-of select="$value"/>
+			</xsl:attribute>
+			<xsl:if test="$rowsPerPage=$value">
+				<xsl:attribute name="selected">
+					<xsl:text>selected</xsl:text>
+				</xsl:attribute>
+			</xsl:if>
+			<xsl:choose>
+				<xsl:when test="$value='0'">
+					<xsl:value-of select="$$${wc.ui.table.string.pagination.label.chooseAllRowsPerPage}"/>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:value-of select="$value"/>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:element>
+	</xsl:template>
+</xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.thead.th.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.thead.th.xsl
@@ -21,7 +21,6 @@
 			</xsl:attribute>
 			
 			<xsl:if test="@sortable=$t">
-				
 				<xsl:variable name="sortControl" select="../../ui:sort"/>
 				
 				<xsl:if test="$sortControl">

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.thead.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.thead.xsl
@@ -1,89 +1,15 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
-	<xsl:import href="wc.ui.table.n.offscreenSpan.xsl"/>
-	<xsl:import href="wc.constants.xsl"/>
+	<xsl:import href="wc.common.offscreenSpan.xsl"/>
 
 	<!--
-		Template for ui:thead tests whether the table requires selection and expansion 
-		controls and if so applies these in a row. Then outputs the column headers in a
-		separate row.
-		
-		parameters
-		addCols: see comments in transform of ui:table in wc.ui.table.xsl
-		
-		The thead element is not hidden for a11y reasons. If the hidden attribute is "true"
-		then only the row containing the column headers is hidden. In this instance hidden
-		means rendered off screen.
+		Template for ui:thead. Simple generation of the HTML thead element. If the table needs row selection or expansion
+		columns these are added then the ui:th elements are applied.
 	-->
 	<xsl:template match="ui:thead">
-		<xsl:param name="addCols" select="0"/>
-		<xsl:param name="disabled" select="0"/>
-		<xsl:variable name="tableId" select="../@id"/>
-		<xsl:variable name="hasRowSelection">
-			<xsl:choose>
-				<xsl:when test="../ui:rowSelection[@selectAll='text'] and ..//ui:tr[not(@unselectable=$t)]">
-					<xsl:value-of select="1"/>
-				</xsl:when>
-				<xsl:otherwise>
-					<xsl:value-of select="0"/>
-				</xsl:otherwise>
-			</xsl:choose>
-		</xsl:variable>
-		<xsl:variable name="hasExpandAll">
-			<xsl:choose>
-				<xsl:when test="../ui:rowExpansion/@expandAll=$t and ..//ui:subTr[ancestor::ui:table[1]/@id=$tableId]">
-					<xsl:value-of select="1"/>
-				</xsl:when>
-				<xsl:otherwise>
-					<xsl:value-of select="0"/>
-				</xsl:otherwise>
-			</xsl:choose>
-		</xsl:variable>
-		<xsl:variable name="hasHeaderElements">
-			<xsl:value-of select="$hasRowSelection + $hasExpandAll"/>
-		</xsl:variable>
-		<xsl:element name="thead">
-			<xsl:if test="$hasHeaderElements &gt; 0">
-				<xsl:variable name="numCols">
-					<xsl:value-of select="count(ui:th)"/>
-				</xsl:variable>
-				<xsl:variable name="colSpan1">
-					<xsl:value-of select="$addCols +  floor($numCols div $hasHeaderElements)"/>
-				</xsl:variable>
-				<xsl:element name="tr">
-					<xsl:attribute name="class">
-						<xsl:text>wc_table_func</xsl:text>
-					</xsl:attribute>
-					<xsl:if test="$hasRowSelection = 1">
-						<xsl:element name="td">
-							<xsl:attribute name="colspan">
-								<xsl:value-of select="$colSpan1"/>
-							</xsl:attribute>
-							<xsl:apply-templates select="../ui:rowSelection"/>
-						</xsl:element>
-					</xsl:if>
-					<xsl:if test="$hasExpandAll = 1">
-						<xsl:element name="td">
-							<xsl:attribute name="colspan">
-								<xsl:choose>
-									<xsl:when test="$hasRowSelection = 1">
-										<xsl:value-of select="$numCols + $addCols - $colSpan1"/>
-									</xsl:when>
-									<xsl:otherwise>
-										<xsl:value-of select="$colSpan1"/>
-									</xsl:otherwise>
-								</xsl:choose>
-							</xsl:attribute>
-							<xsl:apply-templates select="../ui:rowExpansion"/>
-						</xsl:element>
-					</xsl:if>
-				</xsl:element>
-			</xsl:if>
-			<xsl:element name="tr">
+		<thead>
+			<tr>
 				<xsl:if test="../ui:rowSelection">
-					<xsl:element name="th">
-						<xsl:attribute name="class">
-							<xsl:text>wc_table_sel_wrapper</xsl:text>
-						</xsl:attribute>
+					<th class="wc_table_sel_wrapper" scope="col">
 						<xsl:choose>
 							<xsl:when test="../ui:rowSelection/@selectAll = 'control'">
 								<xsl:apply-templates select="../ui:rowSelection"/>
@@ -103,20 +29,17 @@
 								</xsl:call-template>
 							</xsl:otherwise>
 						</xsl:choose>
-					</xsl:element>
+					</th>
 				</xsl:if>
 				<xsl:if test="../ui:rowExpansion">
-					<xsl:element name="th">
-						<xsl:attribute name="class">
-							<xsl:text>wc_table_rowexp_container</xsl:text>
-						</xsl:attribute>
+					<th class="wc_table_rowexp_container" scope="col">
 						<xsl:call-template name="offscreenSpan">
 							<xsl:with-param name="text" select="$$${wc.ui.table.string.expandCollapse}"/>
 						</xsl:call-template>
-					</xsl:element>
+					</th>
 				</xsl:if>
 				<xsl:apply-templates select="ui:th" mode="thead"/>
-			</xsl:element>
-		</xsl:element>
+			</tr>
+		</thead>
 	</xsl:template>
 </xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.xsl
@@ -6,6 +6,7 @@
 	<xsl:import href="wc.common.hField.xsl"/>
 	<xsl:import href="wc.common.hide.xsl"/>
 	<xsl:import href="wc.ui.table.n.xsl"/>
+	<xsl:import href="wc.ui.table.n.caption.xsl"/>
 	<!--
 		WTable (and WDataTable)
 
@@ -18,11 +19,7 @@
 
 		The HTML TABLE element is actually wrapped in a DIV. This is to provide
 		somewhere to attach messages as a WTable can be in an error state (yes, really).
-
-
-		This is the base transform for WTable. The component root HTML element is a DIV.
-		This allows us to add error messaging to the component.
-
+		
 		Common XSLT parameters
 
 		Individual element transforms may require to reference the ancestor table. To
@@ -179,11 +176,29 @@
 				<xsl:if test="ui:sort">
 					<xsl:attribute name="sortable">sortable</xsl:attribute>
 				</xsl:if>
-				<xsl:if test="@caption">
-					<xsl:element name="caption">
-						<xsl:value-of select="@caption"/>
-					</xsl:element>
-				</xsl:if>
+				
+				<xsl:call-template name="caption">
+					<xsl:with-param name="hasExpandAll">
+						<xsl:choose>
+							<xsl:when test="ui:rowExpansion/@expandAll=$t and .//ui:subTr[ancestor::ui:table[1]/@id=$id]">
+								<xsl:value-of select="1"/>
+							</xsl:when>
+							<xsl:otherwise>
+								<xsl:value-of select="0"/>
+							</xsl:otherwise>
+						</xsl:choose>
+					</xsl:with-param>
+					<xsl:with-param name="hasRowSelection">
+						<xsl:choose>
+							<xsl:when test="ui:rowSelection[@selectAll='text'] and ..//ui:tr[not(@unselectable=$t) and ancestor::ui:table[1]/@id=$id]">
+								<xsl:value-of select="1"/>
+							</xsl:when>
+							<xsl:otherwise>
+								<xsl:value-of select="0"/>
+							</xsl:otherwise>
+						</xsl:choose>
+					</xsl:with-param>
+				</xsl:call-template>
 
 				<xsl:element name="colgroup">
 					<xsl:if test="@separators='both' or @separators='vertical'">
@@ -241,10 +256,7 @@
 					</xsl:choose>
 				</xsl:element>
 
-				<xsl:apply-templates select="ui:thead">
-					<xsl:with-param name="addCols" select="$staticCols"/>
-					<xsl:with-param name="disabled" select="$disabled"/>
-				</xsl:apply-templates>
+				<xsl:apply-templates select="ui:thead"/>
 
 				<xsl:apply-templates select="ui:tbody">
 					<xsl:with-param name="addCols" select="$staticCols"/>


### PR DESCRIPTION
The a11y tools were reporting a (possibly false negative) error involving lack of table column headers when tables had text select all/none controls &/or expand all.

The issue was that when a table had `@selectAll=‘text’` or `@expandAll=‘true’` then the thead would contain a tr consisting of one or two td elements with appropriate colspans before a tr containing the appropriately scoped th elements.

The a11y testing tool reported that the table did not have appropriate column headings. It did, they just were not in the first row of the thead and this _should_ be OK.

To remove the report/‘fix’ the ‘issue’ I have moved the text mode select all/none controls and expand all/none controls into the table’s wrapper div. This is OK because the controls are scoped to the table using aria-controls.

Whilst I was here I added the ability to put the table pagination controls into the same region above the table (frequent feature request) by allowing an id suffix to be passed into the templates which generate the form bound artefacts.  This included splitting the template match on `ui:rowsSelect` and its option children out of the file containing the templates for `ui:pagination` and into their own file. This is merely for ease of maintenance and override as it puts the element into the same footing as other defined elements.

Finally, in table.xsl, I cleaned up some unused XSLT variables and repositioned the calculation of others closer to where they were used.