### PR TITLE
358 WMenu rendering

### DIFF
--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/menu/MenuBarExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/menu/MenuBarExample.java
@@ -67,6 +67,7 @@ public class MenuBarExample extends WContainer {
 
 		// The Colours menu just shows simple text
 		WSubMenu colourMenu = new WSubMenu("Colours");
+		colourMenu.setMode(WSubMenu.MenuMode.LAZY);
 		addMenuItem(colourMenu, "Red", selectedMenuText);
 		addMenuItem(colourMenu, "Green", selectedMenuText);
 		addMenuItem(colourMenu, "Blue", selectedMenuText);
@@ -80,6 +81,7 @@ public class MenuBarExample extends WContainer {
 
 		WMenuItemGroup triangleGroup = new WMenuItemGroup("Triangles");
 		shapeMenu.add(triangleGroup);
+		shapeMenu.setMode(WSubMenu.MenuMode.DYNAMIC);
 		addMenuItem(triangleGroup, "Equilateral", selectedMenuText);
 		addMenuItem(triangleGroup, "Isosceles", selectedMenuText);
 		addMenuItem(triangleGroup, "Scalene", selectedMenuText);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/menu/TreeMenuExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/menu/TreeMenuExample.java
@@ -152,6 +152,7 @@ public class TreeMenuExample extends WPanel {
 		WDecoratedLabel dLabel = new WDecoratedLabel(null, new WText("Settings Menu"), new WImage(
 				"/image/settings.png", "settings"));
 		WSubMenu settings = new WSubMenu(dLabel);
+		settings.setMode(WSubMenu.MenuMode.LAZY);
 		menu.add(settings);
 		settings.add(new WMenuItem(new WDecoratedLabel(null, new WText("Account Settings"),
 				new WImage("/image/user-properties.png", "user properties"))));
@@ -159,6 +160,7 @@ public class TreeMenuExample extends WPanel {
 				new WImage("/image/user.png", "user"))));
 		WSubMenu addressSub = new WSubMenu(new WDecoratedLabel(null, new WText("Address Details"),
 				new WImage("/image/address-book-open.png", "address book")));
+		addressSub.setMode(WSubMenu.MenuMode.LAZY);
 		settings.add(addressSub);
 		addressSub.add(new WMenuItem(new WDecoratedLabel(null, new WText("Home Address"),
 				new WImage("/image/home.png", "home"))));

--- a/wcomponents-theme/src/main/js/wc/ui/menu/bar.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/bar.js
@@ -160,7 +160,7 @@ define(["wc/ui/menu/core", "wc/dom/keyWalker", "wc/dom/shed", "wc/dom/Widget", "
 						item = this._getBranch(item);
 					}
 					if (this._isBranch(item)) {
-						if (shed.isExpanded(item)) {
+						if (shed.isExpanded(this._getBranchExpandableElement(item))) {
 							this._keyMap[VK_UP] = keyWalker.MOVE_TO.LAST_CHILD;  // "lastChildItem";
 							this._keyMap[VK_DOWN] = keyWalker.MOVE_TO.CHILD;
 						}

--- a/wcomponents-theme/src/main/js/wc/ui/menu/column.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/column.js
@@ -51,11 +51,12 @@ define(["wc/ui/menu/core", "wc/dom/keyWalker", "wc/dom/shed", "wc/dom/Widget", "
 			 * @function
 			 * @protected
 			 * @override
-			 * @param {Element} element The menu item which has focus.
+			 * @param {Element} _element The menu item which has focus.
 			 */
-			this._remapKeys = function(element) {
+			this._remapKeys = function(_element) {
+				var element = _element;
 				if (this._isBranchOrOpener(element)) {
-					element = this._getBranch(element);
+					element = this._getBranchExpandableElement(element);
 					if (!shed.isExpanded(element)) {
 						this._keyMap["DOM_VK_RIGHT"] = this._FUNC_MAP.ACTION;
 					}

--- a/wcomponents-theme/src/main/js/wc/ui/menu/core.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/core.js
@@ -115,7 +115,7 @@ define(["wc/has",
 		 * @returns {Object} an object containing properties the values of which are Widgets.
 		 */
 		function setupFixedWidgets() {
-			var branchWidget = new Widget("", "submenu", { "aria-expanded": null }),
+			var branchWidget = new Widget("", "submenu"),
 				branchTriggerWidget = new Widget(BUTTON);
 			branchTriggerWidget.descendFrom(branchWidget, true);
 			return {
@@ -301,8 +301,8 @@ define(["wc/has",
 
 				// skip over closed branches
 				if (ignoreClosed && result !== NodeFilter.FILTER_REJECT && instance._wd.submenu.isOneOfMe(element)) {
-					if ((branch = instance._getBranch(element))) {  // should always be true
-						if (!shed.isExpanded(branch)) {
+					if ((branch = instance._getBranch(element))) { // should always be true
+						if (!shed.isExpanded(instance._getBranchExpandableElement(branch))) {
 							result = NodeFilter.FILTER_REJECT;
 						}
 					}
@@ -450,7 +450,7 @@ define(["wc/has",
 					if (this._isOpener(item)) {
 						item = this._getBranch(item);
 					}
-					if (item && this._isBranch(item) && !shed.isExpanded(item)) {
+					if (item && this._isBranch(item) && !shed.isExpanded(this._getBranchExpandableElement(item))) {
 						this[FUNC_MAP.OPEN](item);
 					}
 				}
@@ -1083,13 +1083,13 @@ define(["wc/has",
 		 * @private
 		 */
 		function enableDisable(element, action, root, isTransient, instance) {
-			var shedFunc;
+			var shedFunc, branch;
 			if (instance._isBranch(element)) {
 				shedFunc = action === shed.actions.DISABLE ? "disable" : "enable";
 				if (isTransient) {
 					// close the submenu
-					if (action === shed.actions.DISABLE && shed.isExpanded(element)) {
-						shed.collapse(element);  // do not call this[FUNC_MAP.CLOSE] because we don't want all the animate gubbins
+					if (action === shed.actions.DISABLE && (branch = instance._getBranchExpandableElement(element)) && shed.isExpanded(branch)) {
+						shed.collapse(branch); // do not call this[FUNC_MAP.CLOSE] because we don't want all the animate gubbins
 					}
 				}
 				// dis/en-able the opener
@@ -1112,10 +1112,19 @@ define(["wc/has",
 		 */
 		function writeState(container, toContainer) {
 			var _widgets,
-				root;
+				root,
+				branchItem;
 
 			function writeExpandedState(nextSubmenu) {
-				var name = nextSubmenu.id;
+				var name;
+
+				if (this._isBranch(nextSubmenu)) { // tree
+					name = nextSubmenu.id;
+				}
+				else if (this._wd.submenu.isOneOfMe(nextSubmenu) && (branchItem = this._getBranch(nextSubmenu))) { // menu
+					name = branchItem.id;
+				}
+
 				if (name) {
 					formUpdateManager.writeStateField(toContainer, name + "${wc.ui.menu.submenu.nameSuffix}", TRUE);
 				}
@@ -1129,11 +1138,22 @@ define(["wc/has",
 			}
 
 			function writeMenuState(next, includeMenu) {
-				Array.prototype.forEach.call(getFilteredGroup(next, {
+				/* Cannot use getFilteredGroup for expandables any more.
+				 * Why not?
+				 * Well:
+				 * 1. roles menu and menubar do not include role menu as a scoped role;
+				 * 2. roles menuitem, menuitemradio and menuitemcheckbox do not support aria-expanded
+				 * 3. therefore we cannot use scoped roles to get the group of expanded menu items.
+				 * Array.prototype.forEach.call(getFilteredGroup(next, {
 					filter: (getFilteredGroup.FILTERS.expanded | getFilteredGroup.FILTERS.enabled),
 					ignoreInnerGroups: true
 				}),
-				writeExpandedState, this);
+				writeExpandedState, this);*/
+
+				(toArray(this.getFixedWidgets().BRANCH.findDescendants(next))).filter(function(nextBranch) {
+					return !shed.isDisabled(nextBranch) && shed.isExpanded(this._getBranchExpandableElement(nextBranch));
+				}, this).forEach(writeExpandedState, this);
+
 				Array.prototype.forEach.call(getFilteredGroup(next, {
 					filter: (getFilteredGroup.FILTERS.selected | getFilteredGroup.FILTERS.enabled),
 					ignoreInnerGroups: true
@@ -1378,6 +1398,37 @@ define(["wc/has",
 		};
 
 		/**
+		 * Get the menu element which is able to be "aria-expanded". This is the WSubMenu's content in most menus but
+		 * is the WSubMenu itself in trees.
+		 *
+		 * @function
+		 * @protected
+		 * @param {Element} item The start point for the search. This will normally be a 'branch'.
+		 * @returns {?Element} The "expandable" element. This is usually the branch content but is the branch in trees.
+		 */
+		AbstractMenu.prototype._getBranchExpandableElement = function (item) {
+			var myBranch;
+
+			if (!item) {
+				throw new TypeError("Item must not be undefined.");
+			}
+
+			if (this._wd.submenu.isOneOfMe(item)) {
+				return item;
+			}
+
+			if (this._isBranch(item)) {
+				return this._getSubMenu (item, true);
+			}
+
+			if (this._isOpener(item) && (myBranch = this._getBranch(item))) {
+				return this._getSubMenu (myBranch, true);
+			}
+
+			throw new TypeError("Item must be a branch, submenu or branch opener element.");
+		};
+
+		/**
 		 * Gets the nearest submenu element relative to a start point in the direction specified.
 		 * @function
 		 * @protected
@@ -1387,12 +1438,15 @@ define(["wc/has",
 		 * @returns {?Element} A submenu element if found.
 		 */
 		AbstractMenu.prototype._getSubMenu = function(item, descending) {
-			var result = null,
-				up = !descending;  // mostly look up not down
+			var up = !descending;  // mostly look up not down
+
 			if (this._getRoot(item)) {
-				result = up ? this._wd.submenu.findAncestor(item) : this._wd.submenu.findDescendant(item);
+				if (this._wd.submenu.isOneOfMe(item)) {
+					return item;
+				}
+				return up ? this._wd.submenu.findAncestor(item) : this._wd.submenu.findDescendant(item);
 			}
-			return result;
+			return null;
 		};
 
 		/**
@@ -1425,7 +1479,7 @@ define(["wc/has",
 		 */
 		AbstractMenu.prototype._actionItem = function(element) {
 			var root = this._getRoot(element),
-				item;
+				item, branchOrContent;
 			if (!root) {
 				return false;
 			}
@@ -1441,7 +1495,9 @@ define(["wc/has",
 				}
 			}
 			if (this._isBranch(item)) {
-				this._animateBranch(item, !shed.isExpanded(item));
+				// trees: the treeitem gets expanded, menus: the menu gets expanded.
+				branchOrContent = this._getBranchExpandableElement(item);
+				this._animateBranch(branchOrContent, !shed.isExpanded(branchOrContent));
 				if (this._oneOpen) {
 					closeAllPaths(root, item, this);
 				}
@@ -1478,33 +1534,37 @@ define(["wc/has",
 		 * @returns {Boolean} true if the branch opened.
 		 */
 		AbstractMenu.prototype._openBranch = function(branch) {
-			var result = false,
+			var _branch,
+				_expandable,
 				root;
-			// Open branch may be called from an opener button (pretty common actually)
-			branch = this._getBranch(branch);
-			if (branch && !shed.isExpanded(branch) && (root = this._getRoot(branch))) {
-				if (this._oneOpen) {
-					closeAllPaths(root, branch, this);
+
+			if ((root = this._getRoot(branch))) { // usual test for "am i in the correct menu module". TODO: Maybe make this a helper...
+				// Open branch may be called from an opener button (pretty common actually) so first we need the real branch.
+				if ((_branch = this._getBranch(branch)) && (_expandable = this._getBranchExpandableElement(_branch)) && !shed.isExpanded(_expandable)) {
+					if (this._oneOpen) {
+						closeAllPaths(root, branch, this); // use the original branch
+					}
+					return this._animateBranch(_expandable, true);
 				}
-				result = this._animateBranch(branch, true);
 			}
-			return result;
+
+			return null;
 		};
 
 		/**
-		 * Closes a branch: only works if called from a branch opener, submenu or branch
+		 * Closes a branch: only works if called from a branch opener, submenu or branch.
 		 * @function
 		 * @protected
-		 * @param {Element} branch the branch to close (or its 'opener' button or submenu child)
+		 * @param {Element} branch tThe branch to close (or its 'opener' button or submenu child).
 		 * @returns {Boolean} true if the branch closed.
 		 */
 		AbstractMenu.prototype._closeBranch = function(branch) {
-			var result = false;
+			var _expandable;
 			/* close branch may be called from an opener button or a submenu (pretty common actually) */
-			if ((branch = this._getBranch(branch)) && shed.isExpanded(branch)) {
-				result = this._animateBranch(branch, false);
+			if ((_expandable = this._getBranchExpandableElement(branch)) && shed.isExpanded(_expandable)) {
+				return this._animateBranch(_expandable, false);
 			}
-			return result;
+			return false;
 		};
 
 		/**
@@ -1539,20 +1599,19 @@ define(["wc/has",
 		 */
 		AbstractMenu.prototype._closeMyBranch = function(item) {
 			var branch,
-				result;
+				_item = item;
 			// if we simply called closeMyBranch from a 'closed' opener we would end up doing nothing because the
-			//    opener's parent branch is the branch it is in. So we need to get the branches parent
-			if (this._isBranchOrOpener(item)) {
-				if ((item = this._getBranch(item)) && !shed.isExpanded(item)) {
-					item = item.parentNode;
+			// opener's parent branch is the branch it is in. So we need to get the branches parent.
+			if (this._isBranchOrOpener(_item)) {
+				if ((branch = this._getBranch(_item)) && !shed.isExpanded(this._getBranchExpandableElement(branch))) {
+					_item = branch.parentNode;
 				}
 			}
-			if ((branch = this._getBranch(item)) && branch !== this._getRoot(item)) {
-				// do not try to close root!!
+			if ((branch = this._getBranch(_item)) && branch !== this._getRoot(_item)) { // do not try to close root!!
 				this[FUNC_MAP.CLOSE](branch);
-				result = branch;
+				return branch;
 			}
-			return result;
+			return null;
 		};
 
 		/**
@@ -1769,7 +1828,7 @@ define(["wc/has",
 						this[FUNC_MAP.ACTION](target);
 						if (isMenuTransient(root, this)) {
 							if (this._isBranch(item)) {
-								activateOnHover = shed.isExpanded(item) ? root.id : null;
+								activateOnHover = shed.isExpanded(this._getBranchExpandableElement(item)) ? root.id : null;
 							}
 							else if (this._isLeaf(item)) {
 								me = this;

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.bar.pattern_ff.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.bar.pattern_ff.scss
@@ -6,38 +6,31 @@ $wc-ff-vseparator-pad-top: $wc-ui-menu-item-pad-topbottom * 2;
 .menu[role='menubar'] {
 	> [role],
 	> [role] > .decoratedLabel,
-	> [aria-expanded] > button > .decoratedLabel {
+	> .submenu[role] > button > .decoratedLabel {
 		vertical-align: top;// Firefox honours inter-node whitespace even when the XSLT has indent off so this is required to make bar menus look reasonable.
 	}
 
-	// need the element qualifier to apply this only to the non-active menu items
-	// scss-lint:disable QualifyingElement
 	> div[role] {// buttons, even with no border, no margin, no padding still occupy 2px more vertical space in FF than divs
 		padding-bottom: calc(#{$wc-ui-menu-item-pad-topbottom} + 1px);
 		padding-top: calc(#{$wc-ui-menu-item-pad-topbottom} + 1px);
 	}
-	// scss-lint:enable QualifyingElement
 
 	[role='separator'][aria-orientation='vertical'] {
 		padding-bottom: calc(#{$wc-ff-vseparator-pad-top} + 3px); // I honestly do not know why this works but it does.
 		padding-top: 0;
 	}
 
-	> [aria-expanded] {
-		> button::after {
-			position: static;
-		}
+	> .submenu[role] > button::after {
+		position: static;
 	}
 }
 
-[role='menubar'].bar > [aria-expanded] > button { //top level submenu openers
+[role='menubar'].bar > .submenu[role] > button { //top level submenu openers
 	padding-bottom: 0;
 }
 
-.submenu[aria-expanded='true'] > [role='menu'] {
+.submenu > [role='menu'][aria-expanded='true'] {
 	// FF cannot correctly calculate the width of a container if it is absolutely positioned
 	// scss-lint:disable VendorPrefix
 	width: -moz-max-content;
 }
-
-/* end wc.ui.menu.bar.ff.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.bar.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.bar.scss
@@ -8,7 +8,7 @@
 		display: inline-block;
 
 		> [role],
-		> [aria-expanded] > button { //top level items
+		> .submenu[role] > button { //top level items
 			padding: $wc-ui-menu-flyout-top-level-item-pad;
 		}
 
@@ -19,7 +19,7 @@
 
 	&.bar {
 		> [role],
-		> [aria-expanded] > button {//top level items
+		> .submenu[role] > button {//top level items
 			padding: $wc-ui-menu-bar-column-item-pad;
 		}
 
@@ -31,14 +31,14 @@
 
 	> [role],
 	> [role] > .decoratedLabel,
-	> [aria-expanded] > button > .decoratedLabel {
+	> .submenu[role] > button > .decoratedLabel {
 		display: inline-block;
 		white-space: nowrap;
 		width: auto;
 	}
 
 	> [role] > .decoratedLabel,
-	> [aria-expanded] > button > .decoratedLabel {
+	> .submenu[role] > button > .decoratedLabel {
 		vertical-align: middle;
 	}
 

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.dt.scss
@@ -8,7 +8,7 @@
 		position: relative;
 	}
 
-	&[aria-expanded='true'] > [role='menu'] {
+	> [role='menu'][aria-expanded='true'] {
 		@include border;
 		box-shadow: 3px 3px 3px $wc-ui-color-shadow;
 		min-width: 100%;
@@ -54,4 +54,3 @@
 		top: auto;
 	}
 }
-/* end wc.ui.menu.barColumn.dt.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.icon.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.icon.ie8.scss
@@ -1,5 +1,5 @@
 /* wc.ui.menu.barColumn.icon.ie8.scss */
-[role='menubar'] > [aria-expanded] > button {
+[role='menubar'] > .submenu[role] > button {
 	> .decoratedLabel {
 		background-image: url('../images/down.png');
 		background-position: 100% 50%;
@@ -14,7 +14,7 @@
 	}
 }
 
-[role='menu'] [aria-expanded] > button {
+[role='menu'] .submenu[role] > button {
 	> .decoratedLabel {
 		background-image: url('../images/next.png');
 		background-position: 100% 50%;

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.icon.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.icon.scss
@@ -2,7 +2,7 @@
 // The opener iconoiography for WMenu type BAR, type FLYOUT, type COLUMN.
 @import 'wc.ui.menu_vars.scss';
 
-[role='menubar'] > [aria-expanded] {
+[role='menubar'] > .submenu {
 	> button::after {
 		@include make-box;
 		@include background-image($url: '../images/down.png', $height: 1em, $width: 1em, $y: 0);
@@ -16,7 +16,7 @@
 	}
 }
 
-[role='menu'] [aria-expanded] {
+[role='menu'] .submenu {
 	> button .decoratedLabel::after {
 		@include make-box($display: table-cell, $width: 1em, $height: auto);
 		@include background-image($url: '../images/next.png', $height: 1em, $width: 1em);

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.scss
@@ -4,11 +4,11 @@
 
 [role='menu'] { //this role is any part of a COLUMN menu and submenus of a BAR or FLYOUT
 	> [role],
-	> [aria-expanded] > button {
+	> .submenu[role] > button {
 		padding: $wc-ui-menu-bar-column-item-pad;
 	}
 
-	.submenu[aria-expanded='true'] > & {
+	&[aria-expanded='true'] {
 		z-index: 5;
 
 		dialog & {
@@ -29,9 +29,10 @@
 		position: fixed;
 		top: 0;
 		width: 100%;
+
+		> [role] {
+			font-size: 1.25em;
+		}
 	}
 
-	> [aria-expanded] > [role='menu'] > [role] {
-		font-size: 1.25em;
-	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.color.scss
@@ -30,8 +30,8 @@
 [role='menuitemradio'][aria-checked='true'],
 [role='menuitemcheckbox'][aria-checked='true'],
 [role='treeitem'][aria-selected='true'],
-.submenu[aria-selected='true'][aria-expanded] > button,
-.submenu[aria-checked='true'][aria-expanded] > button {
+.submenu[aria-selected='true'] > button,
+.submenu[aria-checked='true'] > button {
 	background-color: $wc-ui-color-invite-bg;
 	color: $wc-ui-color-invite-fg;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.scss
@@ -21,7 +21,7 @@
 [role='menuitemradio'],
 [role='menuitemcheckbox'],
 [role='treeitem'],
-.menu [aria-expanded] > button {
+.submenu > button {
 	@include border-box;
 	display: block;
 	text-align: $preferred-alignment;
@@ -60,10 +60,8 @@
 	}
 }
 
-.submenu[aria-expanded='false'] {
-	> [role='menu'],
-	> [role='group'] {
-		display: none;
-	}
+.submenu[aria-expanded='false'] >  [role='group'],
+.submenu > [role='menu'][aria-expanded='false'] {
+	display: none;
 }
 /* end wc.ui.menu.scss */

--- a/wcomponents-theme/src/main/xslt/wc.ui.submenu.content.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.submenu.content.xsl
@@ -1,4 +1,5 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
+	<xsl:import href="wc.constants.xsl"/>
 	<!--
 		This is the transform of the content of a submenu. The template creates a 
 		wrapper element and sets up several attributes which control its behaviour, 
@@ -6,6 +7,7 @@
 	-->
 	<xsl:template match="ui:content" mode="submenu">
 		<xsl:param name="open" select="0"/>
+		<xsl:param name="type"/>
 		<xsl:variable name="mode" select="../@mode"/>
 		
 		<xsl:variable name="isAjaxMode">
@@ -47,7 +49,7 @@
 			</xsl:if>
 			<xsl:attribute name="role">
 				<xsl:choose>
-					<xsl:when test="ancestor::ui:menu[1]/@type='tree'">
+					<xsl:when test="$type='tree'">
 						<xsl:text>group</xsl:text>
 					</xsl:when>
 					<xsl:otherwise>
@@ -55,6 +57,26 @@
 					</xsl:otherwise>
 				</xsl:choose>
 			</xsl:attribute>
+			<xsl:if test="not($type='tree')">
+				<xsl:attribute name="aria-expanded">
+					<xsl:choose>
+						<xsl:when test="$open=1">
+							<xsl:copy-of select="$t"/>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:text>false</xsl:text>
+						</xsl:otherwise>
+					</xsl:choose>
+				</xsl:attribute>
+				<xsl:if test="not(*)">
+					<!-- make a dummy menu item.
+						Why?
+						We have to keep the menu role on the content wrapper to make the menu function but role menu
+						must have at least one descendant role menuitem[(?:radio)|(?:checkbox)]?
+					-->
+					<span role="menuitem" class="wc_menuitem_dummy" hidden="hidden"></span>
+				</xsl:if>
+			</xsl:if>
 			<xsl:apply-templates select="*"/>
 		</xsl:element>
 	</xsl:template>

--- a/wcomponents-theme/src/main/xslt/wc.ui.submenu.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.submenu.xsl
@@ -83,23 +83,24 @@
 				certainly avoid it for automated testing.
 			-->
 			<xsl:call-template name="makeCommonClass"/>
-			<xsl:attribute name="aria-expanded">
-				<xsl:choose>
-					<xsl:when test="$open=1">
-						<xsl:copy-of select="$t"/>
-					</xsl:when>
-					<xsl:otherwise>
-						<xsl:text>false</xsl:text>
-					</xsl:otherwise>
-				</xsl:choose>
-			</xsl:attribute>
+			<xsl:if test="$type='tree'">
+				<xsl:attribute name="aria-expanded">
+					<xsl:choose>
+						<xsl:when test="$open=1">
+							<xsl:copy-of select="$t"/>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:text>false</xsl:text>
+						</xsl:otherwise>
+					</xsl:choose>
+				</xsl:attribute>
+			</xsl:if>
 			<xsl:if test="@selectMode and not($type='tree')">
 				<xsl:attribute name="data-wc-selectmode">
 					<xsl:value-of select="@selectMode"/>
 				</xsl:attribute>
 			</xsl:if>
 			<xsl:call-template name="hideElementIfHiddenSet"/>
-
 			<xsl:attribute name="role">
 				<xsl:choose>
 					<xsl:when test="$type='tree'"><!-- this will only be met if we can get to the ancestor menu -->
@@ -203,6 +204,7 @@
 			</xsl:element>
 			<xsl:apply-templates select="ui:content" mode="submenu">
 				<xsl:with-param name="open" select="$open"/>
+				<xsl:with-param name="type" select="$type"/>
 			</xsl:apply-templates>
 		</xsl:element>
 	</xsl:template>


### PR DESCRIPTION
Had to make rather a lot of changes in the menu modules to fix the a11y issues in #358.

* The aria-expanded attribute has been moved to the correct element for menus (left where it was for trees).
* A method to acquire the expandable element was added to wc/ui/menu/core (and overridden for trees).
* The Sass for menus other than trees has been updated.
* A dummy menu item (hidden from all) has been added to empty AJAX powered sub-menus.
* The tree-specific pre-insertion document fragment manipulation method was beefed up to correctly set the treeitem and group roles and attributes and to remove the dummy element required by menus (this is invoked when we do not have a WMenu Type context i.e. inserting a WSubMenu as part of an ajax load of the content of another WSubMenu).
* Re-wrote the menu state writer for expanded states since role menu is not a scoped role of role menu or menubar so we cannot use the standard methods for getting a group within a menu.