### PR TITLE
306 WFilterControl

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WDataTable.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WDataTable.java
@@ -114,6 +114,7 @@ public class WDataTable extends WBeanComponent implements Disableable, Container
 		CLIENT,
 		/**
 		 * Indicates that row expansion occurs on the server (round-trip).
+		 * @deprecated use ExpandMode.DYNAMIC instead.
 		 */
 		SERVER,
 		/**
@@ -138,7 +139,7 @@ public class WDataTable extends WBeanComponent implements Disableable, Container
 		 * Indicates that pagination occurs using a round-trip to the server (no longer implemented). NOTE: no longer
 		 * supported in theme as it causes an a11y failure. Setting this mode will, in effect, set
 		 * PaginationMode.DYNAMIC.
-		 * @deprecated user PaginationMode.DYNAMIC
+		 * @deprecated use PaginationMode.DYNAMIC instead.
 		 */
 		SERVER,
 		/**
@@ -201,6 +202,7 @@ public class WDataTable extends WBeanComponent implements Disableable, Container
 		NONE,
 		/**
 		 * Indicates that sorting occurs using a round-trip to the server.
+		 * @deprecated use SortMode.DYNAMIC instead.
 		 */
 		SERVER,
 		/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WFilterControl.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WFilterControl.java
@@ -6,8 +6,8 @@ package com.github.bordertech.wcomponents;
  *
  * @author Jonathan Austin
  * @since 1.0.0
- * @deprecated WDataTable is deprecated. WFilterControl does not apply to WTable which _must_ be filtered using AJAX if
- *   filtering is required; WDataTable filtering _should_ be done using AJAX.
+ * @deprecated {@link WDataTable} is deprecated, WFilterControl does not apply to {@link WTable} which _must_ be
+ *  filtered using AJAX if filtering is required; {@link WDataTable} filtering _should_ be done using AJAX.
  */
 public class WFilterControl extends AbstractContainer implements AjaxTarget {
 

--- a/wcomponents-theme/src/main/js/wc/ui/filterControl.js
+++ b/wcomponents-theme/src/main/js/wc/ui/filterControl.js
@@ -6,7 +6,16 @@
  * screen will be hidden and pagination isn't dynamically updated to show the requested number of filtered rows
  *
  * NOTE 2: applying or removing a filter from a table will show all rows in the table no matter how they were hidden
- * (filter clearing overrides hidden on rows)
+ * (filter clearing overrides hidden on rows).
+ *
+ * The XSLT to create WFilterControl artefacts and to apply row filters to WDataTable are in place but commented out.
+ * This file will never be included unless you hunt down all of the following in the XSLT and uncomment them:
+ *
+ * * all uses of `ui:filterControl`;
+ * * all uses of `data-wc-filter` and `data-wc-filters`;
+ * * The parts of wc.ui.table.tr.xsl which are commented out with the remark "TODO: remove this when WFilterControl is
+ *   no longer part of the Java API";
+ * * both templates in wc.ui.table.tr.n.containsWords.xsl.
  *
  *
  * @module
@@ -16,7 +25,9 @@
  * @requires module:wc/dom/Widget
  * @requires module:wc/dom/formUpdateManager
  * @requires module:wc/timers
+ *
  * @deprecated No longer supported: to be removed.
+ *
  * @todo Delete me!
  * @ignore
  */
@@ -76,7 +87,7 @@ define(["wc/dom/event", "wc/dom/initialise", "wc/dom/shed", "wc/dom/Widget", "wc
 				var controllerWd, controllers, targetId, value;
 				if (FILTERS.isOneOfMe(element)) {
 					targetId = element.getAttribute("aria-controls");
-					value = element.getAttribute("${wc.ui.filterControl.attribute.filter}");
+					value = element.getAttribute("data-wc-filter");
 					controllerWd = FILTERS.extend("", {"aria-controls": targetId});
 					controllers = controllerWd.findDescendants(document.body);
 
@@ -123,7 +134,7 @@ define(["wc/dom/event", "wc/dom/initialise", "wc/dom/shed", "wc/dom/Widget", "wc
 					for (i = 0; i < rows.length; i++) {
 						changed = false;
 						row = rows[i];
-						rowFilterValues = row.getAttribute("${wc.ui.filterControl.attribute.rowFilter}");
+						rowFilterValues = row.getAttribute("data-wc-filters");
 						if (rowFilterValues) {
 							rowFilterValues = rowFilterValues.split(" ");
 						}

--- a/wcomponents-theme/src/main/properties/wc.ui.filterControl.properties
+++ b/wcomponents-theme/src/main/properties/wc.ui.filterControl.properties
@@ -1,2 +1,0 @@
-wc.ui.filterControl.attribute.filter=data-wc-filter
-wc.ui.filterControl.attribute.rowFilter=data-wc-filters

--- a/wcomponents-theme/src/main/xslt/wc.common.registrationScripts.requiredLibraries.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.registrationScripts.requiredLibraries.xsl
@@ -49,9 +49,15 @@
 			<xsl:if test=".//ui:fileUpload">
 				<xsl:text>"wc/ui/multiFileUploader","wc/ui/fileUpload",</xsl:text>
 			</xsl:if>
+			<!-- 
+				WFilterControl only works on WDataTable and both are in the process of being removed. If you require
+				WFilterControl you will need to uncomment the following piece of XSLT.
+				
+				TODO: this should be deleted when WFilterControl is removed from the Java API.
 			<xsl:if test=".//ui:filterControl">
 				<xsl:text>"wc/ui/filterControl",</xsl:text>
 			</xsl:if>
+			-->
 			<xsl:if test=".//ui:listBox[not(@readOnly)]">
 				<xsl:text>"wc/ui/dropdown",</xsl:text>
 			</xsl:if>

--- a/wcomponents-theme/src/main/xslt/wc.ui.filterControl.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.filterControl.xsl
@@ -11,25 +11,18 @@
 		filtering is to use ajax to filter on the server. WMenu or similar could then
 		be used to filter by actual column content.
 	-->
+	<xsl:template match="ui:filterControl"/>
+	<!-- 
+	
+		If your theme needs to retain support for WDataTable and WFilterControl you will need the following:
+		
 	<xsl:template match="ui:filterControl">
-		<xsl:element name="button">
-			<xsl:attribute name="id">
-				<xsl:value-of select="@id"/>
-			</xsl:attribute>
+		<button id="{@id}" type="button" aria-control="{@for}" data-wc-filter="{@value}">
 			<xsl:attribute name="class">
 				<xsl:text>filterControl wc_btn_link</xsl:text>
 				<xsl:if test="@class">
 					<xsl:value-of select="concat(' ', @class)"/>
 				</xsl:if>
-			</xsl:attribute>
-			<xsl:attribute name="type">
-				<xsl:text>button</xsl:text>
-			</xsl:attribute>
-			<xsl:attribute name="aria-controls">
-				<xsl:value-of select="@for"/>
-			</xsl:attribute>
-			<xsl:attribute name="${wc.ui.filterControl.attribute.filter}">
-				<xsl:value-of select="@value"/>
 			</xsl:attribute>
 			<xsl:attribute name="aria-pressed">
 				<xsl:choose>
@@ -39,6 +32,7 @@
 			</xsl:attribute>
 			<xsl:call-template name="hideElementIfHiddenSet"/>
 			<xsl:apply-templates select="ui:decoratedLabel"/>
-		</xsl:element>
+		</button>
 	</xsl:template>
+	-->
 </xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.tr.n.clientRowClosedHelper.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.tr.n.clientRowClosedHelper.xsl
@@ -1,0 +1,26 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
+	<xsl:template name="clientRowClosedHelper">
+		<xsl:param name="myTable"/>
+		<xsl:variable name="clientPaginationRows">
+			<xsl:choose>
+				<xsl:when test="$myTable/ui:pagination/@rowsPerPage">
+					<xsl:value-of select="$myTable/ui:pagination/@rowsPerPage"/>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:value-of select="$myTable/ui:pagination/@rows"/>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+		<xsl:variable name="tableCurrentPage" select="$myTable/ui:pagination/@currentPage"/>
+		<xsl:variable name="myPosition" select="count(preceding-sibling::ui:tr) + 1"/>
+		<xsl:variable name="activeStart" select="($clientPaginationRows * $tableCurrentPage) + 1"/>
+		<xsl:choose>
+			<xsl:when test="(($myPosition &lt; $activeStart) or ($myPosition >= ($activeStart + $clientPaginationRows)))">
+				<xsl:value-of select="1"/>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="0"/>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+</xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.tr.n.containsWords.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.tr.n.containsWords.xsl
@@ -1,5 +1,8 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
 	<!--
+
+		TODO: remove this when WFilterControl is no longer part of the Java API
+
 		Test if a string contains all words in any order. You may want to normalize-space
 		on the strings before you call this.
 
@@ -7,7 +10,7 @@
 		param testWords: A space separated list of words, these are the words we are
 		looking for in the testString
 		return 1 if testString contains all of the words in testWords, otherwise 0
-	-->
+
 	<xsl:template name="containsWords">
 		<xsl:param name="testString"/>
 		<xsl:param name="testWords"/>
@@ -49,7 +52,8 @@
 		</xsl:choose>
 	</xsl:template>
 
-	<!--
+
+
 		Test if a string contains a word as a word, not a word form or fragment.
 
 		eg testString = "bar foobar"\
@@ -57,10 +61,9 @@
 		testWord = "bar" returns 1\
 		eg2 testString = "not_met" testWord = "met" returns 0
 
-	   param testString: The string to test (usually a class name or filter list)
-	   param testWord: A single word - that is one which contains no spaces
-	   return 1 if testString contains testWord, otherwise 0
-	-->
+		param testString: The string to test (usually a class name or filter list)
+		param testWord: A single word - that is one which contains no spaces
+		return 1 if testString contains testWord, otherwise 0
 	<xsl:template name="containsWord">
 		<xsl:param name="testString"/>
 		<xsl:param name="testWord"/>
@@ -82,4 +85,5 @@
 			</xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>
+	-->
 </xsl:stylesheet>


### PR DESCRIPTION
`WFilterControl` is an orphan component which should _not_ have made it
out into the OS version of WComponents. It is a controller for an
aspect of `WDataTable` and does not have any effect on `WTable`.

`WFilterControl` has been deprecated for many release. WDataTable has
been deprecated for **years** and support is maintained for a _single_
consumer. This last user of `WDataTable` does not use `WFilterControl`.

Not only does `WFilterControl` _only_ work on `WDataTable`; it does not
work well at that. It was built for a specific use case and is not
extensible in its current form. Ajax filtering is far more flexible and
fit for multiple use cases.

WFilterControl will be deleted from the next major release. These
changes remove default client support for WFilterControl as this
support has a measurable performance impact on all tables due to some
rather heavy XSLT variable calculations.

The code to implement `WFilterControl` has been left in but commented
out. The JavaScript module `wc/ui/filterControl` has a header comment
which outlines the changes a custom theme would require to re-instate
support for `WFilterControl`.

Addresses the client aspects of #306.