### PR TITLE
#384 table row headers

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTable.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTable.java
@@ -908,6 +908,21 @@ public class WTable extends WBeanComponent implements Container, AjaxTarget, Sub
 	}
 
 	/**
+	 * Set the table as having row headers.
+	 * @param rowHeaders indicates that the first data column in the table should be considered a row header.
+	 */
+	public void setRowHeaders(final boolean rowHeaders) {
+		getOrCreateComponentModel().rowHeaders = rowHeaders;
+	}
+
+	/**
+	 * @return is the first data column a row header column?
+	 */
+	public boolean isRowHeaders() {
+		return getComponentModel().rowHeaders;
+	}
+
+	/**
 	 * Sets whether the "expand all" control should be available.
 	 *
 	 * @param expandAll true if the expand-all control should be available, false if not.
@@ -2104,6 +2119,11 @@ public class WTable extends WBeanComponent implements Container, AjaxTarget, Sub
 
 			constraintForComponent.add(constraint);
 		}
+
+		/**
+		 * Indicates that the first data column in the table is considered a row header.
+		 */
+		private boolean rowHeaders;
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WTableRowRendererRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WTableRowRendererRenderer.java
@@ -64,14 +64,21 @@ final class WTableRowRendererRenderer extends AbstractWebXmlRenderer {
 		xml.appendOptionalAttribute("expandable", rowExpandable && !rowExpanded, "true");
 		xml.appendClose();
 
+		// wrote the column cell.
+		boolean isRowHeader = table.isRowHeaders(); // need this before we get into the loop
 		for (int i = 0; i < numCols; i++) {
 			int colIndex = columnOrder == null ? i : columnOrder[i];
 			WTableColumn col = table.getColumn(colIndex);
+			String cellTag = "ui:td";
 
 			if (col.isVisible()) {
-				xml.appendTag("ui:td");
+				if (isRowHeader) { // The first rendered column will be the row header.
+					cellTag = "ui:th";
+					isRowHeader = false; // only set one col as the row header.
+				}
+				xml.appendTag(cellTag);
 				renderer.getRenderer(colIndex).paint(renderContext);
-				xml.appendEndTag("ui:td");
+				xml.appendEndTag(cellTag);
 			}
 		}
 

--- a/wcomponents-core/src/main/resources/schema/ui/v1/table.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/table.xsd
@@ -498,14 +498,14 @@
 			<xs:element name="th" minOccurs="0">
 				<xs:complexType mixed="true">
 					<xs:sequence>
-						<xs:element ref="ui:decoratedlabel" minOccurs="0"/>
+						<xs:group ref="ui:contentGroup" minOccurs="0" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="td" minOccurs="1" maxOccurs="unbounded">
 				<xs:complexType mixed="true">
 					<xs:sequence>
-						<xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+						<xs:group ref="ui:contentGroup" minOccurs="0" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -517,7 +517,7 @@
 						<xs:element name="content">
 							<xs:complexType mixed="true">
 								<xs:sequence>
-									<xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+									<xs:group ref="ui:contentGroup" minOccurs="0" maxOccurs="unbounded"/>
 								</xs:sequence>
 								<xs:attribute name="spanAllCols" type="xs:boolean"/>
 							</xs:complexType>

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WTable_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WTable_Test.java
@@ -150,6 +150,11 @@ public final class WTable_Test extends AbstractWComponentTestCase {
 	}
 
 	@Test
+	public void testRowHeadersAccessors() {
+		assertAccessorsCorrect(new WTable(), "rowHeaders", false, true, false);
+	}
+
+	@Test
 	public void testNoDataMessageAccessors() {
 		String msg = I18nUtilities.format(null, InternalMessages.DEFAULT_NO_TABLE_DATA);
 		assertAccessorsCorrect(new WTable(), "noDataMessage", msg, "nodata1", "nodata2");

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WTableRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WTableRenderer_Test.java
@@ -526,6 +526,40 @@ public class WTableRenderer_Test extends AbstractWebXmlRendererTestCase {
 	}
 
 	@Test
+	public void testDoPaintOfRowHeaderWithNoRowHeaderColumn() throws IOException, SAXException, XpathException {
+
+		WTable table = new WTable();
+		table.addColumn(new WTableColumn(COL1_HEADING_TEST, WTextField.class));
+		table.addColumn(new WTableColumn(COL2_HEADING_TEST, WTextField.class));
+		table.addColumn(new WTableColumn(COL3_HEADING_TEST, WTextField.class));
+		// no row headers set
+
+		TableModel tableModel = createTableModel();
+		table.setTableModel(tableModel);
+
+		assertSchemaMatch(table);
+		assertXpathNotExists("//ui:table/ui:tbody/ui:tr/ui:th", table);
+	}
+
+	@Test
+	public void testDoPainWithRowHeaderColumn() throws IOException, SAXException, XpathException {
+
+		WTable table = new WTable();
+		table.addColumn(new WTableColumn(COL1_HEADING_TEST, WTextField.class));
+		table.addColumn(new WTableColumn(COL2_HEADING_TEST, WTextField.class));
+		table.addColumn(new WTableColumn(COL3_HEADING_TEST, WTextField.class));
+		// set the first column as the row headers
+		table.setRowHeaders(true);
+
+		TableModel tableModel = createTableModel();
+		table.setTableModel(tableModel);
+
+		assertSchemaMatch(table);
+		assertXpathExists("//ui:table/ui:tbody/ui:tr/ui:th", table);
+		assertXpathNotExists("//ui:table/ui:tbody/ui:tr/ui:th[2]", table);
+	}
+
+	@Test
 	public void testDoPaintSortableSortModeDynamicClientSettings() throws IOException, SAXException,
 			XpathException {
 		WTable component = new WTable();

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/table/WTableOptionsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/table/WTableOptionsExample.java
@@ -155,6 +155,11 @@ public class WTableOptionsExample extends WBeanContainer {
 	private final WCheckBox cbToggleSubRowSelection = new WCheckBox();
 
 	/**
+	 * Use row headers.
+	 */
+	private final WCheckBox cbHasRowHeaders = new WCheckBox();
+
+	/**
 	 * Construct the example.
 	 */
 	public WTableOptionsExample() {
@@ -184,15 +189,6 @@ public class WTableOptionsExample extends WBeanContainer {
 
 		layout.addField("Select Mode", rbsSelect);
 		WField fieldSelectAll = layout.addField("Select All Type", rbsSelectAll);
-		layout.addField("Expand Mode", rbsExpand);
-		layout.addField("Paging Mode", rbsPaging);
-		layout.addField("Striping Type", rbsStriping);
-		layout.addField("Separator Type", rbsSeparator);
-		layout.addField("Sort Mode", rbsSorting);
-		layout.addField("Show col headers", showColHeaders);
-		WField fieldExpandAll = layout.addField("Expand all", expandAll);
-		WField fieldToggleSubRowSelection = layout.addField("Parent row selection controls sub row selection", cbToggleSubRowSelection);
-
 		/* show and hide the row selection sub-options */
 		WSubordinateControl subShowSelectOptions = new WSubordinateControl();
 		Rule rule = new Rule();
@@ -202,6 +198,13 @@ public class WTableOptionsExample extends WBeanContainer {
 		subShowSelectOptions.addRule(rule);
 		add(subShowSelectOptions);
 
+		layout.addField("Expand Mode", rbsExpand);
+		layout.addField("Paging Mode", rbsPaging);
+		layout.addField("Striping Type", rbsStriping);
+		layout.addField("Separator Type", rbsSeparator);
+		layout.addField("Sort Mode", rbsSorting);
+		layout.addField("Show col headers", showColHeaders);
+		WField fieldExpandAll = layout.addField("Expand all", expandAll);
 		/* show and hide the row expansion sub-options */
 		WSubordinateControl subShowExpandOptions = new WSubordinateControl();
 		rule = new Rule();
@@ -211,13 +214,22 @@ public class WTableOptionsExample extends WBeanContainer {
 		subShowExpandOptions.addRule(rule);
 		add(subShowExpandOptions);
 
+		WField fieldToggleSubRowSelection = layout.addField("Parent row selection controls sub row selection", cbToggleSubRowSelection);
+		/* show/hide sub-row selection options */
+		WSubordinateControl subToggler = new WSubordinateControl();
+		rule = new Rule();
+		rule.setCondition(new And(new Equal(rbsSelect, WTable.SelectMode.MULTIPLE), new NotEqual(rbsExpand, WTable.ExpandMode.NONE)));
+		rule.addActionOnTrue(new Show(fieldToggleSubRowSelection));
+		rule.addActionOnFalse(new Hide(fieldToggleSubRowSelection));
+		subToggler.addRule(rule);
+		add(subToggler);
+
 		layout.addField("Editable", chbEditable);
 		layout.addField("Column order", columnOrder);
 		WField fieldRows = layout.addField("Rows per page", numRowsPerPage);
 		WField fieldRowsOptions = layout.addField("Rows per page options", chbRowsPerPageOptions);
 		WField fieldPaginationLocation = layout.addField("Location of pagination controls", paginationControlsLocation);
-		layout.addField("Caption", tfCaption);
-
+		/* show/hide pagination options */
 		WSubordinateControl pagRowsPerPage = new WSubordinateControl();
 		rule = new Rule();
 		rule.setCondition(new Equal(rbsPaging, WTable.PaginationMode.NONE));
@@ -230,13 +242,8 @@ public class WTableOptionsExample extends WBeanContainer {
 		pagRowsPerPage.addRule(rule);
 		add(pagRowsPerPage);
 
-		WSubordinateControl subToggler = new WSubordinateControl();
-		rule = new Rule();
-		rule.setCondition(new And(new Equal(rbsSelect, WTable.SelectMode.MULTIPLE), new NotEqual(rbsExpand, WTable.ExpandMode.NONE)));
-		rule.addActionOnTrue(new Show(fieldToggleSubRowSelection));
-		rule.addActionOnFalse(new Hide(fieldToggleSubRowSelection));
-		subToggler.addRule(rule);
-		add(subToggler);
+		layout.addField("Caption", tfCaption);
+		layout.addField("Use row headers", cbHasRowHeaders);
 
 		// Apply Button
 		WButton apply = new WButton("Apply");
@@ -487,7 +494,8 @@ public class WTableOptionsExample extends WBeanContainer {
 				&& cbToggleSubRowSelection.isSelected()
 				&& rbsExpand.getSelected() != WTable.ExpandMode.NONE
 				&& rbsSelect.getSelected() == WTable.SelectMode.MULTIPLE);
-
+		// row headers
+		table.setRowHeaders(cbHasRowHeaders.isSelected());
 		// Caption
 		if (null == tfCaption.getText() || "".equals(tfCaption.getText())) {
 			table.setCaption(null);

--- a/wcomponents-theme/src/main/js/wc/ui/multiSelectPair.js
+++ b/wcomponents-theme/src/main/js/wc/ui/multiSelectPair.js
@@ -37,7 +37,7 @@ define(["wc/dom/attribute",
 		 * @private
 		 */
 		function MultiSelectPair() {
-			var CONTAINER = new Widget("fieldset", "wc-multiSelectPair"),
+			var CONTAINER = new Widget("fieldset", "wc-multiselectpair"),
 				SELECT = new Widget("select"),
 				CONTAINER_INITIALISED_KEY = "multiSelectPair.inited",
 				LIST_TYPE_AVAILABLE = 0,

--- a/wcomponents-theme/src/main/js/wc/ui/rowAnalog.js
+++ b/wcomponents-theme/src/main/js/wc/ui/rowAnalog.js
@@ -4,15 +4,16 @@
  * @extends module:wc/dom/ariaAnalog
  * @requires module:wc/dom/ariaAnalog
  * @requires module:wc/dom/initialise
- * @requires module:wc/dom/Widget
+ * @requires module:wc/ui/table/common
  */
 define(["wc/dom/ariaAnalog",
 		"wc/dom/initialise",
-		"wc/ui/selectToggle",
 		"wc/ui/table/common"],
 	/** @param ariaAnalog wc/dom/ariaAnalog @param initialise wc/dom/initialise @param table @ignore */
 	function(ariaAnalog, initialise, table) {
 		"use strict";
+
+		/* Unused dependency: selectToggle is required implicitly. It is probably loaded but we cannot be sure. */
 
 		/**
 		 * @constructor

--- a/wcomponents-theme/src/main/js/wc/ui/table/action.js
+++ b/wcomponents-theme/src/main/js/wc/ui/table/action.js
@@ -7,18 +7,16 @@
  * @requires module:wc/dom/event
  * @requires module:wc/dom/getFilteredGroup
  * @requires module:wc/dom/initialise
- * @requires module:wc/dom/Widget
  * @requires module:wc/dom/shed
  * @requires module:wc/ui/table/common
  */
 define(["wc/dom/event",
 		"wc/dom/getFilteredGroup",
 		"wc/dom/initialise",
-		"wc/dom/Widget",
 		"wc/dom/shed",
 		"wc/ui/table/common"],
-	/** @param event wc/dom/event @param getFilteredGroup wc/dom/getFilteredGroup @param initialise wc/dom/initialise @param Widget wc/dom/Widget @param shed wc/dom/shed @param common @ignore */
-	function(event, getFilteredGroup, initialise, Widget, shed, common) {
+	/** @param event wc/dom/event @param getFilteredGroup wc/dom/getFilteredGroup @param initialise wc/dom/initialise @param shed wc/dom/shed @param common @ignore */
+	function(event, getFilteredGroup, initialise, shed, common) {
 		"use strict";
 
 		/**

--- a/wcomponents-theme/src/main/js/wc/ui/table/common.js
+++ b/wcomponents-theme/src/main/js/wc/ui/table/common.js
@@ -4,7 +4,7 @@
  *
  * @requires module:wc/dom/Widget
  */
-require(["wc/dom/Widget"],
+define(["wc/dom/Widget"],
 	/** @param Widget @ignore */
 	function (Widget) {
 		"use strict";

--- a/wcomponents-theme/src/main/sass/wc.ui.label.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.label.scss
@@ -13,8 +13,8 @@ span.wc-label {
 }
 
 // space between a checkable and its label
-[type='radio'] + .wc-label,
-[type='checkbox'] + .wc-label,
+[type='radio'] + label,
+[type='checkbox'] + label,
 .wc_ro + .wc-label {
 	margin-left: $hgap-small;
 }

--- a/wcomponents-theme/src/main/xslt/wc.common.registrationScripts.requiredLibraries.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.registrationScripts.requiredLibraries.xsl
@@ -100,7 +100,7 @@
 					<xsl:text>"wc/ui/table/action",</xsl:text>
 				</xsl:if>
 				<xsl:if test=".//ui:rowselection">
-					<xsl:text>"wc/ui/rowAnalog",</xsl:text>
+					<xsl:text>"wc/ui/rowAnalog"</xsl:text>
 				</xsl:if>
 				<xsl:if test=".//ui:rowexpansion">
 					<xsl:text>"wc/ui/table/rowExpansion",</xsl:text>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.th.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.th.xsl
@@ -43,9 +43,7 @@
 					<xsl:with-param name="indent" select="$indent"/>
 				</xsl:call-template>
 			</xsl:if>
-			<xsl:apply-templates select="ui:decoratedlabel">
-				<xsl:with-param name="output" select="'div'"/>
-			</xsl:apply-templates>
+			<xsl:apply-templates />
 		</th>
 	</xsl:template>
 </xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.tr.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.tr.xsl
@@ -273,7 +273,7 @@
 								<button type="button" aria-haspopup="true" class="wc_btn_nada" id="{$subRowToggleControlButtonId}" aria-controls="{$subRowToggleControlContentId}">
 									<span class="wc_off"><xsl:value-of select="$$${wc.ui.table.string.rowSelection.label}"/></span>
 								</button>
-								<div class="wc_ wc_seltog" role="menu" aria-expanded="false" id="{$subRowToggleControlContentId}" aria-labelledby="{$subRowToggleControlButtonId}">
+								<div class="wc_submenucontent wc_seltog" role="menu" aria-expanded="false" id="{$subRowToggleControlContentId}" aria-labelledby="{$subRowToggleControlButtonId}">
 									<xsl:variable name="allSelectableSubRows" select="count(.//ui:subtr[ancestor::ui:table[1]/@id = $tableId]/ui:tr[not(@unselectable)])"/>
 									<xsl:variable name="allUnselectedSubRows" select="count(.//ui:subtr[ancestor::ui:table[1]/@id = $tableId]/ui:tr[not(@unselectable or @selected)])"/>
 									<xsl:variable name="subRowControlList">


### PR DESCRIPTION
Added support for row headers to WTable. Fixes #384.

Fixed an error in wc/ui/table/common which broke all tables. Fixed a circular dependency  wc/ui/rowAnalog.