### PR TITLE
WTemplate Example, Sass, validation

### DIFF
--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WTemplateExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WTemplateExample.java
@@ -1,0 +1,389 @@
+package com.github.bordertech.wcomponents.examples;
+
+import com.github.bordertech.wcomponents.Action;
+import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.MessageContainer;
+import com.github.bordertech.wcomponents.WButton;
+import com.github.bordertech.wcomponents.WCardManager;
+import com.github.bordertech.wcomponents.WContainer;
+import com.github.bordertech.wcomponents.WDecoratedLabel;
+import com.github.bordertech.wcomponents.WFieldLayout;
+import com.github.bordertech.wcomponents.WLabel;
+import com.github.bordertech.wcomponents.WMessages;
+import com.github.bordertech.wcomponents.WPanel;
+import com.github.bordertech.wcomponents.WPasswordField;
+import com.github.bordertech.wcomponents.WSection;
+import com.github.bordertech.wcomponents.WTemplate;
+import com.github.bordertech.wcomponents.WText;
+import com.github.bordertech.wcomponents.WTextField;
+import com.github.bordertech.wcomponents.examples.common.ExplanatoryText;
+import com.github.bordertech.wcomponents.template.TemplateRendererFactory;
+import com.github.bordertech.wcomponents.validation.Diagnostic;
+import com.github.bordertech.wcomponents.validation.ValidatingAction;
+import java.util.List;
+
+/**
+ * An example of how to use a WTemplate to center a login form.
+ *
+ * @author Mark Reeves
+ * @since 2016-02-22
+ */
+public class WTemplateExample extends WContainer {
+	/**
+	 * A template used to center content.
+	 */
+	private final WTemplate template = new WTemplate("com/github/bordertech/wcomponents/examples/centerAll.moustache", TemplateRendererFactory.TemplateEngine.HANDLEBARS);
+
+	/**
+	 * Create the LoginViewExample.
+	 */
+	public WTemplateExample() {
+		add(template);
+		template.addTaggedComponent("content", new ContentSection());
+	}
+
+	/**
+	 * A {@link WSection} which holds the guts of the example.
+	 * This is added to the template.
+	 */
+	private final class ContentSection extends WSection implements MessageContainer {
+		/**
+		 * The view manager.
+		 */
+		private final WCardManager cardManager = new WCardManager();
+
+		/**
+		 * This section's content container.
+		 */
+		private WPanel contentPanel;
+
+		/**
+		 * A log in form.
+		 */
+		private final LoginFormCard loginForm;
+
+		/**
+		 * A new user form.
+		 */
+		private final NewUserCard newUserForm;
+
+		/**
+		 * A successful log in will show this card.
+		 */
+		private final LoggedInUserCard loggedIn;
+
+		/**
+		 * Adding a user will show this card.
+		 */
+		private final AddedUserCard added;
+
+		/**
+		 * Validation messages.
+		 */
+		private final WMessages messages = new WMessages();
+
+		/**
+		 * Create the main content and card manager for the example.
+		 */
+		public ContentSection() {
+			super(new WPanel(), new WDecoratedLabel());
+
+			loginForm = new LoginFormCard();
+			newUserForm = new NewUserCard();
+			loggedIn = new LoggedInUserCard();
+			added = new AddedUserCard();
+
+			initCard();
+		}
+
+		/**
+		 * Set up the content of the example.
+		 */
+		private void initCard() {
+			contentPanel = getContent();
+			contentPanel.add(messages);
+			contentPanel.add(cardManager);
+
+			/* The login form. */
+			cardManager.add(loginForm);
+			loginForm.getSubmitButton().setAction(new ValidatingAction(messages.getValidationErrors(), contentPanel) {
+				@Override
+				public void executeOnValid(final ActionEvent event) {
+					cardManager.makeVisible(loggedIn);
+					setTitle(loggedIn.getTitle());
+					getDecoratedLabel().setTail(null);
+				}
+			});
+			loginForm.getNavButton().setAction(new Action() {
+				@Override
+				public void execute(final ActionEvent event) {
+					cardManager.makeVisible(newUserForm);
+					setTitle(newUserForm.getTitle());
+					getDecoratedLabel().setTail(newUserForm.getNavButton());
+					messages.reset();
+				}
+			});
+
+			/* The new user form. */
+			cardManager.add(newUserForm);
+			newUserForm.getSubmitButton().setAction(new ValidatingAction(messages.getValidationErrors(), contentPanel) {
+				@Override
+				public void executeOnValid(final ActionEvent event) {
+					cardManager.makeVisible(added);
+					setTitle(added.getTitle());
+					getDecoratedLabel().setTail(null);
+				}
+			});
+			newUserForm.getNavButton().setAction(new Action() {
+				@Override
+				public void execute(final ActionEvent event) {
+					cardManager.makeVisible(loginForm);
+					setTitle(loginForm.getTitle());
+					getDecoratedLabel().setTail(loginForm.getNavButton());
+					messages.reset();
+				}
+			});
+
+			/* The logged in user card. */
+			cardManager.add(loggedIn);
+
+			/* The new user added card. */
+			cardManager.add(added);
+
+			/* The initial state of the card manager. */
+			cardManager.makeVisible(loginForm);
+			setTitle(loginForm.getTitle());
+			getDecoratedLabel().setTail(loginForm.getNavButton());
+		}
+
+		/**
+		 * Set the title of the WSection.
+		 * @param title The title to set.
+		 */
+		public void setTitle(final String title) {
+			this.getDecoratedLabel().setBody(new WText(title));
+		}
+
+		@Override
+		public WMessages getMessages() {
+			return messages;
+		}
+	}
+
+
+	/**
+	 * A card holding the logged in user message.
+	 */
+	private final class LoggedInUserCard extends WContainer {
+
+		/**
+		 * What to call this form.
+		 */
+		private static final String TITLE = "Log in successful";
+
+		/**
+		 * Create a logged in user message card.
+		 */
+		public LoggedInUserCard() {
+			add(new ExplanatoryText("Log in successful"));
+		}
+
+		/**
+		 * @return the card title.
+		 */
+		public String getTitle() {
+			return TITLE;
+		}
+	}
+
+
+	/**
+	 * A card holding the added new user message.
+	 */
+	private final class AddedUserCard extends WContainer {
+
+		/**
+		 * What to call this form.
+		 */
+		private static final String TITLE = "Added successful";
+
+		/**
+		 * Create a logged in user message card.
+		 */
+		public AddedUserCard() {
+			add(new ExplanatoryText("Successfully added user."));
+		}
+
+		/**
+		 * @return the card title.
+		 */
+		public String getTitle() {
+			return TITLE;
+		}
+	}
+
+	/**
+	 * A card holding the log in form.
+	 */
+	private final class LoginFormCard extends WContainer {
+		/**
+		 * A button to navigate to the "create a new user" view.
+		 */
+		private final WButton newUserButton = new WButton("Create a user");
+
+		/**
+		 * The log-in button.
+		 */
+		private final WButton submit = new WButton("Go");
+
+		/**
+		 * What to call this form.
+		 */
+		private static final String TITLE = "Log in form";
+
+		/**
+		 * Create the login form.
+		 */
+		public LoginFormCard() {
+			final WFieldLayout layout = new WFieldLayout();
+			add(layout);
+
+			final WTextField userName = new WTextField();
+			userName.setMandatory(true);
+			userName.setDefaultSubmitButton(submit);
+
+			final WPasswordField password = new WPasswordField();
+			password.setMandatory(true);
+			password.setDefaultSubmitButton(submit);
+
+			layout.addField("User name", userName);
+			layout.addField("Password", password);
+			layout.addField((WLabel) null, submit);
+
+
+			newUserButton.setImage("/image/user.png");
+			newUserButton.setRenderAsLink(true);
+
+		}
+
+		/**
+		 * @return the log in button.
+		 */
+		public WButton getSubmitButton() {
+			return submit;
+		}
+
+
+		/**
+		 * @return the button to go to the new user form.
+		 */
+		public WButton getNavButton() {
+			return newUserButton;
+		}
+
+		/**
+		 * @return the card title.
+		 */
+		public String getTitle() {
+			return TITLE;
+		}
+	}
+
+
+
+	/**
+	 * Create a new user form.
+	 */
+	private final class NewUserCard extends WContainer {
+		/**
+		 * A button to return to the log in screen.
+		 */
+		private final WButton returnToLogInButton = new WButton("Return to log in screen");
+
+		/**
+		 * The create user button.
+		 */
+		private final WButton submit = new WButton("Add");
+
+		/**
+		 * What to call this form.
+		 */
+		private static final String TITLE = "Create account";
+
+		/**
+		 * Password field.
+		 */
+		private final WPasswordField newPassword = new WPasswordField();
+
+		/**
+		 * Repeat the password field.
+		 */
+		private final WPasswordField newPassword2 = new WPasswordField();
+
+		/**
+		 * Make the New user form.
+		 */
+		public NewUserCard() {
+			WFieldLayout layout = new WFieldLayout();
+			add(layout);
+
+			WTextField newUserName = new WTextField();
+			newUserName.setMandatory(true);
+			newUserName.setMinLength(3);
+			newUserName.setMaxLength(16);
+			newUserName.setDefaultSubmitButton(submit);
+			layout.addField("User name", newUserName).getLabel().setHint("User name must be between 3 and 16 characters.");
+
+			newPassword.setMandatory(true);
+			newPassword.setMinLength(3);
+			newPassword.setMaxLength(16);
+			newPassword.setDefaultSubmitButton(submit);
+			layout.addField("Password", newPassword).getLabel().setHint("Password must be between 3 and 16 characters.");
+
+			newPassword2.setMandatory(true);
+			newPassword2.setMinLength(3);
+			newPassword2.setMaxLength(16);
+			newPassword2.setDefaultSubmitButton(submit);
+			layout.addField("Repeat password", newPassword2);
+
+			layout.addField((WLabel) null, submit);
+
+			returnToLogInButton.setImage("/image/home.png");
+			returnToLogInButton.setRenderAsLink(true);
+		}
+
+		@Override
+		protected void validateComponent(final List<Diagnostic> diags) {
+			super.validateComponent(diags); //To change body of generated methods, choose Tools | Templates.
+			String text1 = newPassword.getText();
+			String text2 = newPassword2.getText();
+
+			if (text1 == null || !text1.equals(text2)) {
+				diags.add(createErrorDiagnostic(newPassword2, "Passwords must be the same."));
+			}
+		}
+
+
+
+		/**
+		 * @return the add user button.
+		 */
+		public WButton getSubmitButton() {
+			return submit;
+		}
+
+		/**
+		 * @return the return to log-in screen button.
+		 */
+		public WButton getNavButton() {
+			return returnToLogInButton;
+		}
+
+		/**
+		 * @return the card title.
+		 */
+		public String getTitle() {
+			return TITLE;
+		}
+	}
+}

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/common/ClientValidationTemplate.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/common/ClientValidationTemplate.java
@@ -1,0 +1,20 @@
+package com.github.bordertech.wcomponents.examples.common;
+
+import com.github.bordertech.wcomponents.WTemplate;
+import com.github.bordertech.wcomponents.template.TemplateRendererFactory;
+
+/**
+ * Creates a simple template to include some JavaScript to enable client side validation.
+ *
+ * @author exbtma
+ */
+public class ClientValidationTemplate extends WTemplate {
+
+	/**
+	 * Create a Client ValidationTemplate.
+	 */
+	public ClientValidationTemplate() {
+		super("com/github/bordertech/wcomponents/examples/clientValidation.txt", TemplateRendererFactory.TemplateEngine.PLAINTEXT);
+		setVisible(false);
+	}
+}

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/picker/ExampleData.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/picker/ExampleData.java
@@ -59,6 +59,7 @@ import com.github.bordertech.wcomponents.examples.WSingleSelectExample;
 import com.github.bordertech.wcomponents.examples.WSkipLinksExample;
 import com.github.bordertech.wcomponents.examples.WStyledTextOptionsExample;
 import com.github.bordertech.wcomponents.examples.WSuggestionsExample;
+import com.github.bordertech.wcomponents.examples.WTemplateExample;
 import com.github.bordertech.wcomponents.examples.WTextExample;
 import com.github.bordertech.wcomponents.examples.WTimeoutWarningDefaultExample;
 import com.github.bordertech.wcomponents.examples.WTimeoutWarningExample;
@@ -206,8 +207,11 @@ public final class ExampleData implements Serializable {
 		new ExampleData("Lazy Panel", AjaxWPanelExample.class),
 		new ExampleData("RadioButtonSelect", AjaxWRadioButtonSelectExample.class),
 		new ExampleData("Repeater", AjaxWRepeaterExample.class),
+		new ExampleData("Suggestions", WSuggestionsExample.class),
+		new ExampleData("WDataListServer", WDataListServletExample.class),
 		new ExampleData("Multi pollers", MultiPollingExample.class),
-		new ExampleData("Suggestions", WSuggestionsExample.class)
+		new ExampleData("Load AJAX controls via AJAX", LoadAjaxControlsExample.class),
+		new ExampleData("Ajax controllers replaced via ajax", AjaxReplaceControllerExample.class)
 	};
 
 	/**
@@ -218,11 +222,11 @@ public final class ExampleData implements Serializable {
 		new ExampleData("Button", WButtonExample.class),
 		new ExampleData("Button action example", WButtonActionExample.class),
 		new ExampleData("Button configuration options", ButtonOptionsExample.class),
-		new ExampleData("WButton default submit", WButtonDefaultSubmitExample.class),
+		new ExampleData("Button default submit", WButtonDefaultSubmitExample.class),
 		new ExampleData("Cancel button", WCancelButtonExample.class),
-		new ExampleData("WCheckBox", WCheckBoxExample.class),
+		new ExampleData("CheckBox", WCheckBoxExample.class),
 		new ExampleData("Checkbox (action on change)", WCheckBoxTriggerActionExample.class),
-		new ExampleData("WCheckBoxSelect", WCheckBoxSelectExample.class),
+		new ExampleData("CheckBoxSelect", WCheckBoxSelectExample.class),
 		new ExampleData("Confirmation button", WConfirmationButtonExample.class),
 		new ExampleData("Date field", WDateFieldExample.class),
 		new ExampleData("Dropdown", WDropdownExample.class),
@@ -243,16 +247,16 @@ public final class ExampleData implements Serializable {
 		new ExampleData("Multi-text field", WMultiTextFieldExample.class),
 		new ExampleData("Partial date field", WPartialDateFieldExample.class),
 		new ExampleData("Phone Number Field", WPhoneNumberFieldExample.class),
-		new ExampleData("WRadioButton", WRadioButtonExample.class),
-		new ExampleData("Radiobutton (action on change)", WRadioButtonTriggerActionExample.class),
-		new ExampleData("Radiobutton in a repeater", WRadioButtonInRepeater.class),
-		new ExampleData("Radiobutton select", WRadioButtonSelectExample.class),
-		new ExampleData("Single Select", WSingleSelectExample.class),
-		new ExampleData("Text Area", TextAreaExample.class),
-		new ExampleData("Text Field", TextFieldExample.class),
+		new ExampleData("RadioButton", WRadioButtonExample.class),
+		new ExampleData("RadioButton (action on change)", WRadioButtonTriggerActionExample.class),
+		new ExampleData("RadioButton in a repeater", WRadioButtonInRepeater.class),
+		new ExampleData("RadioButtonSelect", WRadioButtonSelectExample.class),
 		new ExampleData("Select toggle", WSelectToggleExample.class),
 		new ExampleData("Shuffler", WShufflerExample.class),
-		new ExampleData("Simple Cancel Button", SimpleCancelButtonExample.class)
+		new ExampleData("Simple Cancel Button", SimpleCancelButtonExample.class),
+		new ExampleData("Single Select", WSingleSelectExample.class),
+		new ExampleData("Text Area", TextAreaExample.class),
+		new ExampleData("Text Field", TextFieldExample.class)
 	};
 
 	/**
@@ -262,17 +266,20 @@ public final class ExampleData implements Serializable {
 		new ExampleData("Abbreviations", WAbbrTextExample.class),
 		new ExampleData("Access keys", AccessKeyExample.class),
 		new ExampleData("Audio", WAudioExample.class),
+		new ExampleData("Dynamic images", WImageCachedExample.class),
+		new ExampleData("Figure", WFigureExample.class),
 		new ExampleData("Headings", WHeadingExample.class),
 		new ExampleData("Images", WImageExample.class),
 		new ExampleData("Message Box", WMessageBoxExample.class),
 		new ExampleData("Messages", WMessagesExample.class),
 		new ExampleData("Progress bar", WProgressBarExample.class),
+		// new ExampleData("Session timeout", WSessionExample.class),
+		new ExampleData("Styled Text options", WStyledTextOptionsExample.class),
 		new ExampleData("Text", WTextExample.class),
-		new ExampleData("Video", WVideoExample.class),
-		new ExampleData("Session timeout", WSessionExample.class),
-		new ExampleData("WTimeoutWarning", WTimeoutWarningExample.class),
-		new ExampleData("WTimeoutWarning default options", WTimeoutWarningDefaultExample.class),
-		new ExampleData("WTimeoutWarning options", WTimeoutWarningOptionsExample.class)
+		new ExampleData("Timeout Warning", WTimeoutWarningExample.class),
+		new ExampleData("Timeout Warning default options", WTimeoutWarningDefaultExample.class),
+		new ExampleData("TimeoutWarning options", WTimeoutWarningOptionsExample.class),
+		new ExampleData("Video", WVideoExample.class)
 	};
 
 	/**
@@ -282,8 +289,7 @@ public final class ExampleData implements Serializable {
 		new ExampleData("Basic WDataTable", WDataTableExample.class),
 		new ExampleData("Table with row selection", SelectableDataTableExample.class),
 		new ExampleData("Editable table", SimpleEditableDataTableExample.class),
-		new ExampleData("Editable table with per-cell editability",
-		SimpleRowEditingTableExample.class),
+		new ExampleData("Editable table with per-cell editability", SimpleRowEditingTableExample.class),
 		new ExampleData("Table cell action", TableCellWithActionExample.class),
 		new ExampleData("Data Table (bean)", DataTableBeanExample.class),
 		new ExampleData("Tree table", TreeTableExample.class),
@@ -331,8 +337,6 @@ public final class ExampleData implements Serializable {
 		new ExampleData("Forward example", ForwardExample.class),
 		new ExampleData("Html injector", HtmlInjector.class),
 		new ExampleData("InfoDump", InfoDump.class),
-		new ExampleData("Load AJAX controls via AJAX", LoadAjaxControlsExample.class),
-		new ExampleData("Ajax controllers replaced via ajax", AjaxReplaceControllerExample.class),
 		new ExampleData("Internationalisation", I18nExample.class),
 		new ExampleData("Kitchen sink", KitchenSink.class),
 		new ExampleData("Pattern validation", PatternValidationExample.class),
@@ -342,12 +346,9 @@ public final class ExampleData implements Serializable {
 		new ExampleData("Text duplicator (Velocity2)", TextDuplicatorVelocity2.class),
 		new ExampleData("WApplication", WApplicationExample.class),
 		new ExampleData("WContent", WContentExample.class),
-		new ExampleData("WDataListServer", WDataListServletExample.class),
 		new ExampleData("WHiddenComment", WHiddenCommentExample.class),
 		new ExampleData("Input bean binding", InputBeanBindingExample.class),
-		new ExampleData("White space example", WhiteSpaceExample.class),
-		new ExampleData("WStyledText options", WStyledTextOptionsExample.class),
-		new ExampleData("Dynamic images", WImageCachedExample.class)
+		new ExampleData("White space example", WhiteSpaceExample.class)
 	};
 
 	/**
@@ -382,20 +383,20 @@ public final class ExampleData implements Serializable {
 		new ExampleData("List layout", ListLayoutExample.class),
 		new ExampleData("List layout options", ListLayoutOptionExample.class),
 		new ExampleData("Margins", MarginExample.class),
-		new ExampleData("WCollapsible", WCollapsibleExample.class),
-		new ExampleData("WCollapsible group", WCollapsibleGroupExample.class),
-		new ExampleData("WColumnLayout", WColumnLayoutExample.class),
-		new ExampleData("WDefinitionList", WDefinitionListExample.class),
-		new ExampleData("WFieldLayout", WFieldLayoutExample.class),
-		new ExampleData("WField nested", WFieldNestedExample.class),
-		new ExampleData("WFieldSet", WFieldSetExample.class),
-		new ExampleData("WList", WListExample.class),
-		new ExampleData("WList configuration options", WListOptionsExample.class),
-		new ExampleData("WPanel margins", WPanelMarginExample.class),
-		new ExampleData("WPanel types", WPanelExample.class),
+		new ExampleData("Collapsible", WCollapsibleExample.class),
+		new ExampleData("Collapsible group", WCollapsibleGroupExample.class),
+		// new ExampleData("ColumnLayout", WColumnLayoutExample.class),
+		new ExampleData("Definition List", WDefinitionListExample.class),
+		new ExampleData("Field Layout", WFieldLayoutExample.class),
+		new ExampleData("Field nested", WFieldNestedExample.class),
+		new ExampleData("FieldSet", WFieldSetExample.class),
+		new ExampleData("List", WListExample.class),
+		new ExampleData("List configuration options", WListOptionsExample.class),
+		new ExampleData("Panel margins", WPanelMarginExample.class),
+		new ExampleData("Panel types", WPanelExample.class),
 		new ExampleData("Panel dynamic type", WPanelTypeExample.class),
-		new ExampleData("WSection", WSectionExample.class),
-		new ExampleData("WFigure", WFigureExample.class)
+		new ExampleData("Section", WSectionExample.class),
+		new ExampleData("Template", WTemplateExample.class)
 	};
 
 	/**
@@ -411,10 +412,10 @@ public final class ExampleData implements Serializable {
 	 * Menu examples.
 	 */
 	public static final ExampleData[] MENU_EXAMPLES = new ExampleData[]{
-		new ExampleData("Menu bar", MenuBarExample.class),
-		new ExampleData("Tree menu", TreeMenuExample.class),
+		new ExampleData("Bar Menu", MenuBarExample.class),
 		new ExampleData("Column menu", ColumnMenuExample.class),
 		new ExampleData("Flyout menu", MenuFlyoutExample.class),
+		new ExampleData("Tree menu", TreeMenuExample.class),
 		new ExampleData("Menu action messages", MenuItemActionMessagesExample.class),
 		new ExampleData("Menu Select Mode", WMenuSelectModeExample.class)
 	};

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/validation/ValidationExamples.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/validation/ValidationExamples.java
@@ -8,7 +8,7 @@ import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WFieldLayout;
 import com.github.bordertech.wcomponents.WLabel;
 import com.github.bordertech.wcomponents.WTabSet;
-import com.github.bordertech.wcomponents.WText;
+import com.github.bordertech.wcomponents.examples.common.ClientValidationTemplate;
 import com.github.bordertech.wcomponents.examples.validation.basic.BasicFieldLayoutValidationExample;
 import com.github.bordertech.wcomponents.examples.validation.basic.BasicFieldsValidationExample;
 import com.github.bordertech.wcomponents.examples.validation.fields.FieldValidation;
@@ -22,17 +22,16 @@ import com.github.bordertech.wcomponents.validation.WValidationErrors;
  * @author Adam Millard
  */
 public class ValidationExamples extends WContainer {
+
 	/**
-	 * Use client validation?
+	 * Toggle whether to use client validation.
 	 */
 	private final WCheckBox useClientValidation = new WCheckBox();
 
 	/**
-	 * Include the client side validation scripts.
+	 * Template to include client validation.
 	 */
-	private final WText csvJs = new WText("<script type=\"text/javascript\" defer=\"defer\">\n"
-		+ "require([\"wc/compat/compat!\"], function(){\n\trequire([\"wc/ui/validation/all\"]);});\n"
-		+ "</script>\n");
+	private final ClientValidationTemplate jsPlainTextTemplate = new ClientValidationTemplate();
 
 	private final WButton btnApplySettings =  new WButton("Apply");
 
@@ -40,13 +39,11 @@ public class ValidationExamples extends WContainer {
 	 * Creates a ValidationExamples.
 	 */
 	public ValidationExamples() {
-		csvJs.setEncodeText(false);
-		csvJs.setVisible(false);
 
 		btnApplySettings.setAction(new ValidatingAction(new WValidationErrors(), btnApplySettings) {
 			@Override
 			public void executeOnValid(final ActionEvent event) {
-				csvJs.setVisible(useClientValidation.isSelected());
+				jsPlainTextTemplate.setVisible(useClientValidation.isSelected());
 			}
 		});
 
@@ -64,6 +61,6 @@ public class ValidationExamples extends WContainer {
 		tabs.addTab(new FieldValidation(), "All Fields", WTabSet.TAB_MODE_LAZY);
 
 		add(tabs);
-		add(csvJs);
+		add(jsPlainTextTemplate);
 	}
 }

--- a/wcomponents-examples/src/main/resources/com/github/bordertech/wcomponents/examples/centerAll.moustache
+++ b/wcomponents-examples/src/main/resources/com/github/bordertech/wcomponents/examples/centerAll.moustache
@@ -1,0 +1,46 @@
+<div class="moustache-center-content">
+<div class="content-wrapper">
+{{content}}
+</div>
+</div>
+<style type="text/css" scoped="scoped">
+	.moustache-center-content {
+		display: -webkit-flex;
+		display: flex;
+		-webkit-align-items: center;
+		align-items: center;
+		-webkit-justify-content: center;
+		justify-content: center;
+		margin: 1em auto;
+		height: 100%;
+		min-height: 20em;
+		background-color: #e0e0e0;
+	}
+
+	.content-wrapper {
+		width: 30em;
+		max-width: 90%;
+		margin: 0 auto;
+	}
+
+	.content-wrapper > section {
+		background-color: #fff;
+	}
+
+	@media only-screen and (max-width: 768px) {
+		.moustache-center-content {
+			margin: 0;
+		}
+
+		.content-wrapper {
+			max-width: 100%;
+			margin: 0;
+		}
+	}
+
+	@media only-screen and (max-height: 640px) {
+		.moustache-center-content {
+			min-height: 0;
+		}
+	}
+</style>

--- a/wcomponents-examples/src/main/resources/com/github/bordertech/wcomponents/examples/clientValidation.txt
+++ b/wcomponents-examples/src/main/resources/com/github/bordertech/wcomponents/examples/clientValidation.txt
@@ -1,0 +1,5 @@
+<script type="text/javascript" defer="defer">
+require(["wc/compat/compat!"], function() {
+	require(["wc/ui/validation/all"]);
+});
+</script>

--- a/wcomponents-theme/src/main/sass/mixins_common.scss
+++ b/wcomponents-theme/src/main/sass/mixins_common.scss
@@ -178,11 +178,21 @@
 // Allow duplicate width declarations
 // scss-lint:disable DuplicateProperty
 /// Size a container to fit its content.
-@mixin fit-content {
-	width: auto;
-	width: -webkit-fit-content;
-	width: -moz-fit-content;
-	width: fit-content;
+@mixin fit-content($imp: 0) {
+	@if ($imp == 0) {
+		width: auto;
+		width: -webkit-fit-content;
+		width: -moz-fit-content;
+		width: fit-content;
+	}
+	@else {
+		// Important needed for some reason!
+		// scss-lint:disable ImportantRule
+		width: auto !important;
+		width: -webkit-fit-content !important;
+		width: -moz-fit-content !important;
+		width: fit-content !important;
+	}
 }
 // scss-lint:enable DuplicateProperty
 

--- a/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.scss
@@ -15,19 +15,6 @@ ul.wc-fieldlayout {
 		margin-top: $vgap-normal;
 	}
 
-	> :first-child,
-	> .wc-input {
-		@include respond(phonelike) {
-			// important to override inline CSS from XSLT
-			//scss-lint:disable ImportantRule
-			@include border-box;
-			display: block;
-			margin-left: 0 !important;
-			max-width: 100% !important;
-			width: 100% !important;
-		}
-	}
-
 	// Flat is the most common use, but shouldn't be (due to a11y concerns which are not covered by WCAG 2.0)
 	.flat > & {
 		> * {
@@ -37,22 +24,8 @@ ul.wc-fieldlayout {
 
 		> :first-child { //the first child is the label or standing or merely an empty placeholder/spacer
 			width: $label-width;
-
-			> .wc_req { // Position the required marker next to the input.
-				@include border-box;
-				padding-right: 1em; //Padding right is for the required marker.
-				position: relative;
-
-				// The excessive depth here could be re-written I suppose...
-				// scss-lint:disable NestingDepth
-				&:after { // this is the required marker
-					position: absolute;
-					right: 0;
-					top: 0;
-				}
-				// scss-lint:enable NestingDepth
-			}
 		}
+
 		> .wc-input {
 			max-width: $input-width;
 			width: $input-width;
@@ -95,7 +68,19 @@ ul.wc-fieldlayout {
 }
 
 @include respond(phonelike) {
-	.flat > .wc-field > .wc_fld_pl { //this is the placeholder for a null or moved label (moved for checkbox or radio). Remove on narrow viewports.
-		display: none;
+	.flat > .wc-field {
+		> :first-child,
+		> .wc-input {
+			// important to override inline CSS from XSLT
+			//scss-lint:disable ImportantRule
+			@include fit-content($imp: 1);
+			display: block;
+			margin-left: 0 !important;
+			max-width: 100% !important;
+		}
+
+		> .wc_fld_pl { //this is the placeholder for a null or moved label (moved for checkbox or radio). Remove on narrow viewports.
+			display: none;
+		}
 	}
 }


### PR DESCRIPTION
* Added an example using WTemplate (Handlebars) (additional for #94).* Fixed an error in the Sass for WFieldLayout as responsive overrides were incorrect (#344).
* Moved client validation plugin.
  * Added requirejs i18n module.
  * Added client side validation option to validation example.
  * Removed build of “plugins”.
* Updated i18n Example to implement optional client validation to test i18n of client validation.
* Changed the client side validation examples to use WTemplate instead of WText (#94).
