### PR TITLE
Table row selection sass cleanup

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/selectToggle.js
+++ b/wcomponents-theme/src/main/js/wc/ui/selectToggle.js
@@ -325,8 +325,6 @@ define(["wc/dom/shed",
 					subController,
 					container,
 					namedGroupWd,
-					myGroup,
-					fullGroup,
 					SPACE = /\s+/;
 
 				if (!controller) {
@@ -350,42 +348,19 @@ define(["wc/dom/shed",
 
 				if (SPACE.test(groupName)) {
 					groupName = groupName.split(SPACE);
-					myGroup = groupName.map(function (next) {
+					return groupName.map(function (next) {
 						return document.getElementById(next);
 					});
 				}
-				else if ((container = document.getElementById(groupName))) {
+				if ((container = document.getElementById(groupName))) {
 					if (Widget.isOneOfMe(container, ALL_CB)) {
-						myGroup = [container];
+						return [container];
 					}
-					else if (isTableRowSelectToggle(controller)) {
+
+					if (isTableRowSelectToggle(controller)) {
 						return toArray(ROW_WD.findDescendants(container, true));
 					}
-					else {
-						return toArray(Widget.findDescendants(container, ALL_CB));
-					}
-				}
-
-				if (myGroup) {
-					fullGroup = myGroup;
-					// If I am a table sub-row controller I only "know" about my immediate children, but they may have
-					// their own sub-rows which are part of my "group".
-					if (isSubRowController(controller)) {
-						myGroup.forEach(function (next) {
-							var nextController = getSubRowController(next, true),
-								nextGroup;
-							if (nextController) {
-								if (nextController === controller) { // each row is in its own controller's group.
-									return;
-								}
-
-								if ((nextGroup = getGroup(nextController)) && nextGroup.length) {
-									fullGroup = fullGroup.concat(nextGroup);
-								}
-							}
-						});
-					}
-					return fullGroup;
+					return toArray(Widget.findDescendants(container, ALL_CB));
 				}
 				return null;
 			}

--- a/wcomponents-theme/src/main/js/wc/ui/selectToggle.js
+++ b/wcomponents-theme/src/main/js/wc/ui/selectToggle.js
@@ -515,12 +515,13 @@ define(["wc/dom/shed",
 						}
 					}
 				}
+				/*
 				else if ((action === shed.actions.SELECT || action === shed.actions.DESELECT) && ROW_WD.isOneOfMe(element)) {
 					if ((controller = getSubRowController(element, true))) {
 						setControllerStatus(controller, action === shed.actions.SELECT ? STATE.ALL : STATE.NONE);
 					}
 				}
-
+				*/
 				if (Widget.isOneOfMe(element, ALL_CB) && (controller = getController(element))) {
 					if (isSubRowController(controller)) {
 						do {

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.bar.pattern_ff.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.bar.pattern_ff.scss
@@ -6,11 +6,11 @@ $wc-ff-vseparator-pad-top: $wc-ui-menu-item-pad-topbottom * 2;
 .menu[role='menubar'] {
 	> [role],
 	> [role] > .decoratedLabel,
-	> .submenu[role] > button > .decoratedLabel {
-		vertical-align: top;// Firefox honours inter-node whitespace even when the XSLT has indent off so this is required to make bar menus look reasonable.
+	> .submenu > button > .decoratedLabel {
+		vertical-align: top; // Firefox honours inter-node whitespace even when the XSLT has indent off so this is required to make bar menus look reasonable.
 	}
 
-	> div[role] {// buttons, even with no border, no margin, no padding still occupy 2px more vertical space in FF than divs
+	> div[role] { // buttons, even with no border, no margin, no padding still occupy 2px more vertical space in FF than divs
 		padding-bottom: calc(#{$wc-ui-menu-item-pad-topbottom} + 1px);
 		padding-top: calc(#{$wc-ui-menu-item-pad-topbottom} + 1px);
 	}
@@ -20,16 +20,16 @@ $wc-ff-vseparator-pad-top: $wc-ui-menu-item-pad-topbottom * 2;
 		padding-top: 0;
 	}
 
-	> .submenu[role] > button::after {
+	> .submenu > button::after {
 		position: static;
 	}
 }
 
-[role='menubar'].bar > .submenu[role] > button { //top level submenu openers
+[role='menubar'].bar > .submenu > button { //top level submenu openers
 	padding-bottom: 0;
 }
 
-.submenu > [role='menu'][aria-expanded='true'] {
+.submenu > [role="menu"][aria-expanded="true"] {
 	// FF cannot correctly calculate the width of a container if it is absolutely positioned
 	// scss-lint:disable VendorPrefix
 	width: -moz-max-content;

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.bar.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.bar.scss
@@ -8,7 +8,7 @@
 		display: inline-block;
 
 		> [role],
-		> .submenu[role] > button { //top level items
+		> .submenu > button { //top level items
 			padding: $wc-ui-menu-flyout-top-level-item-pad;
 		}
 
@@ -19,7 +19,7 @@
 
 	&.bar {
 		> [role],
-		> .submenu[role] > button {//top level items
+		> .submenu > button {//top level items
 			padding: $wc-ui-menu-bar-column-item-pad;
 		}
 
@@ -31,14 +31,14 @@
 
 	> [role],
 	> [role] > .decoratedLabel,
-	> .submenu[role] > button > .decoratedLabel {
+	> .submenu > button > .decoratedLabel {
 		display: inline-block;
 		white-space: nowrap;
 		width: auto;
 	}
 
 	> [role] > .decoratedLabel,
-	> .submenu[role] > button > .decoratedLabel {
+	> .submenu > button > .decoratedLabel {
 		vertical-align: middle;
 	}
 

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.icon.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.icon.ie8.scss
@@ -1,5 +1,5 @@
 /* wc.ui.menu.barColumn.icon.ie8.scss */
-[role='menubar'] > .submenu[role] > button {
+[role='menubar'] > .submenu > button {
 	> .decoratedLabel {
 		background-image: url('../images/down.png');
 		background-position: 100% 50%;
@@ -14,7 +14,7 @@
 	}
 }
 
-[role='menu'] .submenu[role] > button {
+[role='menu'] .submenu > button {
 	> .decoratedLabel {
 		background-image: url('../images/next.png');
 		background-position: 100% 50%;

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.scss
@@ -4,7 +4,7 @@
 
 [role='menu'] { //this role is any part of a COLUMN menu and submenus of a BAR or FLYOUT
 	> [role],
-	> .submenu[role] > button {
+	> .submenu > button {
 		padding: $wc-ui-menu-bar-column-item-pad;
 	}
 

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.scss
@@ -28,8 +28,7 @@
 	width: 100%;
 }
 
-
-.submenu[role],
+.submenu,
 [role='menu'] {
 	// We need the important here otherwise we have to do a LOT of overriding of roles.
 	// scss-lint:disable ImportantRule

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansion.icons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansion.icons.scss
@@ -12,14 +12,6 @@ tr[role='row'] {
 		&[aria-disabled='true'] {
 			background-image: url('../images/next-d.png');
 		}
-
-		&[aria-pressed='true'] {
-			background-image: url('../images/down.png');
-
-			&[aria-disabled='true'] {
-				background-image: url('../images/down-d.png');
-			}
-		}
 	}
 
 	&[aria-expanded='true'] {

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.pattern_ff.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.pattern_ff.scss
@@ -1,10 +1,11 @@
 /* wc.ui.table.rowSelection.pattern_ff.scss */
 .wc_table_sel_wrapper {
-	[role='menuitem'][aria-expanded] > button {
-		top: 4px;
+	[role='menubar'] .submenu > button {
+		top: 6px;
 
 		&::after {
 			background-position: 50% 0;
+			vertical-align: top;
 		}
 	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.scss
@@ -33,15 +33,16 @@ tr[aria-selected] {
 		display: none;
 	}
 
-	[role='menuitem'].submenu > button { // the is the submenu opener emulator for the sub-row toggle control
-		@include button($background: $wc-ui-color-menu-bg, $height: 1em, $padding: 0, $width: 1em, $reset-height: -1, $reset-width: -1);
+	[role='menubar'] .submenu > button { // the is the submenu opener emulator for the sub-row toggle control
+		@include button($background: $wc-ui-color-menu-bg, $height: -1, $padding: 0, $width: 1em, $reset-height: -1, $reset-width: -1);
+		height: calc(1em - 2px);
 		position: relative;
 		top: 2px;
 
 		&::after {
 			background-position: 50% 50%;
 			background-size: 0.667em;
-			height: 1em;
+			height: calc(1em - 2px); // allow for the border
 			margin-left: 0; // remove submenu opener indicator margin
 			width: 1em;
 		}

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.scss
@@ -1,5 +1,6 @@
 /* wc.ui.table.rowSelection.scss */
 @import 'wc.ui.table.rowSelection_vars.scss';
+@import 'wc.ui.menu_vars.scss';
 
 // only want to style aria-selected rows, nothing else
 tr[aria-selected] {
@@ -13,8 +14,8 @@ tr[aria-selected] {
 		@include background-image($url: '../images/radio.png', $width: 1em, $height: 1em);
 
 		.wc_table_hastoggleselect & {
-			background-position: $table-cell-padding 50%;
-			padding-left: $table-cell-padding + 1em;
+			background-position: $table-cell-padding-left-right 50%;
+			padding-left: $table-cell-padding-left-right + 1em;
 		}
    }
 }
@@ -31,8 +32,6 @@ tr[aria-selected] {
 	.wc_seltog  button + button::before { // remove select toggle list separator
 		display: none;
 	}
-
-	@import 'wc.ui.menu_vars.scss';
 
 	[role='menuitem'][aria-expanded] > button { // the is the submenu opener emulator for the sub-row toggle control
 		@include button($background: $wc-ui-color-menu-bg, $height: 1em, $padding: 0, $width: 1em, $reset-height: -1, $reset-width: -1);

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.scss
@@ -33,7 +33,7 @@ tr[aria-selected] {
 		display: none;
 	}
 
-	[role='menuitem'][aria-expanded] > button { // the is the submenu opener emulator for the sub-row toggle control
+	[role='menuitem'].submenu > button { // the is the submenu opener emulator for the sub-row toggle control
 		@include button($background: $wc-ui-color-menu-bg, $height: 1em, $padding: 0, $width: 1em, $reset-height: -1, $reset-width: -1);
 		position: relative;
 		top: 2px;

--- a/wcomponents-theme/src/main/sass/wc.ui.table_vars.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table_vars.scss
@@ -8,4 +8,6 @@ $wc-ui-color-table-foot-bg: $std-color-primary;
 $wc-ui-color-table-foot-fg: $std-color-primary-accent;
 $wc-color-table-foot-disabled: $wc-ui-color-disabled-fg;
 // all cells
-$table-cell-padding: $hgap-small;
+$table-cell-padding-top-bottom: $hgap-small;
+$table-cell-padding-left-right: $hgap-small;
+$table-cell-padding: $table-cell-padding-top-bottom;

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.tr.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.tr.xsl
@@ -320,16 +320,16 @@
 						<xsl:variable name="subRowToggleControlContentId" select="concat($subRowToggleControlId, '_content')"/>
 						
 						<div class="menu flyout" role="menubar" id="{$subRowToggleControlId}">
-							<div class="submenu" role="menuitem" aria-expanded="false">
+							<div class="submenu" role="menuitem">
 								<button type="button" aria-haspopup="true" class="wc_btn_nada" id="{$subRowToggleControlButtonId}" aria-controls="{$subRowToggleControlContentId}">
 									<span class="wc_off"><xsl:value-of select="$$${wc.ui.table.string.rowSelection.label}"/></span>
 								</button>
-								<div class="submenucontent wc_seltog" role="menu" id="{$subRowToggleControlContentId}" aria-labelledby="{$subRowToggleControlButtonId}">
+								<div class="submenucontent wc_seltog" role="menu" aria-expanded="false" id="{$subRowToggleControlContentId}" aria-labelledby="{$subRowToggleControlButtonId}">
 									<xsl:variable name="allSelectableSubRows" select="count(.//ui:subTr[ancestor::ui:table[1]/@id = $tableId]/ui:tr[not(@unselectable)])"/>
 									<xsl:variable name="allUnselectedSubRows" select="count(.//ui:subTr[ancestor::ui:table[1]/@id = $tableId]/ui:tr[not(@unselectable or @selected)])"/>
 									<xsl:variable name="subRowControlList">
 										<xsl:value-of select="concat($rowId, ' ')"/><!-- these controllers control this row too -->
-										<xsl:apply-templates select="ui:subTr/ui:tr" mode="subRowControlIdentifier">
+										<xsl:apply-templates select="ui:subTr//ui:tr[ancestor::ui:table[1]/@id = $tableId]" mode="subRowControlIdentifier">
 											<xsl:with-param name="tableId" select="$tableId"/>
 										</xsl:apply-templates>
 									</xsl:variable>


### PR DESCRIPTION
a11y changes to menu bars caused the static menus in the tables used to
toggle sub-row selection to fail because I forgot to update them.

I also split the vertical and horizontal cell padding Sass variables to
fix an override issue in several sub-themes which was exposed by the CSS
changes needed to support the menu in the state display cell.

Finally, I found another condition of failure in selectToggle in which
a sub-row which also had sub-rows would fail to select its subrows when
a super-row controller was activated if said sub-row was already
selected.