### PR TITLE
296 get not selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ These are API changes and enhancements which _may_ have some impact on current u
 * `WFilterControl` has been removed. This WComponent was originally designed as a low-quality row filter for `WDataTable`. It has been deprecated for some time. WDataTable is deprecated and slated for _imminent_ removal (though not in the next major release) (#306).
 
 ## Enhancements
-These are backwards-compatible API changes which are transparent for all current users. For full details see [GitHub issues](https://github.com/BorderTech/wcomponents/issues?q=is%3Aissue+is%3Aclosed+label%3Aenhancement).
+For full details see [GitHub issues](https://github.com/BorderTech/wcomponents/issues?q=is%3Aissue+is%3Aclosed+label%3Aenhancement).
 
 * Added a new property to WSuggestions: WSuggestions.Autocomplete. This is an enum which currently supports two settings `LIST` and `BOTH` but has the potential to support all settings of the HTML attribute [aria-autocomplete](https://www.w3.org/TR/wai-aria/states_and_properties#aria-autocomplete) if required. This has the usual accessors get/setAutocomplete. The default is WSuggestions.Autocomplete.BOTH which provides the same functionality as in previous versions of WSuggestions. When WSuggestions.Autocomplete.LIST is used then the client implementation will attempt to force selection of an option from the suggestions list rather than allowing free-text input (#379).
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWMultiSelectList.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWMultiSelectList.java
@@ -140,6 +140,22 @@ public abstract class AbstractWMultiSelectList extends AbstractWSelectList {
 		return getValue().toArray();
 	}
 
+	/**
+	 * Returns the options which are not selected.
+	 *
+	 * @return The unselected options(s).
+	 */
+	public List<?> getNotSelected() {
+		List options = getOptions();
+		if (options == null || options.isEmpty()) {
+			return Collections.EMPTY_LIST;
+		}
+
+		List notSelected = new ArrayList(options);
+		notSelected.removeAll(getSelected());
+		return Collections.unmodifiableList(notSelected);
+	}
+
 	// ================================
 	// DataBound
 	/**

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/AbstractWMultiSelectList_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/AbstractWMultiSelectList_Test.java
@@ -182,6 +182,33 @@ public class AbstractWMultiSelectList_Test extends AbstractWComponentTestCase {
 	}
 
 	@Test
+	public void testGetUnselectedNoSelection() {
+		AbstractWMultiSelectList multi = new MyWMultiSelectList(OPTIONS, true);
+		// Nothing selected, all should be are deselected
+		Assert.assertEquals("Expect all options to be unselected", OPTIONS, multi.getNotSelected());
+	}
+
+	@Test
+	public void testGetUnselectedSomeSelection() {
+		AbstractWMultiSelectList multi = new MyWMultiSelectList(OPTIONS, true);
+		multi.setSelected(Arrays.asList(OPTION_C));
+		Assert.assertEquals("Expect a nd b to be unselected", SELECTED_A_B, multi.getNotSelected());
+	}
+
+	@Test
+	public void testGetUnselectedAllSelected() {
+		AbstractWMultiSelectList multi = new MyWMultiSelectList(OPTIONS, true);
+		multi.setSelected(OPTIONS);
+		Assert.assertEquals("Expect all options to be selected", EMPTY_LIST, multi.getNotSelected());
+	}
+
+	@Test
+	public void testGetUnselectedNoData() {
+		AbstractWMultiSelectList multi = new MyWMultiSelectList(null, true);
+		Assert.assertEquals("Expect unselected to be an empty collection", Collections.EMPTY_LIST, multi.getNotSelected());
+	}
+
+	@Test
 	public void testGetValueConvertDataToList() {
 		// =======================
 		// ALLOW NONE - TRUE


### PR DESCRIPTION
Added a simple helper to get options which are not selected to AbstractMultiSelectList. I am _not_ inclined to add it to single select lists as it is ridiculous. Fixes #296.

@jonathanaustin please TAL.