### PR TITLE
WSuggestions force selection

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WSuggestions.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WSuggestions.java
@@ -45,6 +45,23 @@ public class WSuggestions extends AbstractWComponent implements AjaxTarget {
 	public static final String AJAX_REFRESH_ACTION_COMMAND = "Refresh";
 
 	/**
+	 * The way in which the suggestion is provided to and selected by the user. Defaults to BOTH and should remain as
+	 * this for combobox implementations. LIST should be used for implementations which enforce selection of an
+	 * existing value. We may want to consider INLINE in the future but I see no reason for NONE since then it would
+	 * not be a combo.
+	 */
+	public enum Autocomplete {
+		/**
+		 * Indicates that autocomplete may be from the textbox or from the suggestion list.
+		 */
+		BOTH,
+		/**
+		 * Indicates the autocomplete must only be from the suggestion list.
+		 */
+		LIST
+	};
+
+	/**
 	 * Create a WSuggestions.
 	 */
 	public WSuggestions() {
@@ -219,6 +236,20 @@ public class WSuggestions extends AbstractWComponent implements AjaxTarget {
 	}
 
 	/**
+	 * @param autocomplete The Autocomplete to set for this instance.
+	 */
+	public void setAutocomplete(final Autocomplete autocomplete) {
+		getOrCreateComponentModel().autocomplete = autocomplete;
+	}
+
+	/**
+	 * @return The autocomplete for this instance.
+	 */
+	public Autocomplete getAutocomplete() {
+		return getComponentModel().autocomplete;
+	}
+
+	/**
 	 * The minimum number of characters entered before refreshing suggestions. A value of zero indicates to use the
 	 * theme default, which is usually 3.
 	 *
@@ -308,6 +339,11 @@ public class WSuggestions extends AbstractWComponent implements AjaxTarget {
 		private List<String> getSuggestions() {
 			return suggestions;
 		}
+
+		/**
+		 * The autocomplete model for the suggestions.
+		 */
+		private Autocomplete autocomplete = Autocomplete.BOTH;
 
 		/**
 		 * @param suggestions the suggestions to set.

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WSuggestionsRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WSuggestionsRenderer.java
@@ -40,6 +40,10 @@ final class WSuggestionsRenderer extends AbstractWebXmlRenderer {
 				getMinRefresh());
 		xml.appendOptionalAttribute("ajax", useAjax, "true");
 		xml.appendOptionalAttribute("data", dataKey);
+		WSuggestions.Autocomplete autocomplete = suggestions.getAutocomplete();
+		if (autocomplete == WSuggestions.Autocomplete.LIST) {
+			xml.appendOptionalAttribute("autocomplete", "list");
+		}
 		xml.appendClose();
 
 		// Check if this is the current AJAX trigger
@@ -57,5 +61,4 @@ final class WSuggestionsRenderer extends AbstractWebXmlRenderer {
 		// End tag
 		xml.appendEndTag("ui:suggestions");
 	}
-
 }

--- a/wcomponents-core/src/main/resources/schema/ui/v1/suggestions.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/suggestions.xsd
@@ -1,16 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0"
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" 
+	targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0"
 	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0">
 	<xs:element name="suggestions">
 		<xs:annotation>
 			<xs:documentation>
-				<p>WSuggestions represents a device for providing suggested input for a text-like input field. The suggestions may be a static list, derived from a data url or
-					acquired on the fly based on user input into an associated input.</p>
-				<p>WSuggestions has no effect unless it is associated with a text-like input control such as WTextField. If it is associated with a constrained input (such as
-					WEmailField) then it is expected (but not enforced) that the suggestions would be in line with the associated field's constraints.</p>
-				<p>It allows for client caching of frequently used lists via a data key or lists that can be produced via AJAX depending on the text entered in the related
-					TextField. </p>
-				<p>If the suggestion list is populated on-the-fly then an ajax request for suggestions will contain the following:</p>
+				<p>WSuggestions represents a device for providing suggested input for a text-like input field. The
+					suggestions may be a static list, derived from a data url or acquired on the fly based on user input
+					into an associated input.</p>
+				<p>WSuggestions has no effect unless it is associated with a text-like input control such as WTextField.
+					If it is associated with a constrained input (such as WEmailField) then it is expected (but not
+					enforced) that the suggestions would be in line with the associated field's constraints.</p>
+				<p>It allows for client caching of frequently used lists via a data key or lists that can be produced
+					via AJAX depending on the text entered in the related WTextField. </p>
+				<p>If the suggestion list is populated on-the-fly then an ajax request for suggestions will contain the
+					following:</p>
 				<table>
 					<thead>
 						<tr>
@@ -35,12 +39,16 @@
 			<xs:sequence>
 				<xs:element name="suggestion" minOccurs="0" maxOccurs="unbounded">
 					<xs:annotation>
-						<xs:documentation>Each suggestion in the suggestions list. Provided when not using a data list key. </xs:documentation>
+						<xs:documentation>
+							Each suggestion in the suggestions list. Provided when not using a data list key.
+						</xs:documentation>
 					</xs:annotation>
 					<xs:complexType>
 						<xs:attribute name="value" type="xs:string" use="required">
 							<xs:annotation>
-								<xs:documentation>The suggested value. </xs:documentation>
+								<xs:documentation>
+									The suggested value.
+								</xs:documentation>
 							</xs:annotation>
 						</xs:attribute>
 					</xs:complexType>
@@ -48,22 +56,30 @@
 			</xs:sequence>
 			<xs:attribute name="id" type="xs:ID" use="required">
 				<xs:annotation>
-					<xs:documentation>The unique identifier for the component. </xs:documentation>
+					<xs:documentation>
+						The unique identifier for the component.
+					</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
 			<xs:attribute name="class" type="xs:string">
 				<xs:annotation>
-					<xs:documentation>Provides the ability to pass an HTML class attribute onto the root output element.</xs:documentation>
+					<xs:documentation>
+						Provides the ability to pass an HTML class attribute onto the root output element.
+					</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
 			<xs:attribute name="ajax" type="xs:boolean">
 				<xs:annotation>
-					<xs:documentation> Indicates if the suggestions list will be updated via AJAX. Is n/a for data lists. </xs:documentation>
+					<xs:documentation>
+						Indicates if the suggestions list will be updated via AJAX. Is n/a for data lists.
+					</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
 			<xs:attribute name="min">
 				<xs:annotation>
-					<xs:documentation> Indicates the minimum number of characters entered before refreshing suggestions. Default is theme dependent. Is n/a for data lists.
+					<xs:documentation>
+						Indicates the minimum number of characters entered before refreshing suggestions. Default is
+						theme dependent. Is n/a for data lists.
 					</xs:documentation>
 				</xs:annotation>
 				<xs:simpleType>
@@ -72,9 +88,47 @@
 			</xs:attribute>
 			<xs:attribute name="data" type="xs:string">
 				<xs:annotation>
-					<xs:documentation>The key name for a datalist. If set then no individual suggestion elements are included in the source XML but are fetched in a separate
-						transaction.</xs:documentation>
+					<xs:documentation>
+						The key name for a datalist. If set then no individual suggestion elements are included in the
+						source XML but are fetched in a separate transaction.
+					</xs:documentation>
 				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="autocomplete" default="both">
+				<xs:annotation>
+					<xs:documentation>
+						How should suggestion(s) be displayed to the client? See
+						<a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-autocomplete">https://www.w3.org/TR/wai-aria/states_and_properties#aria-autocomplete</a>.
+						Note, however, there is no implementation of 'none' as there is no reason to have suggestions 
+						if no suggestions are provided!
+					</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:NMTOKEN">
+						<xs:enumeration value="inline">
+							<xs:annotation>
+								<xs:documentation>
+									The system provides text after the caret as a suggestion for how to complete the
+									field.
+								</xs:documentation>
+							</xs:annotation>
+						</xs:enumeration>
+						<xs:enumeration value="list">
+							<xs:annotation>
+								<xs:documentation>
+									A list of choices appears from which the user can choose.
+								</xs:documentation>
+							</xs:annotation>
+						</xs:enumeration>
+						<xs:enumeration value="both">
+							<xs:annotation>
+								<xs:documentation>
+									A list of choices appears and the currently selected suggestion also appears inline.
+								</xs:documentation>
+							</xs:annotation>
+						</xs:enumeration>
+					</xs:restriction>
+				</xs:simpleType>
 			</xs:attribute>
 		</xs:complexType>
 	</xs:element>

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WSuggestions_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WSuggestions_Test.java
@@ -92,6 +92,11 @@ public class WSuggestions_Test extends AbstractWComponentTestCase {
 	}
 
 	@Test
+	public void testAutocompleteAccessors() {
+		assertAccessorsCorrect(new WSuggestions(), "autocomplete", WSuggestions.Autocomplete.BOTH, WSuggestions.Autocomplete.LIST, WSuggestions.Autocomplete.BOTH);
+	}
+
+	@Test
 	public void testMinRefreshAccessors() {
 		assertAccessorsCorrect(new WSuggestions(), "minRefresh", 0, 1, 2);
 	}

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WSuggestionsRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WSuggestionsRenderer_Test.java
@@ -41,6 +41,7 @@ public class WSuggestionsRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertXpathNotExists("//ui:suggestions/@ajax", field);
 		assertXpathNotExists("//ui:suggestions/@min", field);
 		assertXpathNotExists("//ui:suggestions/@data", field);
+		assertXpathNotExists("//ui:suggestions/@autocomplete", field);
 		assertXpathNotExists("//ui:suggestions/suggestion", field);
 
 		// Set min
@@ -128,6 +129,20 @@ public class WSuggestionsRenderer_Test extends AbstractWebXmlRendererTestCase {
 		} finally {
 			AjaxHelper.clearCurrentOperationDetails();
 		}
+	}
+
+
+	@Test
+	public void testDoPaintAutocomplete() throws IOException, SAXException, XpathException {
+		List<String> options = Arrays.asList("A", "B", "C");
+		WSuggestions field = new WSuggestions(options);
+
+		assertSchemaMatch(field);
+		assertXpathNotExists("//ui:suggestions/@autocomplete", field);
+		field.setAutocomplete(WSuggestions.Autocomplete.LIST);
+		assertXpathEvaluatesTo("list", "//ui:suggestions/@autocomplete", field);
+		field.setAutocomplete(WSuggestions.Autocomplete.BOTH);
+		assertXpathNotExists("//ui:suggestions/@autocomplete", field);
 	}
 
 }

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WSuggestionsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WSuggestionsExample.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.examples;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.WCheckBox;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WEmailField;
 import com.github.bordertech.wcomponents.WFieldLayout;
@@ -29,7 +30,6 @@ public class WSuggestionsExample extends WContainer {
 
 		add(layout);
 
-		// Cached suggestions
 		WSuggestions suggestions = new WSuggestions("icao");
 		add(suggestions);
 		WTextField text = new WTextField();
@@ -67,6 +67,14 @@ public class WSuggestionsExample extends WContainer {
 		layout.addField("Dynamic email", email);
 		suggestions.setRefreshAction(new AjaxAction("Email - "));
 
+		// Dynamic suggestions with force selection
+		suggestions = new WSuggestions();
+		suggestions.setAutocomplete(WSuggestions.Autocomplete.LIST);
+		add(suggestions);
+		text = new WTextField();
+		text.setSuggestions(suggestions);
+		layout.addField("Force selection from list", text);
+		suggestions.setRefreshAction(new AjaxAction(""));
 	}
 
 	/**

--- a/wcomponents-theme/src/main/sass/wc.ui.combo.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.combo.scss
@@ -18,11 +18,13 @@ input[role='combobox'] {
 
 	~ [role='listbox'] {
 		@include border;
-		background-color: $wc-ui-color-global-bg;
+		background-color: $wc-ui-color-highlight-bg;
 		display: block;
 		list-style-type: none;
 		margin: 0;
+		max-height: (7 * ($line-size + (2 * $hgap-small))); // allow for up to seven visible options.
 		max-width: 100%;
+		overflow: auto;
 		padding: 0;
 		position: absolute;
 		z-index: 2;
@@ -33,12 +35,13 @@ input[role='combobox'] {
 
 		&[aria-busy='true'] { // we do not want dynamic suggestion lists to go transparent when busy
 			// scss-lint:disable ImportantRule
-			background-color: $wc-ui-color-global-bg !important;
+			background-color: $wc-ui-color-highlight-bg !important;
 		}
 	}
 }
 
 li[role='option'] {
+	color: $wc-ui-color-highlight-fg;
 	margin: 0;
 	min-height: 1em;
 	padding: $hgap-small;
@@ -46,8 +49,7 @@ li[role='option'] {
 	&:hover,
 	&:focus {
 		background-color: $wc-ui-color-invite-bg;
+		color: $wc-ui-color-invite-fg;
 		cursor: pointer;
 	}
 }
-
-/* end wc.ui.combo.scss */

--- a/wcomponents-theme/src/main/xslt/wc.common.textInput.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.textInput.xsl
@@ -78,19 +78,28 @@
 							<xsl:value-of select="$$${wc.common.i18n.requiredPlaceholder}"/>
 						</xsl:attribute>
 					</xsl:if>
-					<xsl:if test="@list">
+					<xsl:variable name="list" select="@list"/>
+					<xsl:if test="$list">
 						<xsl:attribute name="role">
 							<xsl:text>combobox</xsl:text>
-						</xsl:attribute>
-						<xsl:attribute name="aria-autocomplete">
-							<xsl:text>both</xsl:text>
 						</xsl:attribute>
 						<!-- every input that implements combo should have autocomplete turned off -->
 						<xsl:attribute name="autocomplete">
 							<xsl:text>off</xsl:text>
 						</xsl:attribute>
 						<xsl:attribute name="aria-owns">
-							<xsl:value-of select="@list"/>
+							<xsl:value-of select="$list"/>
+						</xsl:attribute>
+						<xsl:variable name="suggestionList" select="//ui:suggestions[@id=$list]"/>
+						<xsl:attribute name="aria-autocomplete">
+							<xsl:choose>
+								<xsl:when test="$suggestionList and $suggestionList/@autocomplete">
+									<xsl:value-of select="$suggestionList/@autocomplete"/>
+								</xsl:when>
+								<xsl:otherwise>
+									<xsl:text>both</xsl:text>
+								</xsl:otherwise>
+							</xsl:choose>
 						</xsl:attribute>
 					</xsl:if>
 					<xsl:attribute name="type">
@@ -106,15 +115,13 @@
 					</xsl:if>
 					<xsl:if test="self::ui:numberField">
 						<!--
-							Turning off autocomplete is CRITICAL in Internet Explorer (8, others untested,
-							but those with a native HTML5 number field are probably going to be OK).
-							It tooks me days to find this after tearing apart the entire framework.
-							Here's the issue:
-								In Internet Explorer the autocomplete feature on an input field
-								causes the keydown event to be cancelled once there is something in
-								the autocomplete list, i.e. once you have entered something into that field.
-								So your event listeners are called with a cancelled event but you can find no
-								code that cancels the event - very tricky to track down.
+							Turning off autocomplete is CRITICAL in Internet Explorer (8, others untested, but those
+							with a native HTML5 number field are probably going to be OK). It tooks me days to find this
+							after tearing apart the entire framework. Here's the issue:
+								In Internet Explorer the autocomplete feature on an input field causes the keydown event
+								to be cancelled once there is something in the autocomplete list, i.e. once you have
+								entered something into that field. So your event listeners are called with a cancelled
+								event but you can find no code that cancels the event - very tricky to track down.
 						-->
 						<xsl:attribute name="autocomplete">
 							<xsl:text>off</xsl:text>

--- a/wcomponents-theme/src/main/xslt/wc.ui.suggestions.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.suggestions.xsl
@@ -27,7 +27,19 @@
 					<xsl:value-of select="1"/>
 				</xsl:attribute>
 			</xsl:if>
-			<xsl:apply-templates />
+			<xsl:if test="not(*)">
+				<xsl:choose>
+					<xsl:when test="not(@ajax) or parent::ui:ajaxTarget">
+						<li role="option" hidden="hidden"></li>
+					</xsl:when>
+					<xsl:otherwise>
+						<xsl:attribute name="aria-busy">
+							<xsl:copy-of select="$t"/>
+						</xsl:attribute>
+					</xsl:otherwise>
+				</xsl:choose>
+			</xsl:if>
+			<xsl:apply-templates select="*"/>
 		</ul>
 	</xsl:template>
 


### PR DESCRIPTION
## WSuggestions

Amended WSuggestions to allow the autocomplete method to be set to
“both” (the default) or “list”.

When set to “both” the combo works exactly as it has previously and any
content entered which does not match a suggestion is retained. This is
the default state and still allows an application to use custom
validation to report errors to the user.

When set to “list” the suggestions will be set based on user input but
will not allow acceptance of a value not in the suggestion list.

* If the user selects from the suggestions or types a value equal to a
suggestion then that entry is retained.

If the user types content which results in at least one suggestion but
that suggestion is not the equivalent of the user content when the user
leaves the field then the first such match is deemed to be the selected
option and the textbox is updated accordingly.

* If the user enters content which results in no valid matches then
leaves the textbox then the textbox is emptied.

* If the user types content which results in at least one suggestion
then defocuses the application, refocuses the application at that field
then rapidly types new (non-matching) content and leaves the field
before the suggestion list updates then the text field will be emptied
as if there was no match.

Fixes #379.

## A11y
Fixed an a11y error which occurred in comboboxes with ajax-based
suggestions when there were no suggestions.