### PR TITLE
Elements loaded by AJAX do not collapse to 0px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+## Enhancements
+* Improved AJAX updates so "busy" regions maintain their dimensions and do not collapse to 0px.
+
+# Release 1.0.2
 ## API Changes
 * Updated WAbbrText, WAbbrTextRenderer and associated tests (#157)
     * Removed WAbbrText.AbbrTextModel This custom component model is completely superfluous. The refactoring of WAbbrText brings the component into line with other WComponents and standardises API calls. **NOTE** If you have extended this model (well stop it you will go blind) you will now have to implement your own component model.

--- a/wcomponents-theme/src/main/sass/wc.ui.loading.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.loading.scss
@@ -48,7 +48,7 @@
 	background-position: 50% 50%;
 	background-repeat: no-repeat;
 	background-size: $line-size $line-size !important;
-	border-color: transparent !important;
+	// border-color: transparent !important; busy stuff should keep borders - we should ensure they keep the same dimensions too so it doesn't look stupid
 	color: $wc-ui-color-disabled-fg;
 
 	// Make any interactive child element of a busy region invisible. We want them to take up their space but not be

--- a/wcomponents-theme/src/main/sass/wc.ui.tabset.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.tabset.scss
@@ -116,11 +116,9 @@
 
 .tabset > [role='presentation'] {
 	@include border;
-	border-top: 0 none;
 }
 
 [role='tabpanel'] {
-	@include border($pos: top);
 	padding: $hgap-normal;
 
 	&[aria-busy='true'] {


### PR DESCRIPTION
Previously most AJAX updates caused the targeted region to jump around various sizes - at the least down to 16px whilst busy, then zero pixels when busy was removed then the new size based on its content - that's at least three size jumps per AJAX update.

Ideally there should be no size jumps, especially if the new content is the same size as the old content. At most there should be only one.

This update goes a long way towards this goal.
