### PR TITLE
Tweaks to HTTP response headers of theme resources

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WebUtilities.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WebUtilities.java
@@ -8,6 +8,7 @@ import com.github.bordertech.wcomponents.util.TreeUtil;
 import com.github.bordertech.wcomponents.util.mock.MockRequest;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.URLConnection;
 import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -575,8 +576,10 @@ public final class WebUtilities {
 		String mimeType = config.getString("bordertech.wcomponents.mimeType." + suffix);
 
 		if (mimeType == null) {
-			mimeType = config.getString("bordertech.wcomponents.mimeType.defaultMimeType",
-					"application/octet-stream");
+			mimeType = URLConnection.guessContentTypeFromName(fileName);
+			if (mimeType == null) {
+				mimeType = config.getString("bordertech.wcomponents.mimeType.defaultMimeType", "application/octet-stream");
+			}
 		}
 
 		return mimeType;

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/container/TransformXMLInterceptor.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/container/TransformXMLInterceptor.java
@@ -114,7 +114,7 @@ public class TransformXMLInterceptor extends InterceptorComponent {
 	 */
 	private void transform(final String xml, final UIContext uic, final PrintWriter writer) {
 		String xsltName = ThemeUtil.getThemeXsltName(uic);
-		String resourceName = "/theme/" + ThemeUtil.getThemeName() + "/xslt/" + xsltName;
+		String resourceName = ThemeUtil.getThemeBase() + "xslt/" + xsltName;
 		Transformer transformer = newTransformer(resourceName);
 		Source inputXml;
 		try {

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/ThemeUtil.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/ThemeUtil.java
@@ -46,12 +46,20 @@ public final class ThemeUtil {
 	 */
 	private static final String THEME_WC_BUILD_NUMBER_PARAM = "wc.project.version";
 
+	private static final String THEME_NAME;
+
+	/**
+	 * The base
+	 * This assumes theme names do not change on the fly and a restart is acceptable if they do.
+	 */
+	private static final String THEME_BASE;
+
 	static {
-		// Get theme name
-		String name = getThemeName();
+		THEME_NAME = Config.getInstance().getString(THEME_PARAM);
+		THEME_BASE = "/theme/" + THEME_NAME + '/';
 
 		// Load theme build (depends on the theme name)
-		String resourceName = "/theme/" + name + '/' + THEME_VERSION_FILE_NAME;
+		String resourceName = THEME_BASE + THEME_VERSION_FILE_NAME;
 
 		// Get theme version property file (if in classpath)
 		InputStream resourceStream = null;
@@ -83,7 +91,7 @@ public final class ThemeUtil {
 			THEME_BUILD = themeBuild;
 		}
 
-		LOG.info("Using theme \"" + name + "\"" + " build \"" + THEME_BUILD + "\"");
+		LOG.info("Using theme \"" + THEME_NAME + "\"" + " build \"" + THEME_BUILD + "\"");
 
 		// Check the theme wcomponent version against the project wcomponent version
 		if (themeWcVersion != null) {
@@ -102,10 +110,12 @@ public final class ThemeUtil {
 	}
 
 	/**
+	 * The theme name as determined on instantiation.
+	 * Changes require a restart.
 	 * @return the current theme name
 	 */
 	public static String getThemeName() {
-		return Config.getInstance().getString(THEME_PARAM);
+		return THEME_NAME;
 	}
 
 	/**
@@ -113,6 +123,15 @@ public final class ThemeUtil {
 	 */
 	public static String getThemeBuild() {
 		return THEME_BUILD;
+	}
+
+	/**
+	 * Gets the base path of the theme resources.
+	 * Note that this path will end with a forward slash.
+	 * @return The theme resource path.
+	 */
+	public static String getThemeBase() {
+		return THEME_BASE;
 	}
 
 	/**
@@ -140,11 +159,8 @@ public final class ThemeUtil {
 		path.append(getThemeXsltName(uic));
 
 		// Add cache busting suffix
-		String build = getThemeBuild();
-		String themeName = getThemeName();
-
-		path.append("?build=").append(WebUtilities.escapeForUrl(build))
-				.append("&theme=").append(WebUtilities.escapeForUrl(themeName));
+		path.append("?build=").append(WebUtilities.escapeForUrl(THEME_BUILD))
+				.append("&theme=").append(WebUtilities.escapeForUrl(THEME_NAME));
 
 		return path.toString();
 	}

--- a/wcomponents-core/src/main/resources/com/github/bordertech/wcomponents/mime.properties
+++ b/wcomponents-core/src/main/resources/com/github/bordertech/wcomponents/mime.properties
@@ -8,6 +8,7 @@ bordertech.wcomponents.mimeType.js=application/x-javascript
 bordertech.wcomponents.mimeType.xsl=application/xml+xslt
 bordertech.wcomponents.mimeType.xml=text/xml
 bordertech.wcomponents.mimeType.rdf=application/rdf+xml
+bordertech.wcomponents.mimeType.html=text/html
 
 #Image formats
 bordertech.wcomponents.mimeType.gif=image/gif


### PR DESCRIPTION
Improvements when serving up theme resources:

- `last-modified` header no longer hardcoded
- Removed `content-disposition` header because it is (probably) superfluous and breaks Polymer.
- `content-type` header can now be "guessed" for types that aren't found in the hardcoded properties file.
- Some refactoring for minor performance and maintainability reasons.
