### PR TITLE
A11y output and improvements

### DIFF
--- a/wcomponents-theme/src/main/js/wc/debug/a11y.js
+++ b/wcomponents-theme/src/main/js/wc/debug/a11y.js
@@ -104,7 +104,7 @@ define(["wc/ui/loading", "wc/dom/storage"], function(loading, storage) {
 			}
 			// html = html.replace(/</g, "&lt;");
 			// html = html.replace(/>/g, "&gt;");
-			html = html.match(/\<([^>]+)>/)[1]; // just get the content of the element's opening tag
+			html = html.match(/<([^>]+)>/)[1]; // just get the content of the element's opening tag
 			listItem.innerHTML = html;
 			list.appendChild(listItem);
 		});

--- a/wcomponents-theme/src/main/js/wc/debug/a11y.js
+++ b/wcomponents-theme/src/main/js/wc/debug/a11y.js
@@ -59,6 +59,8 @@ define(["wc/ui/loading", "wc/dom/storage"], function(loading, storage) {
 			 * Skip "focusableElementNotVisibleAndNotAriaHidden" because it sets focus and that could be annoying.
 			 */
 			auditConfig.auditRulesToIgnore = ["focusableElementNotVisibleAndNotAriaHidden"];
+			auditConfig.ignoreSelectors('elementsWithMeaningfulBackgroundImage', '[title]'); // this is an error in the testing tool
+
 			issues = axs.Audit.run(auditConfig);
 			issues.forEach(function(issue) {
 				var obj, isFail = issue.result === axs.constants.AuditResult.FAIL;
@@ -66,6 +68,7 @@ define(["wc/ui/loading", "wc/dom/storage"], function(loading, storage) {
 					obj = {
 						isWarning: issue.rule.severity === axs.constants.Severity.WARNING,
 						url: issue.rule.url,
+						name: issue.rule.name,
 						description: issue.rule.heading,
 						nodes: issue.elements
 					};
@@ -89,7 +92,8 @@ define(["wc/ui/loading", "wc/dom/storage"], function(loading, storage) {
 			link = document.createElement("a");
 		link.href = issue.url;
 		link.target = "_blank";
-		link.innerHTML = issue.description;
+		link.innerHTML = issue.description + (issue.name ? " (" + issue.name + ")" : "");
+
 		issue.nodes.forEach(function(element) {
 			var html, listItem = document.createElement("li");
 			if (element.html) {
@@ -98,8 +102,9 @@ define(["wc/ui/loading", "wc/dom/storage"], function(loading, storage) {
 			else {
 				html = element.outerHTML;
 			}
-			html = html.replace(/</g, "&lt;");
-			html = html.replace(/>/g, "&gt;");
+			// html = html.replace(/</g, "&lt;");
+			// html = html.replace(/>/g, "&gt;");
+			html = html.match(/\<([^>]+)>/)[1]; // just get the content of the element's opening tag
 			listItem.innerHTML = html;
 			list.appendChild(listItem);
 		});

--- a/wcomponents-theme/src/main/sass/wc.ui.table.sort.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.sort.scss
@@ -1,27 +1,18 @@
 /* wc.ui.table.sort.scss */
-
-// Column sorting relate to the sorting of data in sortable tables.
-// This css covers control elements in the heading cells and the rendering of
-// sorted columns.
-
-// TODO: the direction of sort is an attribute of the th element now so it should be used instead of the aria-pressed
-// state of the control.
 @import 'mixins_common.scss';
 
-table[sortable] {
-	th {
-		&[aria-sort] {
-			@include background-image ('../images/down-d.png', $x: 100%);
-			background-position-x: calc(100% - 0.25em);
-			cursor: pointer;
-		}
+th {
+	&[aria-sort] {
+		@include background-image ('../images/down-d.png', $x: 100%);
+		background-position-x: calc(100% - 0.25em);
+		cursor: pointer;
+	}
 
-		&[sorted] {
-			background-image: url('../images/down.png');
-		}
+	&[sorted] {
+		background-image: url('../images/down.png');
+	}
 
-		&[sorted~='reversed'] {
-			background-image: url('../images/up.png');
-		}
+	&[sorted~='reversed'] {
+		background-image: url('../images/up.png');
 	}
 }

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.subTr.content.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.subTr.content.xsl
@@ -23,9 +23,6 @@
 			<xsl:if test="$parentIsClosed=1 or ancestor::ui:subTr[not(@open) or @open='false']">
 				<xsl:call-template name="hiddenElement"/>
 			</xsl:if>
-			<xsl:attribute name="aria-level">
-				<xsl:value-of select="count(ancestor::ui:subTr[ancestor::ui:table/@id=$tableId]) + 1"/>
-			</xsl:attribute>
 			<xsl:variable name="class">
 				<xsl:if test="$topRowIsStriped=1">
 					<xsl:text>wc_table_stripe </xsl:text>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.subTr.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.subTr.xsl
@@ -40,9 +40,6 @@
 					<xsl:attribute name="id">
 						<xsl:value-of select="concat($tableId,'${wc.ui.table.id.subTr.suffix}',../@rowIndex)"/>
 					</xsl:attribute>
-					<xsl:attribute name="aria-level">
-						<xsl:value-of select="count(ancestor::ui:subTr[ancestor::ui:table[1]/@id=$tableId]) + 2"/>
-					</xsl:attribute>
 					<xsl:call-template name="hiddenElement"/>
 				</xsl:element>
 			</xsl:otherwise>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.thead.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.thead.xsl
@@ -9,7 +9,7 @@
 		<thead>
 			<tr>
 				<xsl:if test="../ui:rowSelection">
-					<th class="wc_table_sel_wrapper" scope="col">
+					<th class="wc_table_sel_wrapper" scope="col" aria-hidden="true">
 						<xsl:choose>
 							<xsl:when test="../ui:rowSelection/@selectAll = 'control'">
 								<xsl:apply-templates select="../ui:rowSelection"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.tr.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.tr.xsl
@@ -187,56 +187,55 @@
 				 These attributes are used in place of name and value attributes to report the
 				 selected state of the row back to the server.
 			-->
-			<xsl:choose>
-				<xsl:when test="$selectableRow=1 and not(@unselectable=$t)">
-					<xsl:attribute name="role">
-						<xsl:choose>
-							<xsl:when test="$selectableRow=1 and $myTable/ui:rowSelection/@multiple=$t">
-								<xsl:text>checkbox</xsl:text>
-							</xsl:when>
-							<xsl:otherwise>
-								<xsl:text>radio</xsl:text>
-							</xsl:otherwise>
-						</xsl:choose>
-					</xsl:attribute>
-					<xsl:attribute name="aria-checked">
-						<xsl:choose>
-							<xsl:when test="@selected=$t">
-								<xsl:copy-of select="$t"/>
-							</xsl:when>
-							<xsl:otherwise>
-								<xsl:text>false</xsl:text>
-							</xsl:otherwise>
-						</xsl:choose>
-					</xsl:attribute>
-					<xsl:attribute name="tabindex">
-						<xsl:text>0</xsl:text>
-					</xsl:attribute>
-
-					<xsl:attribute name="data-wc-name">
-						<xsl:value-of select="concat($tableId,'${wc.ui.table.rowSelect.state.suffix}')"/>
-					</xsl:attribute>
-					<xsl:attribute name="data-wc-value">
-						<xsl:value-of select="@rowIndex"/>
-					</xsl:attribute>
-					<!-- WDataTable still needs disabled support -->
+			<xsl:if test="$selectableRow=1 and not(@unselectable=$t)">
+				<xsl:attribute name="role">
 					<xsl:choose>
-						<xsl:when test="@disabled">
-							<xsl:call-template name="disabledElement"/>
+						<xsl:when test="$selectableRow=1 and $myTable/ui:rowSelection/@multiple=$t">
+							<xsl:text>checkbox</xsl:text>
 						</xsl:when>
-						<xsl:when test="$myTable and $myTable/@disabled">
-							<xsl:call-template name="disabledElement">
-								<xsl:with-param name="field" select="$myTable"/>
-							</xsl:call-template>
-						</xsl:when>
+						<xsl:otherwise>
+							<xsl:text>radio</xsl:text>
+						</xsl:otherwise>
 					</xsl:choose>
-				</xsl:when>
-				<xsl:when test="ui:subTr or parent::ui:subTr">
-					<xsl:attribute name="aria-level">
-						<xsl:value-of select="count(ancestor::ui:subTr[ancestor::ui:table[1]/@id=$tableId]) + 1"/>
-					</xsl:attribute>
-				</xsl:when>
-			</xsl:choose>
+				</xsl:attribute>
+				<xsl:attribute name="aria-checked">
+					<xsl:choose>
+						<xsl:when test="@selected=$t">
+							<xsl:copy-of select="$t"/>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:text>false</xsl:text>
+						</xsl:otherwise>
+					</xsl:choose>
+				</xsl:attribute>
+				<xsl:attribute name="tabindex">
+					<xsl:text>0</xsl:text>
+				</xsl:attribute>
+
+				<xsl:attribute name="data-wc-name">
+					<xsl:value-of select="concat($tableId,'${wc.ui.table.rowSelect.state.suffix}')"/>
+				</xsl:attribute>
+				<xsl:attribute name="data-wc-value">
+					<xsl:value-of select="@rowIndex"/>
+				</xsl:attribute>
+				<!-- WDataTable still needs disabled support -->
+				<xsl:choose>
+					<xsl:when test="@disabled">
+						<xsl:call-template name="disabledElement"/>
+					</xsl:when>
+					<xsl:when test="$myTable and $myTable/@disabled">
+						<xsl:call-template name="disabledElement">
+							<xsl:with-param name="field" select="$myTable"/>
+						</xsl:call-template>
+					</xsl:when>
+				</xsl:choose>
+			</xsl:if>
+
+			<xsl:if test="ui:subTr or parent::ui:subTr">
+				<xsl:attribute name="aria-level">
+					<xsl:value-of select="count(ancestor::ui:subTr[ancestor::ui:table[1]/@id=$tableId]) + 1"/>
+				</xsl:attribute>
+			</xsl:if>
 
 			<xsl:if test="$removeRow=1">
 				<xsl:call-template name="hiddenElement"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.tr.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.tr.xsl
@@ -271,7 +271,7 @@
 			 the row selection mechanism and state indicators.
 			-->
 			<xsl:if test="$selectableRow=1">
-				<td class="wc_table_sel_wrapper">
+				<td class="wc_table_sel_wrapper" aria-hidden="true">
 				</td>
 			</xsl:if>
 			<!--

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.tr.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.tr.xsl
@@ -231,12 +231,6 @@
 				</xsl:choose>
 			</xsl:if>
 
-			<xsl:if test="ui:subTr or parent::ui:subTr">
-				<xsl:attribute name="aria-level">
-					<xsl:value-of select="count(ancestor::ui:subTr[ancestor::ui:table[1]/@id=$tableId]) + 1"/>
-				</xsl:attribute>
-			</xsl:if>
-
 			<xsl:if test="$removeRow=1">
 				<xsl:call-template name="hiddenElement"/>
 			</xsl:if>


### PR DESCRIPTION
* Updated the output and config of the AXS a11y tester to make the rule
being applied more transparent. This is so I can better discover which
rules are causing false negatives.
* Set ignore on meaningful background images for all elements which
have a title attribute.
* Fixed a potential a11y issue in tables. The row selection indicator
is **ONLY** a secondary indicator for non-AT users therefore I have set
the heading and cell to both be aria-hidden.
* Removed the aria-level attribute from table rows as it is no longer a sensible indicator of nesting in hierarchic tables.