### PR TITLE
Restored imageedit filename behavior in a (hopefully) x-browser manner

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/imageEdit.js
+++ b/wcomponents-theme/src/main/js/wc/ui/imageEdit.js
@@ -702,8 +702,11 @@ function(has, event, uid, classList, timers, loader, i18n, fabric, Mustache, dia
 //			if (typeof File === "function") {
 //				return new File([blob], name, filePropertyBag);
 //			}
-
-			blob.lastModified = new Date();
+			if (!blob.type) {
+				blob.type = filePropertyBag.type;
+			}
+			blob.lastModifiedDate = filePropertyBag.lastModified;
+			blob.lastModified = filePropertyBag.lastModified.getTime();
 			blob.name = name;
 			return blob;
 		}

--- a/wcomponents-theme/src/main/js/wc/ui/multiFileUploader.js
+++ b/wcomponents-theme/src/main/js/wc/ui/multiFileUploader.js
@@ -947,7 +947,12 @@ define(["wc/dom/attribute",
 					onAbort = abortHandlerFactory(fileId);
 				formData.append("wc_target", uploadName);
 				formData.append("wc_fileid", fileId);
-				formData.append(uploadName, file);
+				/*
+				 * On the line below we specify the file name because some browsers do not support the File constructor.
+				 * In this case the file object is actually a Blob with the same duck type as a File.
+				 * The name, however, is a readonly property of blob and while we may appear to have overridden the value we probably haven't.
+				 */
+				formData.append(uploadName, file, file.name);
 
 				request = {
 					url: uri,


### PR DESCRIPTION
file name will default to "blob" unless we override it which is non-trivial without the `File` constructor (thanks a lot Safari).