### PR TITLE
ListLayout BAR CSS

### DIFF
--- a/wcomponents-theme/src/main/sass/wc.ui.listLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.listLayout.scss
@@ -14,13 +14,30 @@
 	// separators
 	// NOTE: we do not output the separator as a class when the list is ordered (except NONE) so all of this is safe.
 	&.bar { // bar bullets
-		> li:before {
-			content: '|';
-			margin-right: $hgap-normal;
+		> li {
+			> * {
+				display: inline-block; // otherwise the marker wraps
+				vertical-align: middle;
+				width: calc(100% - #{$hgap-normal} - 0.5em);
+			}
+
+			&:before {
+				content: '|';
+				display: inline-block;
+				margin-right: $hgap-normal;
+				text-align: right;
+				width: 0.5em;
+			}
 		}
 
-		&.flat > li:first-child:before {
-			content: '';
+		&.flat > li {
+			&:before {
+				display: inline;
+			}
+
+			&:first-child:before {
+				content: '';
+			}
 		}
 	}
 

--- a/wcomponents-theme/src/main/xslt/wc.ui.listLayout.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.listLayout.xsl
@@ -34,7 +34,7 @@
 			<xsl:attribute name="class">
 				<xsl:value-of select="normalize-space(concat('listLayout ',@type,' ', @align))"/>
 				<xsl:if test="not(@align)">
-					<xsl:text>${wc.common.align.std}</xsl:text>
+					<xsl:text> ${wc.common.align.std}</xsl:text>
 				</xsl:if>
 				<xsl:choose>
 					<xsl:when test="@ordered=$t and (not(@separator) or @separator='none')">


### PR DESCRIPTION
“Fixed” a CSS issue which caused blocky elements to wrap under the BAR marker when a `ListLayout` or `WList` repeated component was a blocky element. 

I have a strong feeling I am going to revisit this…