### PR TITLE
Easier js css

### DIFF
--- a/wcomponents-theme/src/main/xslt/wc.ui.js.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.js.xsl
@@ -3,6 +3,6 @@
 	<xsl:template match="ui:js"/>
 
 	<xsl:template match="ui:js" mode="inHead">
-		<script type="text/javascript" defer="defer" src="{@url}"></script>
+		<script type="text/javascript" src="{@url}"></script>
 	</xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
The new way of loading the javascript seems to run the script “too late” compared to actually putting it in the head line.

For example, the syntax highlighting in the examples does not work on the first page load, but if it is refreshed with AJAX it works.

Removed the “defer” when loading the js and it works.