### PR TITLE
Debug CSS

### DIFF
--- a/wcomponents-theme/build-css.xml
+++ b/wcomponents-theme/build-css.xml
@@ -168,7 +168,7 @@
 	<!--
 		Build browser and platform dependent CSS.
 	-->
-	<target name="buildBrowserCss"><!-- depends="buildDebugCss" -->
+	<target name="buildBrowserCss" depends="buildDebugCss">
 		<gatherIeVersionInfo sourceDir="${style.tmp.src.dir}" sourceFileExt=".css" nameOfLowestVersionPropToSet="ie.support.lowest.css.version" />
 		<for list="${ie.version.list}" param="version">
 			<sequential>
@@ -185,9 +185,9 @@
 		<!-- <buildCSSSets pattern="print" targetFile="${css.target.file.name.print}"/>-->
 	</target>
 
-<!--	<target name="buildDebugCss">
+	<target name="buildDebugCss">
 		<buildCSSSets pattern="${common.debugFiles.name.pattern}" targetFile="${css.target.file.name.debug}" />
-	</target>-->
+	</target>
 
 	<!--
 		Trawl the copied (and transpiled) source and find files with pattern_X in their names. Make a list of all

--- a/wcomponents-theme/src/main/js/wc/debug/a11y.js
+++ b/wcomponents-theme/src/main/js/wc/debug/a11y.js
@@ -84,7 +84,8 @@ define(["wc/ui/loading", "wc/dom/storage"], function(loading, storage) {
 	 *    debug is enabled.
 	 */
 	function formatIssue(issue) {
-		var container = document.createElement("div"),
+		var container = document.createElement("section"),
+			heading = document.createElement("h1"),
 			list = document.createElement("ul"),
 			link = document.createElement("a");
 		link.href = issue.url;
@@ -110,7 +111,8 @@ define(["wc/ui/loading", "wc/dom/storage"], function(loading, storage) {
 		else {
 			container.classList.add("warning");
 		}
-		container.appendChild(link);
+		container.appendChild(heading);
+		heading.appendChild(link);
 		container.appendChild(list);
 		document.body.appendChild(container);
 	}

--- a/wcomponents-theme/src/main/js/wc/debug/a11y.js
+++ b/wcomponents-theme/src/main/js/wc/debug/a11y.js
@@ -84,8 +84,7 @@ define(["wc/ui/loading", "wc/dom/storage"], function(loading, storage) {
 	 *    debug is enabled.
 	 */
 	function formatIssue(issue) {
-		var container = document.createElement("section"),
-			heading = document.createElement("h1"),
+		var container = document.createElement("div"),
 			list = document.createElement("ul"),
 			link = document.createElement("a");
 		link.href = issue.url;
@@ -111,8 +110,7 @@ define(["wc/ui/loading", "wc/dom/storage"], function(loading, storage) {
 		else {
 			container.classList.add("warning");
 		}
-		container.appendChild(heading);
-		heading.appendChild(link);
+		container.appendChild(link);
 		container.appendChild(list);
 		document.body.appendChild(container);
 	}

--- a/wcomponents-theme/src/main/properties/wc.common.properties
+++ b/wcomponents-theme/src/main/properties/wc.common.properties
@@ -1,7 +1,6 @@
 wc.global.config=wcconfig
 wc.amd.has=lib/dojo/has
 wc_css_main_id=wc_css_screen
-wc_css_link_id_prefix=wc_css_
 #SHED magic word
 wc.common.helper.anySelectedState=any
 #standard alignment (should be inherited!!)

--- a/wcomponents-theme/src/main/sass/wc.debug.axs.scss
+++ b/wcomponents-theme/src/main/sass/wc.debug.axs.scss
@@ -1,0 +1,49 @@
+/* wc.debug.axs.scss */
+// CSS for the AXE/AXS output in debug mode
+
+@import 'mixins_common.scss';
+
+.wc_a11y {
+	@include border;
+	margin: $hgap-large;
+
+	> h1 {
+		font-size: 1em;
+		font-weight: normal;
+		margin: 0 $hgap-small;
+	}
+
+	&.warning { // I have never seen a warning level issue in WComponents which has NOT been a false negative.
+		border-color: $wc-ui-color-warning-fg;
+		// max-height: 5em;
+		// overflow: auto;
+
+		&:before {
+			background-color: $wc-ui-color-warning-fg;
+			content: 'A11Y: WARNING';
+		}
+	}
+
+	&.severe {
+		border-color: $wc-ui-color-error-fg;
+
+		&:before {
+			background-color: $wc-ui-color-error-fg;
+			content: 'A11Y: SEVERE';
+		}
+	}
+
+	&.warning,
+	&.severe {
+		&:before {
+			@include border-box;
+			color: $std-color-white;
+			display: block;
+			font-weight: bold;
+			margin-bottom: $hgap-normal;
+			padding: $hgap-small;
+			text-align: center;
+			width: 100%;
+		}
+	}
+}

--- a/wcomponents-theme/src/main/sass/wc.debug.axs.scss
+++ b/wcomponents-theme/src/main/sass/wc.debug.axs.scss
@@ -7,9 +7,7 @@
 	@include border;
 	margin: $hgap-large;
 
-	> h1 {
-		font-size: 1em;
-		font-weight: normal;
+	> a {
 		margin: 0 $hgap-small;
 	}
 

--- a/wcomponents-theme/src/main/sass/wc.debug.common.scss
+++ b/wcomponents-theme/src/main/sass/wc.debug.common.scss
@@ -1,0 +1,27 @@
+/* wc.debug.common.scss */
+// CSS for common debug mode diagnostics
+// NOTE FOR MARK
+// YES, that means **YOU** Mark
+// Next time you decide to delete all of the debug Sass and stop building it:
+// ### **DON'T** ###
+// Really, just don't otherwise you will have to put some of it back again and that is a PITA.
+@import 'mixins_common.scss';
+
+// next used only in debug mode
+$wc-ui-color-debug-fg: $std-color-primary;
+
+// body element required to differentiate from other elements in a debug state or type
+// scss-lint:disable QualifyingElement
+body.wc_debug:before {
+	background-color: $wc-ui-color-highlight-bg;
+	color: $wc-ui-color-highlight-fg;
+	content: 'Client debug/diagnostic mode is on.';
+	display: block;
+	padding: 0.5em;
+}
+
+// The attribute inclusion here doesn't work in IE8 so there is no point including it in the :before
+body.wc_debug::before {
+	content: 'Client debug/diagnostic mode: document has ' attr(data-wc-nodeCount) ' elements.';
+}
+// scss-lint:enable QualifyingElement

--- a/wcomponents-theme/src/main/sass/wc.debug.logger.scss
+++ b/wcomponents-theme/src/main/sass/wc.debug.logger.scss
@@ -1,4 +1,4 @@
-/* wc.ui.logger.scss */
+/* wc.debug.logger.scss */
 
 // These colors have been inverted to create a DRAMATIC change when there
 // is a warning or an error. This is necessary since colorblind users may not
@@ -16,4 +16,3 @@ body {
 		background-color: $wc-ui-color-error-fg;
 	}
 }
-/* end wc.ui.logger.scss */

--- a/wcomponents-theme/src/main/xslt/wc.ui.root.n.wcBodyClass.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.root.n.wcBodyClass.xsl
@@ -5,7 +5,7 @@
 	-->
 	<xsl:template name="wcBodyClass">
 		<xsl:if test="$isDebug=1">
-			<xsl:text>debug</xsl:text>
+			<xsl:text>wc_debug</xsl:text>
 		</xsl:if>
 	</xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
* Re-instated a tiny subset of the debug mode Sass and the CSS build
target. It is required for the body element debug flag.
* Updated wc/loader/style.js to load the debug CSS if in debug mode.
* Added some debug mode Sass for the AXS/AXE output.
* Added a public function to wc/loader/style to allow any other module
to load CSS from a URL (or name). Tested with the debug CSS. This is
another step towards #172.
* Renamed wc.ui.logger.scss to wc.debug.logger.scss since it is only
required when wc/debug/consoleColor.js is available.