### PR TITLE
Tests js

### DIFF
--- a/wcomponents-theme/src/test/intern/wc.dom.getBox.test.js
+++ b/wcomponents-theme/src/test/intern/wc.dom.getBox.test.js
@@ -2,16 +2,21 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils"], functi
 	"use strict";
 	var controller, testHolder, TOP = 150,
 		LEFT = 100,
+		SCROLL = 60, // simpler to keep it less than LEFT
+		MARGIN = 60, // doesn't really matter how much
 		TEST_ID = "testgetBoxElement";
 
 
-	function doSimpleTest(expected, dimension, noReset) {
+	function doSimpleTest(expected, dimension, scroll) {
 		var element = document.getElementById(TEST_ID);
-		if (!noReset) {
-			document.body.scrollTop = 0;  // browsers
-			document.documentElement.scrollTop = 0;  // IE
-			document.body.scrollLeft = 0;  // browsers
-			document.documentElement.scrollLeft = 0;  // IE
+
+		document.body.scrollTop = 0;  // browsers
+		document.documentElement.scrollTop = 0;  // IE
+		document.body.scrollLeft = 0;  // browsers
+		document.documentElement.scrollLeft = 0;  // IE
+		if (scroll) {
+			document.body[scroll] = SCROLL;  // browsers
+			document.documentElement[scroll] = SCROLL;  // IE
 		}
 		assert.strictEqual(controller(element)[dimension], expected);
 	}
@@ -38,32 +43,22 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils"], functi
 			doSimpleTest(TOP, "top");
 		},
 		testGetBoxTopWithMarginTop: function() {
-			var MARGIN = 60,
-				element = document.getElementById(TEST_ID);
+			var  element = document.getElementById(TEST_ID);
 			element.style.marginTop = MARGIN + "px";
 			doSimpleTest(TOP + MARGIN, "top");
 		},
 		testGetBoxTopWithMarginLeft: function() {
-			var MARGIN = 60,
-				element = document.getElementById(TEST_ID);
+			var element = document.getElementById(TEST_ID);
 			element.style.marginLeft = MARGIN + "px";
 			doSimpleTest(LEFT + MARGIN, "left");
 		},
 		testGetBoxTopWithVerticalScroll: function() {
-			var SCROLL = 60;
 			testHolder.insertAdjacentHTML("beforeEnd", "<div style='height:10000px;'>spacer</div>");
-
-			document.body.scrollTop = SCROLL;  // broswers
-			document.documentElement.scrollTop = SCROLL;  // IE
-			doSimpleTest(TOP - SCROLL, "top", true);
+			doSimpleTest(TOP - SCROLL, "top", "scrollTop");
 		},
-		testGetBoxTopWithHorizontalScroll: function() {
-			var SCROLL = 60;
+		testGetBoxLeftWithHorizontalScroll: function() {
 			testHolder.insertAdjacentHTML("beforeEnd", "<div style='height:20px;width:10000px;'>spacer</div>");
-
-			document.body.scrollLeft = SCROLL;  // broswers
-			document.documentElement.scrollLeft = SCROLL;  // IE
-			doSimpleTest(LEFT - SCROLL, "left", true);
+			doSimpleTest(LEFT - SCROLL, "left", "scrollLeft");
 		}
 	});
 });


### PR DESCRIPTION
The getBox and viewportCollision unit tests both had subtle race
conditions caused by Intern’s logger. These tweaks are designed to make
it _almost_ impossible for the test to lose the race with the logger
except on very old Android browser (cannot get it to win).