### PR TITLE
WTree - Schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,41 @@
 # Change log
 
 ## API Changes
-These are API changes and enhancements which _may_ have some impact on current users.
-
-* `WDataTable.PaginationMode.SERVER` has been modified to implement `WDataTable.PaginationMode.DYNAMIC` to overcome an a11y problem inherent in `WDataTable.PagainationMode.SERVER`. Whilst `WDataTable` is deprecated it is being retained (for the foreseeable future) for backwards compatibility and therefore must meet a11y requirements. `WDataTable.PaginationMode.SERVER` has been individually deprecated and **will be removed** in a near future release.
 
 ## Enhancements
-These are backwards-compatible API changes which are transparent for all current users. For full details see [GitHub issues](https://github.com/BorderTech/wcomponents/issues?q=is%3Aissue+is%3Aclosed+label%3Aenhancement).
-
-* Improved AJAX updates so "busy" regions maintain their dimensions and do not collapse to 0px.
-* `WTable` API allows for setting the location of the pagination controls using `setPaginationLocation(WTable.PaginationLocation location)` (#297).
-* `WMessageBox` API allows for setting message box title string using `setTitleText(String title)` (#280).
-* `WApplication` API allows for custom `js` and `css` resources to be easily loaded (#172).
 
 ## Major Bug fixes
 For all bug fixes see [GitHub Issues](https://github.com/BorderTech/wcomponents/issues?q=is%3Aissue+is%3Aclosed+label%3Abug)
 
+# Release 1.0.3
+
+## API Changes
+These are API changes and enhancements which _may_ have some impact on current users.
+
+* `WDataTable.PaginationMode.SERVER` has been modified to implement `WDataTable.PaginationMode.DYNAMIC` to overcome an a11y problem inherent in `WDataTable.PagainationMode.SERVER`. Whilst `WDataTable` is deprecated it is being retained (for the foreseeable future) for backwards compatibility and therefore must meet a11y requirements. `WDataTable.PaginationMode.SERVER` has been individually deprecated and **will be removed** in a near future release.
+* `WSubMenu` child count has changed. This was necessary to allow correct AJAX loading of sub-menus (#250). Applications should use `getMenuItems` instead of `getChildAt`.
+
+### JavaScript API changes
+* Client-side support of `WFilterControl` has been removed. This applied _only_ to (the deprecated) `WDataTable` but caused significant overhead during XSLT processing of all tables. The old code is available if a custom theme requires it.
+
+## Enhancements
+These are backwards-compatible API changes which are transparent for all current users. For full details see [GitHub issues](https://github.com/BorderTech/wcomponents/issues?q=is%3Aissue+is%3Aclosed+label%3Aenhancement).
+
+* `WTable` API allows for setting the location of the pagination controls using `setPaginationLocation(WTable.PaginationLocation location)` (#297).
+* `WTable` API allows for sub-row group selection (select all/select none) when a table has multiple row selection **and** row expansion enabled. The optional extra functionality allows for a select all/none control for every row which has one or more selectable sub-rows (#257).
+* `WMessageBox` API allows for setting message box title string using `setTitleText(String title)` (#280).
+* `WApplication` API allows for custom `js` and `css` resources to be easily loaded (#172).
+* `AbstractWComponent` API allows for custom HTML class attribute values to be added to any WComponent for improved application-level customisation (#172).
+* `WColumn` and `ColumnLayout` may now be created without specifying a width. The column widths _should_ then be specified in [application level CSS](https://github.com/BorderTech/wcomponents/wiki/Adding-custom-CSS). This is primarily aimed at applications which require responsive design (#172, #180).
+* Added improved guards against clickjacking (#240).
+
+## Major Bug fixes
+For all bug fixes see [GitHub Issues](https://github.com/BorderTech/wcomponents/issues?q=is%3Aissue+is%3Aclosed+label%3Abug)
+
+* Fixed loading `WSubMenu` via AJAX. Items can now be dynamically added when the `WSubMenu` is opened (#250). **NOTE** Any application using `WSubMenu.getChildAt` **must** now use `WSubMenu.getMenuItems` as the child count _will_ be different.
 * Fixed WTabSet ACCORDION interactions (#277).
-* Fixed `WShuffler` to work correctly when used as an `AjaxTrigger` (#323). 
+* Fixed `WShuffler` to work correctly when used as an `AjaxTrigger` (#323).
+* Fixed AJAX-enabled, drag & drop, multi-file upload in Firefox (#245).
 
 # Release 1.0.2
 ## API Changes
@@ -36,5 +54,4 @@ For all bug fixes see [GitHub Issues](https://github.com/BorderTech/wcomponents/
 * `WTab` implements `SubordinateTarget` (#158).
 
 ## Major Bug fixes
-* Fixed loading `WSubMenu` via AJAX. Items can now be dynamically added when the `WSubMenu` is opened. (#250)
 * `AbstractWComponentTestCase` now works with variable arguments on setter methods (#188)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Enhancements
 
+* In wcomponents-theme: Added a new class attribute value `wc_btn_img` to the HTML output element of `WLink` and `WButton` where the element contains an image without text (i.e. in XML `@imageUrl` is set and` @imagePosition` is not set). This allows more granular control of the styling of these buttons which are generally intended to be iconic.
+
 ## Major Bug fixes
 For all bug fixes see [GitHub Issues](https://github.com/BorderTech/wcomponents/issues?q=is%3Aissue+is%3Aclosed+label%3Abug)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ## Enhancements
 
-* In wcomponents-theme: Added a new class attribute value `wc_btn_img` to the HTML output element of `WLink` and `WButton` where the element contains an image without text (i.e. in XML `@imageUrl` is set and` @imagePosition` is not set). This allows more granular control of the styling of these buttons which are generally intended to be iconic.
-
 ## Major Bug fixes
 For all bug fixes see [GitHub Issues](https://github.com/BorderTech/wcomponents/issues?q=is%3Aissue+is%3Aclosed+label%3Abug)
 

--- a/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.button.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.button.xsd
@@ -1,52 +1,62 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0"
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" 
+	targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0"
 	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0">
-	<!--
-		Attribute groups for buttons and button-like controls
-	-->
+	
 	<xs:include schemaLocation="attributeGroups.control.xsd" />
-
-
+	<!--
+		Attribute groups for buttons and button-like controls.
+	-->
 	<xs:attributeGroup name="button.attributes">
 		<xs:annotation>
-			<xs:documentation>Common attributes for components which have a button nature to provide user interactivity.</xs:documentation>
+			<xs:documentation>
+				Common attributes for components which have a button nature to provide user interactivity.
+			</xs:documentation>
 		</xs:annotation>
+
 		<xs:attributeGroup ref="ui:control.attributes" />
 		<xs:attributeGroup ref="ui:accesskey.attributes" />
 	</xs:attributeGroup>
 
 
+
 	<xs:attributeGroup name="button.link.attributes">
 		<xs:annotation>
-			<xs:documentation>Common attributes for button and link components.</xs:documentation>
+			<xs:documentation>
+				Common attributes for button and link components.
+			</xs:documentation>
 		</xs:annotation>
 
 		<xs:attributeGroup ref="ui:button.attributes" />
 
 		<xs:attribute name="tabIndex" type="xs:int">
 			<xs:annotation>
-				<xs:documentation>Sets the component's position in the tab navigation order. Not implemented by default as it may pose significant accessibility and usability
-					problems.</xs:documentation>
+				<xs:documentation>
+					Sets the component's position in the tab navigation order. Not implemented by default as it may pose
+					significant accessibility and usability problems. Under review: may be removed.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
 		<xs:attribute name="accessibleText" type="xs:string">
 			<xs:annotation>
-				<xs:documentation>Deprecated. Use toolTip instead.</xs:documentation>
+				<xs:documentation>
+					Deprecated. Use toolTip instead.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
 		<xs:attribute name="imageUrl" type="xs:anyURI">
 			<xs:annotation>
-				<xs:documentation>The location of an image to display in the control.</xs:documentation>
+				<xs:documentation>
+					The location of an image to display in the control.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
 		<xs:attribute name="imagePosition">
 			<xs:annotation>
-				<xs:documentation>The position of the image specified in the imageUrl attribute relative to any text content in the control. If imageUrl is not set then this
-					attribute is ignored. If imageUrl is set and this attribute is not set then the component will not output the text content (if any) of the
-					component.</xs:documentation>
+				<xs:documentation>
+					The position of the image specified in the imageUrl attribute relative to any text content in the
+					control. If imageUrl is not set then this attribute is ignored.
+				</xs:documentation>
 			</xs:annotation>
 			<xs:simpleType>
 				<xs:restriction base="xs:NMTOKEN">
@@ -57,11 +67,12 @@
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>
-
 		<xs:attribute name="type">
 			<xs:annotation>
-				<xs:documentation>indicates the rendered appearance of the component. The default is the native output of the control (button for buttons, link for
-					links).</xs:documentation>
+				<xs:documentation>
+					Indicates the rendered appearance of the component. The default is the native output of the control
+					(button for buttons, link for links).
+				</xs:documentation>
 			</xs:annotation>
 			<xs:simpleType>
 				<xs:restriction base="xs:NMTOKEN">
@@ -72,28 +83,35 @@
 		</xs:attribute>
 	</xs:attributeGroup>
 
+
+
 	<xs:attributeGroup name="button.menu.attributes">
 		<xs:annotation>
-			<xs:documentation>Common attributes used by buttons and menu items to implement cancel, confirm and validation region behaviour.</xs:documentation>
+			<xs:documentation>
+				Common attributes used by buttons and menu items to implement cancel, confirm and validation region
+				behaviour.
+			</xs:documentation>
 		</xs:annotation>
-
-		<xs:attribute name="cancel" type="xs:boolean">
+		<xs:attribute name="cancel" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>If true then the component acts as a cancel control and the user will be warned of unsaved changes.</xs:documentation>
+				<xs:documentation>
+					If true then the component acts as a cancel control and the user will be warned of unsaved changes.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
 		<xs:attribute name="msg" type="xs:string">
 			<xs:annotation>
-				<xs:documentation>If set then the component will require confirmation before submission. This can be used to add a custom unsaved changes warning if @cancel is
-					true.</xs:documentation>
+				<xs:documentation>
+					If set then the component will require confirmation before submission. This can be used to add a
+					custom unsaved changes warning if @cancel is "true".
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
 		<xs:attribute name="validates" type="xs:NMTOKEN">
 			<xs:annotation>
-				<xs:documentation>Used in conjunction with client side validation (WComponents plugin since v14.0.001). If client side validation is enabled and "validates" not
-					defined, then the entire form will be validated client side by any interaction <strong>unless</strong> the cancel property is set "true".</xs:documentation>
+				<xs:documentation>
+					Indicates the region of the view which will be validated by the control's validating action.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>

--- a/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.common.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.common.xsd
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0"
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" 
+	targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0"
 	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0">
 	<!--
 		Common attributes for various components.
@@ -15,8 +16,11 @@
 	<xs:attributeGroup name="accesskey.attributes">
 		<xs:attribute name="accessKey">
 			<xs:annotation>
-				<xs:documentation>Sets a single modified key access key for a control. This attribute should be used with caution as: <ul>
-						<li>some user agents reserve some keys for internal use and do not expose them to the client for use as access keys; and</li>
+				<xs:documentation>
+					Sets a single modified key access key for a control. This attribute should be used with caution as:
+					<ul>
+						<li>some user agents reserve some keys for internal use and do not expose them to the client for
+							use as access keys; and</li>
 						<li>some keys may clash or cause issues with use of various assistive technologies.</li>
 					</ul>
 				</xs:documentation>
@@ -36,62 +40,87 @@
 	<xs:attributeGroup name="ajax.mode.attributes">
 		<xs:attribute name="mode" use="required">
 			<xs:annotation>
-				<xs:documentation>Indicates the content display mode for the component</xs:documentation>
+				<xs:documentation>
+					Indicates the content display mode for the component.
+				</xs:documentation>
 			</xs:annotation>
 			<xs:simpleType>
 				<xs:restriction base="xs:NMTOKEN">
 					<xs:enumeration value="client">
 						<xs:annotation>
-							<xs:documentation>The content exists in the page and showing/hiding that content is purely a client-side process.</xs:documentation>
+							<xs:documentation>
+								The content exists in the page and showing/hiding that content is purely a client-side
+								process.
+							</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 					<xs:enumeration value="dynamic">
 						<xs:annotation>
-							<xs:documentation>The content is fetched from the server using AJAX each time the content is displayed.</xs:documentation>
+							<xs:documentation>
+								The content is fetched from the server using AJAX each time the content is displayed.
+							</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 					<xs:enumeration value="eager">
 						<xs:annotation>
-							<xs:documentation>The content is not part of the underlying page XML but is fetched from the server using AJAX as the browser renders the page.</xs:documentation>
+							<xs:documentation>
+								The content is not part of the underlying page XML but is fetched from the server using
+								AJAX as the browser renders the page.
+							</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 					<xs:enumeration value="lazy">
 						<xs:annotation>
-							<xs:documentation>The content is fetched from the server the first time the content is displayed then remains static for the rest fo the lifecycle of the page.</xs:documentation>
+							<xs:documentation>
+								The content is fetched from the server the first time the content is displayed then
+								remains static for the rest fo the lifecycle of the page.
+							</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 					<xs:enumeration value="server">
 						<xs:annotation>
-							<xs:documentation>The content is not part of the page's XML unless it is in a visible (open) state and a user action to display the content will result in the entire
-								application POSTing to the server application. This mode is deprecated for all implementing components and should be avoided as it poses significant
-								user interaction problems.</xs:documentation>
+							<xs:documentation>
+								The content is not part of the page's XML unless it is in a visible (open) state and a
+								user action to display the content will result in the entire application POSTing to the
+								server application. This mode is deprecated for all implementing components and should
+								be avoided as it poses significant user interaction problems.
+							</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>
 	</xs:attributeGroup>
-	
+
+
+
 	<xs:attributeGroup name="ajax.mode.simple.attributes">
 		<xs:attribute name="mode">
 			<xs:annotation>
-				<xs:documentation>Indicates the content display mode for the component</xs:documentation>
+				<xs:documentation>
+					Indicates the content display mode for the component.
+				</xs:documentation>
 			</xs:annotation>
 			<xs:simpleType>
 				<xs:restriction base="xs:NMTOKEN">
 					<xs:enumeration value="eager">
 						<xs:annotation>
-							<xs:documentation>The content is not part of the underlying page XML but is fetched from the server using AJAX as the browser renders the page.</xs:documentation>
+							<xs:documentation>
+								The content is not part of the underlying page XML but is fetched from the server using
+								AJAX as the browser renders the page.
+							</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 					<xs:enumeration value="lazy">
 						<xs:annotation>
-							<xs:documentation>The content is fetched from the server the first time the content is displayed then remains static for the rest fo the lifecycle of the page.</xs:documentation>
+							<xs:documentation>
+								The content is fetched from the server the first time the content is displayed then
+								remains static for the rest fo the lifecycle of the page.
+							</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>
 	</xs:attributeGroup>
-	
 </xs:schema>

--- a/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.container.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.container.xsd
@@ -1,33 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" 
+	targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0"
+	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0">
+	<xs:include schemaLocation="attributeGroups.common.xsd"/>
 	<!--
 		Common attributes for container components.
 	-->
-	<xs:include schemaLocation="attributeGroups.common.xsd"/>
-
-
 	<xs:attributeGroup name="container.attributes">
 		<xs:annotation>
-			<xs:documentation>Common attributes for container components.</xs:documentation>
+			<xs:documentation>
+				Common attributes for container components.
+			</xs:documentation>
 		</xs:annotation>
 		<xs:attribute name="id" type="xs:ID" use="required">
 			<xs:annotation>
-				<xs:documentation>The unique identifier for the component.</xs:documentation>
+				<xs:documentation>
+					The unique identifier for the component.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="class" type="xs:string">
 			<xs:annotation>
-				<xs:documentation>Provides the ability to pass an HTML class attribute onto the root output element.</xs:documentation>
+				<xs:documentation>
+					Provides the ability to pass an HTML class attribute onto the root output element.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute name="hidden" type="xs:boolean">
+		<xs:attribute name="hidden" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>The component will be in a hidden state if "true". Not output if "false".</xs:documentation>
+				<xs:documentation>
+					The component will be in a hidden state if "true".
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute name="track" type="xs:boolean">
+		<xs:attribute name="track" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>Indicates that the component should take part in web analytics tracking.</xs:documentation>
+				<xs:documentation>
+					Indicates that the component should take part in web analytics tracking.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>
@@ -36,7 +46,9 @@
 
 	<xs:attributeGroup name="container.key.attributes">
 		<xs:annotation>
-			<xs:documentation>Common attributes for all container components which are able to be accessed using a keyboard shourtcut.</xs:documentation>
+			<xs:documentation>
+				Common attributes for all container components which are able to be accessed using a keyboard shourtcut.
+			</xs:documentation>
 		</xs:annotation>
 		<xs:attributeGroup ref="ui:container.attributes"/>
 		<xs:attributeGroup ref="ui:accesskey.attributes"/>

--- a/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.control.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.control.xsd
@@ -1,230 +1,295 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" 
+	targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" 
+	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0">
 	<!--
 		Attribute groups used by interactive controls.
 	-->
 	<xs:include schemaLocation="attributeGroups.common.xsd"/>
-	
+
 	<xs:attributeGroup name="interaction.attributes">
 		<xs:annotation>
-			<xs:documentation>Common attributes for interactive components.</xs:documentation>
+			<xs:documentation>
+				Common attributes for interactive components.
+			</xs:documentation>
 		</xs:annotation>
 		<xs:attribute name="id" type="xs:ID" use="required">
 			<xs:annotation>
-				<xs:documentation>The unique identifier for the component.</xs:documentation>
+				<xs:documentation>
+					The unique identifier for the component.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="class" type="xs:string">
 			<xs:annotation>
-				<xs:documentation>Provides the ability to pass an HTML class attribute onto the root output element.</xs:documentation>
+				<xs:documentation>
+					Provides the ability to pass an HTML class attribute onto the root output element.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute name="disabled" type="xs:boolean">
+		<xs:attribute name="disabled" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>The component will be in a disabled state if "true". Not output if "false".</xs:documentation>
+				<xs:documentation>
+					The component will be in a disabled state if "true".
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute name="hidden" type="xs:boolean">
+		<xs:attribute name="hidden" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>The component will be in a hidden state if "true". Not output if "false".</xs:documentation>
+				<xs:documentation>
+					The component will be in a hidden state if "true".
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute name="track" type="xs:boolean">
+		<xs:attribute name="track" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>Indicates that the component should take part in web analytics tracking.</xs:documentation>
+				<xs:documentation>
+					Indicates that the component should take part in web analytics tracking.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>
-	
-	
-	
+
+
+
 	<xs:attributeGroup name="control.attributes">
 		<xs:annotation>
-			<xs:documentation>Common attributes for form controls.</xs:documentation>
+			<xs:documentation>
+				Common attributes for form controls.
+			</xs:documentation>
 		</xs:annotation>
-		
+
 		<xs:attributeGroup ref="ui:interaction.attributes"/>
-		
+
 		<xs:attribute name="toolTip" type="xs:string">
 			<xs:annotation>
-				<xs:documentation>Text to display to the user as optional 'helper' information. Note, however, that there are some 
-						accessibility and usability implications of this attribute and it should be used with care.</xs:documentation>
+				<xs:documentation>
+					Text to display to the user as optional 'helper' information. Note, however, that there are some 
+					accessibility and usability implications of this attribute and it should be used with care.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>
-	
-	
-	
+
+
+
 	<xs:attributeGroup name="input.attributes">
 		<xs:annotation>
-			<xs:documentation>Common attributes for data input controls.</xs:documentation>
+			<xs:documentation>
+				Common attributes for data input controls.
+			</xs:documentation>
 		</xs:annotation>
-		
+
 		<xs:attributeGroup ref="ui:control.attributes"/>
-		
-		<xs:attribute name="required" type="xs:boolean">
+
+		<xs:attribute name="required" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>The component will be mandatory if "true". Not output if "false".</xs:documentation>
+				<xs:documentation>
+					The component will be mandatory if "true".
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		
-		<xs:attribute name="readOnly" type="xs:boolean">
+		<xs:attribute name="readOnly" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>The component will be in a non-interactive state if "true". Not output if "false".</xs:documentation>
+				<xs:documentation>
+					The component will be in a non-interactive state if "true".
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		
 		<xs:attribute name="tabIndex" type="xs:int">
 			<xs:annotation>
-				<xs:documentation>Sets the component's position in the tab navigation order. Not implemented by default as it may 
-						pose significant accessibility and usability problems.</xs:documentation>
+				<xs:documentation>
+					Sets the component's position in the tab navigation order. Not implemented by default as it may pose
+					significant accessibility and usability problems.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		
 		<xs:attribute name="accessibleText" type="xs:string">
 			<xs:annotation>
-				<xs:documentation>Deprecated. Use toolTip instead.</xs:documentation>
+				<xs:documentation>
+					Deprecated. Use toolTip instead.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>
-	
+
+
+
 	<xs:attributeGroup name="submitting.input.attributes">
 		<xs:annotation>
-			<xs:documentation>Common attributes for data input components which provide support for form submission using the ENTER key.</xs:documentation>
+			<xs:documentation>
+				Common attributes for data input components which provide support for form submission using the ENTER 
+				key.
+			</xs:documentation>
 		</xs:annotation>
 		
 		<xs:attributeGroup ref="ui:input.attributes"/>
 		
 		<xs:attribute name="buttonId" type="xs:NMTOKEN">
 			<xs:annotation>
-				<xs:documentation>The component id of a WButton which is used as the application submit button if the user presses 
-						the ENTER key with this component focussed.</xs:documentation>
+				<xs:documentation>
+					The component id of a WButton which is used as the application submit button if the user presses the
+					ENTER key with this component focussed.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>
-	
-	
-	
+
+
+
 	<xs:attributeGroup name="text.input.attributes">
 		<xs:annotation>
-			<xs:documentation>Common attributes for text input components.</xs:documentation>
+			<xs:documentation>
+				Common attributes for text input components.
+			</xs:documentation>
 		</xs:annotation>
-		
+
 		<xs:attribute name="size" type="xs:positiveInteger">
 			<xs:annotation>
-				<xs:documentation>The visible size of the text input widget as determined by the renderer.</xs:documentation>
+				<xs:documentation>
+					The visible size of the text input widget as determined by the renderer.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		
 		<xs:attribute name="minLength" type="xs:positiveInteger">
 			<xs:annotation>
-				<xs:documentation>The minimum number of characters which constitute valid input <em>if the user makes any input at 
-						all</em>. If not set then no minimum is required.</xs:documentation>
+				<xs:documentation>
+					The minimum number of characters which constitute valid input <em>if the user makes any input at
+					all</em>. If not set then no minimum is required.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		
 		<xs:attribute name="maxLength" type="xs:positiveInteger">
 			<xs:annotation>
-				<xs:documentation>The maximum number of characters which constitute valid input <em>if the user makes any input at 
-						all</em>. If not set then no maximum is set but one may be implied by the user agent.</xs:documentation>
+				<xs:documentation>
+					The maximum number of characters which constitute valid input <em>if the user makes any input at
+					all</em>. If not set then no maximum is set but one may be implied by the user agent.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		
 		<xs:attribute name="pattern" type="xs:string">
 			<xs:annotation>
-				<xs:documentation>A <a href="http://www.w3.org/TR/html5/forms.html#attr-input-pattern" target="_blank">HTML5 regular
-						expression pattern</a> which applies to the content of the input as a whole.</xs:documentation>
+				<xs:documentation>
+					A <a href="http://www.w3.org/TR/html5/forms.html#attr-input-pattern" target="_blank">HTML5 regular
+					expression pattern</a> which applies to the content of the input as a whole.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		
 	</xs:attributeGroup>
-	
-	
-	
+
+
+
 	<xs:attributeGroup name="submitOnChange.attributes">
 		<xs:attribute name="submitOnChange" type="xs:boolean">
 			<xs:annotation>
-				<xs:documentation>This attribute has significant negative accessibility implications and <strong>extreme</strong>
-					care should be taken with its implementation. It may be removed completely from future versions of
-					WComponents because of these accessibility issues.</xs:documentation>
+				<xs:documentation>
+					This attribute has significant negative accessibility implications and <strong>extreme</strong> care
+					should be taken with its implementation. It may be removed completely from future versions of 
+					WComponents because of these accessibility issues.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>
-	
-	
-	
-	
+
+
+
 	<xs:attributeGroup name="multiSelect.constraints.attributes">
 		<xs:attribute name="min" type="xs:positiveInteger">
 			<xs:annotation>
-				<xs:documentation>indicates the minimum number of selected options which represents a valid input <em>if any selection is made at all</em>. If not set then there is no minimum constraint.</xs:documentation>
+				<xs:documentation>
+					Indicates the minimum number of selected options which represents a valid input <em>if any selection
+					is made at all</em>. If not set then there is no minimum constraint.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		
 		<xs:attribute name="max" type="xs:positiveInteger">
 			<xs:annotation>
-				<xs:documentation>indicates the maximum number of selected options which represents a valid input <em>if any selection is made at all</em>. If not set then there is no maximum constraint.</xs:documentation>
+				<xs:documentation>
+					Indicates the maximum number of selected options which represents a valid input <em>if any selection
+					is made at all</em>. If not set then there is no maximum constraint.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>
-	
+
+
+
 	<xs:attributeGroup name="selectList.attributes">
 		<xs:attributeGroup ref="ui:input.attributes" />
 		<xs:attributeGroup ref="ui:submitOnChange.attributes" />
+
 		<xs:attribute name="data" type="xs:string">
 			<xs:annotation>
-				<xs:documentation>The key name for the datalist. If set then only the selected option[s] is/are included in the source XML and all options and optgroups are
-					fetched in a separate transaction.</xs:documentation>
+				<xs:documentation>
+					The key name for the datalist. If set then only the selected option[s] is/are included in the source
+					XML and all options and optgroups are fetched in a separate transaction.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>
-	
+
+
+
 	<xs:attributeGroup name="selectionWidgetWithLayout.attributes">
 		<xs:attributeGroup ref="ui:input.attributes"/>
 		<xs:attributeGroup ref="ui:submitOnChange.attributes"/>
+
 		<xs:attribute name="layout" use="required">
 			<xs:annotation>
-				<xs:documentation>Indicated the playout pattern for the options in the component.</xs:documentation>
+				<xs:documentation>
+					Indicates the layout pattern for the options in the component.
+				</xs:documentation>
 			</xs:annotation>
 			<xs:simpleType>
 				<xs:restriction base="xs:NMTOKEN">
 					<xs:enumeration value="flat">
 						<xs:annotation>
-							<xs:documentation>Each option widget and its label is rendered in line with all others. Wrap points are determined by the user agent.</xs:documentation>
+							<xs:documentation>
+								Each option widget and its label is rendered in line with all others. Wrap points are
+								determined by the user agent.
+							</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 					<xs:enumeration value="stacked">
 						<xs:annotation>
-							<xs:documentation>Each option widget and its label is rendered on an individual line forming a single column of label:input pairs.</xs:documentation>
+							<xs:documentation>
+								Each option widget and its label is rendered on an individual line forming a single
+								column of label:input pairs.
+							</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 					<xs:enumeration value="column">
 						<xs:annotation>
-							<xs:documentation><p>Each option widget and its label is rendered in a column so that the complete control 
-								contains the number of columns of option-widget:label pairs indicated by the 
-								layoutColumnCount attribute.</p>
+							<xs:documentation>
+								<p>Each option widget and its label is rendered in a column so that the complete control
+									contains the number of columns of option-widget:label pairs indicated by the
+									layoutColumnCount attribute.</p>
 								<p><strong>NOTE:</strong> some rounding may cause there to be one fewer columns than
 									indicated depending on the number of option widgets in the group. When the readOnly 
 									attribute is set then only selected option widgets in the component are output which
 									may result in fewer columns. In all cases there will be no more than the
-									requested number of columns.</p></xs:documentation>
+									requested number of columns.</p>
+							</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 					<!-- add new layouts here -->
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>
-		
 		<xs:attribute name="layoutColumnCount" type="xs:positiveInteger">
 			<xs:annotation>
-				<xs:documentation>The maximum number of columns to render when the layout attribute is "column". Ignored if
-					the layout attribute is not "column".</xs:documentation>
+				<xs:documentation>
+					The maximum number of columns to render when the layout attribute is "column". Ignored if the layout
+					attribute is not "column".
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		
-		<xs:attribute name="frameless" type="xs:boolean">
+		<xs:attribute name="frameless" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>indicates that the wrapper element of the component (normally a HTML Fieldset) should be rendered without a border. Not output if false.</xs:documentation>
+				<xs:documentation>
+					Indicates that the wrapper element of the component (normally a HTML Fieldset) should be rendered
+					without a border.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>

--- a/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.media.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.media.xsd
@@ -1,84 +1,100 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0"
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+	targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0"
 	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0">
 	<!--
 		Attribute groups for audio and video controls
 	-->
 
-
 	<xs:attributeGroup name="media.attributes">
 		<xs:annotation>
-			<xs:documentation>Common attributes for audio and video components.</xs:documentation>
+			<xs:documentation>
+				Common attributes for audio and video components.
+			</xs:documentation>
 		</xs:annotation>
-
 		<xs:attribute name="id" type="xs:ID" use="required">
 			<xs:annotation>
-				<xs:documentation>The unique identifier for the component.</xs:documentation>
+				<xs:documentation>
+					The unique identifier for the component.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
 		<xs:attribute name="class" type="xs:string">
 			<xs:annotation>
-				<xs:documentation>Provides the ability to pass an HTML class attribute onto the root output element.</xs:documentation>
+				<xs:documentation>
+					Provides the ability to pass an HTML class attribute onto the root output element.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
-		<xs:attribute name="disabled" type="xs:boolean">
+		<xs:attribute name="disabled" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>The component will be in a disabled state if "true". Not output if "false". <strong>Deprecated:</strong> HTML5 audio and video do not support the
-					disabled state.</xs:documentation>
+				<xs:documentation>
+					The component will be in a disabled state if "true". <strong>Deprecated:</strong> HTML5 audio and
+					video do not support the disabled state.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
-		<xs:attribute name="hidden" type="xs:boolean">
+		<xs:attribute name="hidden" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>The component will be in a hidden state if "true". Not output if "false".</xs:documentation>
+				<xs:documentation>
+					The component will be in a hidden state if "true".
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
 		<xs:attribute name="toolTip" type="xs:string">
 			<xs:annotation>
-				<xs:documentation>Text to display to the user as optional 'helper' information. Note, however, that there are some accessibility and usability implications of this
-					attribute and it should be used with care.</xs:documentation>
+				<xs:documentation>
+					Text to display to the user as optional 'helper' information. Note, however, that there are some
+					accessibility and usability implications of this attribute and it should be used with care.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
 		<xs:attribute name="alt" type="xs:string">
 			<xs:annotation>
-				<xs:documentation>Alternative text to display if the media is not able to be rendered or if the component supports in-situ images (video poster for
-					example).</xs:documentation>
+				<xs:documentation>
+					Alternative text to display if the media is not able to be rendered or if the component supports 
+					in-situ images (video poster for example).
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
-		<xs:attribute name="preload">
+		<xs:attribute name="preload" default="auto">
 			<xs:annotation>
-				<xs:documentation>Indicates the rules for pre-loading the media file(s) by the user agent. If absent, "auto" is assumed.</xs:documentation>
+				<xs:documentation>
+					Indicates the rules for pre-loading the media file(s) by the user agent.
+				</xs:documentation>
 			</xs:annotation>
 			<xs:simpleType>
 				<xs:restriction base="xs:NMTOKEN">
 					<xs:enumeration value="none">
 						<xs:annotation>
-							<xs:documentation>Do not preload anything.</xs:documentation>
+							<xs:documentation>
+								Do not preload anything.
+							</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 					<xs:enumeration value="metadata">
 						<xs:annotation>
-							<xs:documentation>Pre-load only the media's meta data.</xs:documentation>
+							<xs:documentation>
+								Pre-load only the media's meta data.
+							</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 					<xs:enumeration value="auto">
 						<xs:annotation>
-							<xs:documentation>Allow the user agent to determine what to pre-load.</xs:documentation>
+							<xs:documentation>
+								Allow the user agent to determine what to pre-load.
+							</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>
-
-		<xs:attribute name="controls">
+		<xs:attribute name="controls" default="default">
 			<xs:annotation>
-				<xs:documentation>Indicates what controls to display to the user. May not be implemented depending on other factors. In most cases the user agent determines the
-					control set and only "none" has any impact. If absent, "default" is assumed and native controls will be used.</xs:documentation>
+				<xs:documentation>
+					Indicates what controls to display to the user. May not be implemented depending on other factors.
+					In most cases the user agent determines the control set and only "none" has any impact.
+				</xs:documentation>
 			</xs:annotation>
 			<xs:simpleType>
 				<xs:restriction base="xs:NMTOKEN">
@@ -89,39 +105,43 @@
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>
-
-		<xs:attribute name="autoplay" type="xs:boolean">
+		<xs:attribute name="autoplay" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>Indicates the media autoplay setting. Not implemented by default due to accessibility concerns. Not output if "false".</xs:documentation>
+				<xs:documentation>
+					Indicates the media autoplay setting. Not implemented by default in wcomponents-theme due to
+					accessibility concerns.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
 		<xs:attribute name="mediagroup" type="xs:NMTOKEN">
 			<xs:annotation>
-				<xs:documentation>Indicates a group name for a set of media components. Not yet implemented due to low levels of user agent support.</xs:documentation>
+				<xs:documentation>
+					Indicates a group name for a set of media components. Not yet implemented due to low levels of user
+					agent support.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
-		<xs:attribute name="loop" type="xs:boolean">
+		<xs:attribute name="loop" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>Indicates that the media should automatically replay at the end. May have considerable accessibility implications and should notbe used or used
-					with extreme caution. <strong>NOTE:</strong> default implementation of this attribute may be dropped from future releases due to these accessibility concerns.
-					Not output if "false".</xs:documentation>
+				<xs:documentation>
+					Indicates that the media should automatically replay at the end. May have considerable accessibility
+					implications and should no tbe used. Not supported by default in wcomponents-theme.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
-		<xs:attribute name="muted" type="xs:boolean">
+		<xs:attribute name="muted" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>Indicates that the media should be muted on page load. Not output if "false".</xs:documentation>
+				<xs:documentation>
+					Indicates that the media should be muted on page load.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
 		<xs:attribute name="duration" type="xs:positiveInteger">
 			<xs:annotation>
-				<xs:documentation>Indicates the temporal length of the media. Deprecated, not implemented by default since WComponents 12.0.001.</xs:documentation>
+				<xs:documentation>
+					Indicates the temporal length of the media. Not implemented by default in wcomponents-theme.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
-
 	</xs:attributeGroup>
 </xs:schema>

--- a/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.window.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.window.xsd
@@ -9,78 +9,92 @@
 	-->
 	<xs:attributeGroup name="popupAttributes">
 		<xs:annotation>
-			<xs:documentation>Attribute group for controls which open a new browser window</xs:documentation>
+			<xs:documentation>
+				Attribute group for controls which open a new browser window. 
+			</xs:documentation>
 		</xs:annotation>
 
 		<xs:attribute name="top" type="xs:unsignedInt">
 			<xs:annotation>
-				<xs:documentation>The position in pixels for the top of the new window relative to the screen. Not widely supported.</xs:documentation>
+				<xs:documentation>
+					The position in pixels for the top of the new window relative to the screen. Not universally
+					supported.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
 		<xs:attribute name="left" type="xs:unsignedInt">
 			<xs:annotation>
-				<xs:documentation>The position in pixels for the left edge of the new window relative to the screen. Not widely supported.</xs:documentation>
+				<xs:documentation>
+					The position in pixels for the left edge of the new window relative to the screen. Not universally
+					supported.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
 		<xs:attribute name="width" type="xs:positiveInteger">
 			<xs:annotation>
-				<xs:documentation>The size in pixels for the width new window. Not universally supported.</xs:documentation>
+				<xs:documentation>
+					The size in pixels for the width new window. Not universally supported.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
 		<xs:attribute name="height" type="xs:positiveInteger">
 			<xs:annotation>
-				<xs:documentation>The size in pixels for the height new window. Not universally supported.</xs:documentation>
+				<xs:documentation>
+					The size in pixels for the height new window. Not universally supported.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
-		<xs:attribute name="resizable" type="xs:boolean">
+		<xs:attribute name="resizable" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>Indicates that the user should be allowed to resize the new window. This should generally be set "true" if any of the linked attributes are set to
-					any explicit value as a window which cannot be resized may cause significant usability and accessibility issues. Not universally supported and may be overridden
-					by user settings. Not output if "false".</xs:documentation>
+				<xs:documentation>
+					Indicates that the user should be allowed to resize the new window. This should generally be set 
+					"true" if any of the linked attributes are set to any explicit value as a window which cannot be
+					resized may cause significant usability and accessibility issues. Not universally supported and may
+					be overridden by user settings.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
-		<xs:attribute name="showMenubar" type="xs:boolean">
+		<xs:attribute name="showMenubar" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>Indicates that the new window should show browser menu bars. Not universally supported and may be overridden by user settings. Not output if
-					"false".</xs:documentation>
+				<xs:documentation>
+					Indicates that the new window should show browser menu bars. Not universally supported and may be
+					overridden by user settings.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
-		<xs:attribute name="showToolbar" type="xs:boolean">
+		<xs:attribute name="showToolbar" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>Indicates that the new window should show browser tool bars. Not universally supported and may be overridden by user settings. Not output if
-					"false".</xs:documentation>
+				<xs:documentation>
+					Indicates that the new window should show browser tool bars. Not universally supported and may be
+					overridden by user settings.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
-		<xs:attribute name="showLocation" type="xs:boolean">
+		<xs:attribute name="showLocation" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>Indicates that the new window should show browser address/location bar. Not universally supported and may be overridden by user settings. Not
-					output if "false".</xs:documentation>
+				<xs:documentation>
+					Indicates that the new window should show browser address/location bar. Not universally supported
+					and may be overridden by user settings.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
-		<xs:attribute name="showStatus" type="xs:boolean">
+		<xs:attribute name="showStatus" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>Indicates that the new window should the show browser status bar. Not universally supported and may be overridden by user settings. Not output if
-					"false".</xs:documentation>
+				<xs:documentation>
+					Indicates that the new window should the show browser status bar. Not universally supported and may
+					be overridden by user settings.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
-		<xs:attribute name="showScrollbars" type="xs:boolean">
+		<xs:attribute name="showScrollbars" type="xs:boolean" default="false">
 			<xs:annotation>
-				<xs:documentation>Indicates that the new window should show browser scroll bars when needed. Not universally supported and may be overridden by user settings. This
-					should generally be set "true" if any of the linked attributes are set to any explicit value as a window which cannot be scrolled may cause significant
-					usability and accessibility issues. Not output if "false".</xs:documentation>
+				<xs:documentation>
+					Indicates that the new window should show browser scroll bars when needed. Not universally supported
+					and may be overridden by user settings. This should generally be set "true" if any of the linked
+					attributes are set to any explicit value as a window which cannot be scrolled may cause significant
+					usability and accessibility issues.
+				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-
 	</xs:attributeGroup>
-
-
 </xs:schema>

--- a/wcomponents-core/src/main/resources/schema/ui/v1/submenu.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/submenu.xsd
@@ -12,10 +12,11 @@
 
 		<xs:annotation>
 			<xs:documentation>
-				<p>WSubMenu provides a grouping mechanism for a set of items with in a WMenu where those items have an intrinsic semantic group nature. In practice a submenu is a
-					hideable set of items which is indicated by a label and interacting with the label toggles the hidden state of the submenu's content.</p>
-				<p>WSubMenu expects that the POSTed form data contains:</p>
+				<p>WSubMenu provides a grouping mechanism for a set of items with in a WMenu where those items have an 
+					intrinsic semantic group nature. In practice a submenu is a hideable set of items which is indicated
+					by a label and interacting with the label toggles the hidden state of the submenu's content.</p>
 				<table>
+					<caption>WSubMenu expects that the POSTed form data contains these items.</caption>
 					<thead>
 						<tr>
 							<th>Field name</th>

--- a/wcomponents-core/src/main/resources/schema/ui/v1/tree.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/tree.xsd
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" 
+	targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" 
+	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0">
+
+	<xs:include schemaLocation="attributeGroups.control.xsd"/>
+	<xs:include schemaLocation="treeItem.xsd"/>
+	<xs:include schemaLocation="margin.xsd"/>
+
+	<xs:element name="tree">
+		<xs:annotation>
+			<xs:documentation>
+				<p>WTree represents a tree view tool. You should note that a tree view tool is a selection toolas per 
+					<a href="http://www.w3.org/TR/2011/CR-wai-aria-20110118/roles#tree">WAI-ARIA Tree role</a>. It
+					is directly analogous to a HTML select element with the added enhancement of being able to support
+					nested groups of options.</p>
+				<table>
+					<caption>WTree expects that the POSTed form data contains</caption>
+					<thead>
+						<tr>
+							<th>Field name</th>
+							<th>Type</th>
+							<th>Mandatory</th>
+							<th>Value</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>@id + "-h"</td>
+							<td>String</td>
+							<td>yes</td>
+							<td>"x"</td>
+						</tr>
+					</tbody>
+				</table>
+			</xs:documentation>
+		</xs:annotation>
+
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="ui:margin" minOccurs="0"/>
+				<xs:element ref="ui:treeItem" maxOccurs="unbounded"/>
+			</xs:sequence>
+
+			<xs:attributeGroup ref="ui:interaction.attributes"/>
+
+			<xs:attribute name="htree" type="xs:boolean" default="false">
+				<xs:annotation>
+					<xs:documentation>
+						"true" indicates that the tree represents a horizontal tree.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="rows" type="xs:positiveInteger">
+				<xs:annotation>
+					<xs:documentation>
+						The number of rows to display for a htree. Ignored if htree is not "true".
+					</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="selectMode" default="single">
+				<xs:annotation>
+					<xs:documentation>
+						Indicates the manner in which the items in the tree may be "selected". Only applies if @htree is
+						not "true" as a horizontal tree is <strong>always</strong> multi-select.
+					</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="single">
+							<xs:annotation>
+								<xs:documentation>
+									Indicates that selection is exclusive and when selecting any selectable descendant 
+									node any previously selected nodes will be deselected. This is analogous to a HTML
+									select element in the single select state.
+								</xs:documentation>
+							</xs:annotation>
+						</xs:enumeration>
+						<xs:enumeration value="multiple">
+							<xs:annotation>
+								<xs:documentation>
+									Indicates that selection is not exclusive and multiple child treeItem elements may 
+									be selected. This is analogous to a HTML select element in a multiple select state.
+								</xs:documentation>
+							</xs:annotation>
+						</xs:enumeration>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/wcomponents-core/src/main/resources/schema/ui/v1/treeItem.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/treeItem.xsd
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" 
+	targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0"
+	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0">
+	<xs:include schemaLocation="attributeGroups.button.xsd" />
+	<xs:element name="treeItem">
+		<xs:complexType>
+			<xs:annotation>
+				<xs:documentation>
+					<p>WTreeItem provides a single intem within a WTree. The item can be used to invoke commands or 
+						provide a selection mechanism, or both. If the tree item contains other tree items it also acts
+						as a control to show/hide these child elements.</p>
+					<table>
+						<caption>WTreeItem expects that the POSTed form data contains:</caption>
+						<thead>
+							<tr>
+								<th>Field name</th>
+								<th>Type</th>
+								<th>Mandatory</th>
+								<th>Value</th>
+								<th>Notes</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td>@id</td>
+								<td>String</td>
+								<td>yes</td>
+								<td>"x"</td>
+								<td>Value POSTed only if the WTreeItem is the item causing the form submission.</td>
+							</tr>
+							<tr>
+								<td>@id.selected</td>
+								<td>String</td>
+								<td>no</td>
+								<td>"x"</td>
+								<td>Value POSTed only if the WTreeItem is in the selected state.</td>
+							</tr>
+							<tr>
+								<td>@id.open</td>
+								<td>String</td>
+								<td>no</td>
+								<td>"true"</td>
+								<td>Value POSTed only if the WTreeItem has children and is in the expanded state.</td>
+							</tr>
+						</tbody>
+					</table>
+				</xs:documentation>
+			</xs:annotation>
+
+			<xs:sequence>
+				<xs:element ref="ui:treeItem" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+
+			<xs:attributeGroup ref="ui:control.attributes" />
+			<xs:attributeGroup ref="ui:button.menu.attributes" />
+			<xs:attribute name="label" type="xs:string" use="required">
+				<xs:annotation>
+					<xs:documentation>
+						The text label of the tree item.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="imageUrl" type="xs:anyURI">
+				<xs:annotation>
+					<xs:documentation>The location of an image to display in the control.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="url" type="xs:anyURI">
+				<xs:annotation>
+					<xs:documentation>
+						Setting a url indicates that actioning this item should trigger navigation. This attribute and 
+						@submit are mutually exclusive.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="targetWindow" type="xs:NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>
+						Provides a machine-readable reference to a browser window. If set, and the @url attribute is 
+						set, then the link to the @url value will open in a new window with this as its window name. 
+						There are some implementation issues caused by long standing bugs in some common user agents and
+						some keywords in the HTML specification.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="submit" type="xs:boolean" default="false">
+				<xs:annotation>
+					<xs:documentation>
+						Setting submit indicates that actioning this item should trigger a form submit. This attribute
+						and @url are mutually exclusive.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="selected" type="xs:boolean" default="false">
+				<xs:annotation>
+					<xs:documentation>
+						"true" indicates that the submenu is selected.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="expanded" type="xs:boolean" default="false">
+				<xs:annotation>
+					<xs:documentation>
+						"true" indicates that the submenu is expanded. Not output if "false". Only valid if the treeItem
+						has one or more child elements.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WMessageBoxExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WMessageBoxExample.java
@@ -169,11 +169,10 @@ public class WMessageBoxExample extends WPanel {
 				getSelected());
 		messageBox.setVisible(cbVisible.isSelected());
 
-		if (tfTitle.getText() != null) {
+		if (tfTitle.getText() != null && !"".equals(tfTitle.getText())) {
 			messageBox.setTitleText(tfTitle.getText());
-		}
-		else {
-			messageBox.setTitleText("");
+		} else {
+			messageBox.setTitleText(null);
 		}
 	}
 


### PR DESCRIPTION
First draft schemas for mooted WTree (ui:tree) and WTreeItem (ui:treeItem - though I would prefer ui:leaf).

 This constitutes a
first step towards #263.

Cleaned up the style of the attribute group XSDs to make them a bit more readable (especially the SchemaDoc annotations). No changes to the
schemas themselves.

Fixed an error in an example which caused a WMessageBox to be rendered without a title. We _may_ be able to catch this in XSLT in future. The error was highlighted by a change to demonstrate the functionality introduced in #280.