### PR TITLE
240 X-Frame-Options

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/servlet/HttpServletHelper.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/servlet/HttpServletHelper.java
@@ -359,6 +359,10 @@ public class HttpServletHelper extends AbstractContainerHelper {
 			httpServletResponse.setHeader("Pragma", "no-cache");
 			httpServletResponse.setHeader("Expires", "-1");
 		}
+		// This is to prevent clickjacking. It can also be set to "DENY" to prevent embedding in a frames at all or
+		// "ALLOW-FROM uri" to allow embedding in a frame within a particular site.
+		// The default will allow WComponents applications in a frame on the same origin.
+		httpServletResponse.setHeader("X-Frame-Options", "SAMEORIGIN");
 	}
 
 	/**


### PR DESCRIPTION
Updated `com.github.bordertech.wcomponents.servlet.HttpServletHelper.addGenericHeaders(UIContext, WComponent)` so that the default behaviour of a WComponents application is to set X-Frame-options to SAMEORIGIN. Fixes #240.