### PR TITLE
151 image mobile

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/imageEdit.js
+++ b/wcomponents-theme/src/main/js/wc/ui/imageEdit.js
@@ -697,8 +697,15 @@ function(has, event, uid, classList, timers, loader, i18n, fabric, Mustache, dia
 				name = config.name;
 			}
 			name = name || uid();
-			var file = new File([blob], name, filePropertyBag);
-			return file;
+
+
+//			if (typeof File === "function") {
+//				return new File([blob], name, filePropertyBag);
+//			}
+
+			blob.lastModified = new Date();
+			blob.name = name;
+			return blob;
 		}
 
 		/**


### PR DESCRIPTION
Don’t try using File constructor to convert blob to file: just pretend
the blob is a file. This makes editing possible in Safari OS X and all
iOS but still no video stream capture. I am calling #151 anyone who
doesn’t like it can raise a bug.

Fixes #151