### PR TITLE
Fix dialog launch action

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/dialog.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dialog.js
@@ -182,7 +182,7 @@ define(["wc/dom/classList",
 						}
 						classList.add(content, "wc_magic");
 						classList.add(content, "wc_dynamic");
-						eagerLoader.load(content, false, true);
+						eagerLoader.load(content, false, false);
 					}
 					else {
 						console.warn("Could not find dialog content wrapper.");


### PR DESCRIPTION
Reverted getting dialog content from GET to POST as we allow Actions to
be set on the launching WButton and we no longer honour Action on GET. Fixes #389 