### PR TITLE
WTree XSLT & Schema

### DIFF
--- a/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.common.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.common.xsd
@@ -34,11 +34,8 @@
 		</xs:attribute>
 	</xs:attributeGroup>
 
-
-
-
 	<xs:attributeGroup name="ajax.mode.attributes">
-		<xs:attribute name="mode" use="required">
+		<xs:attribute name="mode" default="client">
 			<xs:annotation>
 				<xs:documentation>
 					Indicates the content display mode for the component.
@@ -80,10 +77,12 @@
 					<xs:enumeration value="server">
 						<xs:annotation>
 							<xs:documentation>
-								The content is not part of the page's XML unless it is in a visible (open) state and a
-								user action to display the content will result in the entire application POSTing to the
-								server application. This mode is deprecated for all implementing components and should
-								be avoided as it poses significant user interaction problems.
+								<p>This mode is being phased out and is only present for backwards compatibility.</p>
+								<p>Components may not support this mode.</p>
+								<p>The content is not part of the page's XML unless it is in a visible (open) state and
+									a user action to display the content will result in the entire application POSTing 
+									to the server application. This mode is deprecated for all implementing components 
+									and should be avoided as it poses significant user interaction problems.</p>
 							</xs:documentation>
 						</xs:annotation>
 					</xs:enumeration>
@@ -91,8 +90,6 @@
 			</xs:simpleType>
 		</xs:attribute>
 	</xs:attributeGroup>
-
-
 
 	<xs:attributeGroup name="ajax.mode.simple.attributes">
 		<xs:attribute name="mode">

--- a/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.control.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.control.xsd
@@ -6,6 +6,7 @@
 		Attribute groups used by interactive controls.
 	-->
 	<xs:include schemaLocation="attributeGroups.common.xsd"/>
+	<xs:include schemaLocation="attributeGroups.container.xsd"/>
 
 	<xs:attributeGroup name="interaction.attributes">
 		<xs:annotation>
@@ -13,20 +14,7 @@
 				Common attributes for interactive components.
 			</xs:documentation>
 		</xs:annotation>
-		<xs:attribute name="id" type="xs:ID" use="required">
-			<xs:annotation>
-				<xs:documentation>
-					The unique identifier for the component.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="class" type="xs:string">
-			<xs:annotation>
-				<xs:documentation>
-					Provides the ability to pass an HTML class attribute onto the root output element.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
+		<xs:attributeGroup ref="ui:container.attributes"/>
 		<xs:attribute name="disabled" type="xs:boolean" default="false">
 			<xs:annotation>
 				<xs:documentation>
@@ -34,23 +22,7 @@
 				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute name="hidden" type="xs:boolean" default="false">
-			<xs:annotation>
-				<xs:documentation>
-					The component will be in a hidden state if "true".
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="track" type="xs:boolean" default="false">
-			<xs:annotation>
-				<xs:documentation>
-					Indicates that the component should take part in web analytics tracking.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
 	</xs:attributeGroup>
-
-
 
 	<xs:attributeGroup name="control.attributes">
 		<xs:annotation>
@@ -70,8 +42,6 @@
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>
-
-
 
 	<xs:attributeGroup name="input.attributes">
 		<xs:annotation>

--- a/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.tree.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/attributeGroups.tree.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+	<xs:attributeGroup name="tree.mode.attributes">
+
+		<xs:attribute name="mode" default="client">
+			<xs:annotation>
+				<xs:documentation>Provides the mode for expanding rows.</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:NMTOKEN">
+					<xs:enumeration value="client">
+						<xs:annotation>
+							<xs:documentation>
+								The content exists in the page and showing/hiding that content is purely a client-side 
+								process.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+					<xs:enumeration value="dynamic">
+						<xs:annotation>
+							<xs:documentation>
+								The content is fetched from the server using AJAX each time the content is displayed.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+					<xs:enumeration value="lazy">
+						<xs:annotation>
+							<xs:documentation>
+								The content is fetched from the server the first time the content is displayed then 
+								remains static for the rest fo the lifecycle of the page.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+					<xs:enumeration value="server">
+						<xs:annotation>
+							<xs:documentation>
+								<p>The content is not part of the page's XML unless it is in a visible (open) state and
+									a user action to display the content will result in the entire application POSTing
+									to the server application.</p>
+								<p>This mode only available for backwards compatibilty with WDataTable and <strong>must
+									not</strong> be implemented for any other purpose.</p>
+							</xs:documentation>
+						</xs:annotation>
+					</xs:enumeration>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:attributeGroup>
+</xs:schema>

--- a/wcomponents-core/src/main/resources/schema/ui/v1/table.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/table.xsd
@@ -7,6 +7,7 @@
 	<xs:include schemaLocation="ajaxTrigger.xsd"/>
 	<xs:include schemaLocation="margin.xsd"/>
 	<xs:include schemaLocation="attributeGroups.control.xsd"/>
+	<xs:include schemaLocation="attributeGroups.tree.xsd"/>
 
 	<xs:element name="table">
 		<xs:annotation>
@@ -176,9 +177,9 @@
 						<xs:documentation>Provides information regarding table row selection. Presence of this element indicates that a table may have selectable rows.</xs:documentation>
 					</xs:annotation>
 					<xs:complexType>
-						<xs:attribute name="multiple" type="xs:boolean">
+						<xs:attribute name="multiple" type="xs:boolean" default="false">
 							<xs:annotation>
-								<xs:documentation>Indicates that more than one row may be selected at a time in a manner similar to a group of check boxes. Not output if "false".</xs:documentation>
+								<xs:documentation>Indicates that more than one row may be selected at a time in a manner similar to a group of check boxes.</xs:documentation>
 							</xs:annotation>
 						</xs:attribute>
 						<xs:attribute name="groupName" type="xs:string">
@@ -220,36 +221,7 @@
 						<xs:documentation>Provides information regarding table row expansion. Presence of this element indicates that a table may have expandable rows.</xs:documentation>
 					</xs:annotation>
 					<xs:complexType>
-						<xs:attribute name="mode" use="required">
-							<xs:annotation>
-								<xs:documentation>Provides the mode for expanding rows.</xs:documentation>
-							</xs:annotation>
-							<xs:simpleType>
-								<xs:restriction base="xs:NMTOKEN">
-									<xs:enumeration value="client">
-										<xs:annotation>
-											<xs:documentation>The content exists in the page and showing/hiding that content is purely a client-side process.</xs:documentation>
-										</xs:annotation>
-									</xs:enumeration>
-									<xs:enumeration value="dynamic">
-										<xs:annotation>
-											<xs:documentation>The content is fetched from the server using AJAX each time the content is displayed.</xs:documentation>
-										</xs:annotation>
-									</xs:enumeration>
-									<xs:enumeration value="lazy">
-										<xs:annotation>
-											<xs:documentation>The content is fetched from the server the first time the content is displayed then remains static for the rest fo the lifecycle of the page.</xs:documentation>
-										</xs:annotation>
-									</xs:enumeration>
-									<xs:enumeration value="server">
-										<xs:annotation>
-											<xs:documentation>The content is not part of the page's XML unless it is in a visible (open) state and a user action to display the content will result in the entire
-												application POSTing to the server application. This mode is deprecated and is available only for backwards compatibilty with a deprecated form of the table component.</xs:documentation>
-										</xs:annotation>
-									</xs:enumeration>
-								</xs:restriction>
-							</xs:simpleType>
-						</xs:attribute>
+						<xs:attributeGroup ref="ui:tree.mode.attributes"/>
 						<xs:attribute name="expandAll" type="xs:boolean">
 							<xs:annotation>
 								<xs:documentation>Indicates that a control should be provided to allow the user to expand or collapse all available expandable rows.</xs:documentation>

--- a/wcomponents-core/src/main/resources/schema/ui/v1/tree.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/tree.xsd
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" 
-	targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" 
-	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0">
 
 	<xs:include schemaLocation="attributeGroups.control.xsd"/>
+	<xs:include schemaLocation="attributeGroups.tree.xsd"/>
 	<xs:include schemaLocation="treeItem.xsd"/>
 	<xs:include schemaLocation="margin.xsd"/>
 
@@ -44,6 +43,15 @@
 
 			<xs:attributeGroup ref="ui:interaction.attributes"/>
 
+			<xs:attributeGroup ref="ui:tree.mode.attributes">
+				<xs:annotation>
+					<xs:documentation>
+						<p>Indicates the open mode for branches in the tree.</p>
+						<p>The mode of 'server' is <strong>not</strong> to be implemented.</p>
+					</xs:documentation>
+				</xs:annotation>
+			</xs:attributeGroup>
+
 			<xs:attribute name="htree" type="xs:boolean" default="false">
 				<xs:annotation>
 					<xs:documentation>
@@ -51,41 +59,21 @@
 					</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
-			<xs:attribute name="rows" type="xs:positiveInteger">
+
+			<xs:attribute name="multiple" type="xs:boolean" default="false">
 				<xs:annotation>
 					<xs:documentation>
-						The number of rows to display for a htree. Ignored if htree is not "true".
-					</xs:documentation>
+						Indicates that more than one item may be selected at a time in a manner similar to a group of 
+						check boxes.</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
-			<xs:attribute name="selectMode" default="single">
+
+			<xs:attribute name="required" type="xs:boolean" default="false">
 				<xs:annotation>
 					<xs:documentation>
-						Indicates the manner in which the items in the tree may be "selected". Only applies if @htree is
-						not "true" as a horizontal tree is <strong>always</strong> multi-select.
+						The component will be mandatory if "true".
 					</xs:documentation>
 				</xs:annotation>
-				<xs:simpleType>
-					<xs:restriction base="xs:NMTOKEN">
-						<xs:enumeration value="single">
-							<xs:annotation>
-								<xs:documentation>
-									Indicates that selection is exclusive and when selecting any selectable descendant 
-									node any previously selected nodes will be deselected. This is analogous to a HTML
-									select element in the single select state.
-								</xs:documentation>
-							</xs:annotation>
-						</xs:enumeration>
-						<xs:enumeration value="multiple">
-							<xs:annotation>
-								<xs:documentation>
-									Indicates that selection is not exclusive and multiple child treeItem elements may 
-									be selected. This is analogous to a HTML select element in a multiple select state.
-								</xs:documentation>
-							</xs:annotation>
-						</xs:enumeration>
-					</xs:restriction>
-				</xs:simpleType>
 			</xs:attribute>
 		</xs:complexType>
 	</xs:element>

--- a/wcomponents-core/src/main/resources/schema/ui/v1/treeItem.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/treeItem.xsd
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" 
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+	elementFormDefault="qualified" 
 	targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0"
 	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0">
-	<xs:include schemaLocation="attributeGroups.button.xsd" />
+
 	<xs:element name="treeitem">
 		<xs:complexType>
 			<xs:annotation>
@@ -51,9 +52,15 @@
 			<xs:sequence>
 				<xs:element ref="ui:treeitem" minOccurs="0" maxOccurs="unbounded"/>
 			</xs:sequence>
-
-			<xs:attributeGroup ref="ui:control.attributes" />
-			<xs:attributeGroup ref="ui:button.menu.attributes" />
+			
+			<xs:attribute name="id" type="xs:ID" use="required">
+				<xs:annotation>
+					<xs:documentation>
+						The unique identifier for the component.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			
 			<xs:attribute name="label" type="xs:string" use="required">
 				<xs:annotation>
 					<xs:documentation>
@@ -61,37 +68,13 @@
 					</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
+			
 			<xs:attribute name="imageUrl" type="xs:anyURI">
 				<xs:annotation>
 					<xs:documentation>The location of an image to display in the control.</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
-			<xs:attribute name="url" type="xs:anyURI">
-				<xs:annotation>
-					<xs:documentation>
-						Setting a url indicates that actioning this item should trigger navigation. This attribute and 
-						@submit are mutually exclusive.
-					</xs:documentation>
-				</xs:annotation>
-			</xs:attribute>
-			<xs:attribute name="targetWindow" type="xs:NMTOKEN">
-				<xs:annotation>
-					<xs:documentation>
-						Provides a machine-readable reference to a browser window. If set, and the @url attribute is 
-						set, then the link to the @url value will open in a new window with this as its window name. 
-						There are some implementation issues caused by long standing bugs in some common user agents and
-						some keywords in the HTML specification.
-					</xs:documentation>
-				</xs:annotation>
-			</xs:attribute>
-			<xs:attribute name="submit" type="xs:boolean" default="false">
-				<xs:annotation>
-					<xs:documentation>
-						Setting submit indicates that actioning this item should trigger a form submit. This attribute
-						and @url are mutually exclusive.
-					</xs:documentation>
-				</xs:annotation>
-			</xs:attribute>
+			
 			<xs:attribute name="selected" type="xs:boolean" default="false">
 				<xs:annotation>
 					<xs:documentation>
@@ -99,7 +82,16 @@
 					</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
-			<xs:attribute name="expanded" type="xs:boolean" default="false">
+			
+			<xs:attribute name="expandable" type="xs:boolean" default="false">
+				<xs:annotation>
+					<xs:documentation>
+						Indicates that the treeitem is exapndable: either has treeitem children or has AJAX children.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			
+			<xs:attribute name="open" type="xs:boolean" default="false">
 				<xs:annotation>
 					<xs:documentation>
 						"true" indicates that the submenu is expanded. Not output if "false". Only valid if the treeItem

--- a/wcomponents-theme/src/main/js/wc/ui/menu/bar.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/bar.js
@@ -222,9 +222,8 @@ define(["wc/ui/menu/core", "wc/dom/keyWalker", "wc/dom/shed", "wc/dom/Widget", "
 
 				if (childCount > 1 && BANNER.findAncestor(nextMenu)) {
 					branchElement = document.createElement("div");
-					branchElement.setAttribute(ROLE, "menuitem");
+					branchElement.setAttribute(ROLE, "presentation");
 					branchElement.className = "wc-submenu";
-					branchElement.setAttribute("aria-expanded", "false");
 					button = document.createElement("button");
 					button.type = "button";
 					button.setAttribute("aria-haspopup", "true");
@@ -232,12 +231,14 @@ define(["wc/ui/menu/core", "wc/dom/keyWalker", "wc/dom/shed", "wc/dom/Widget", "
 					contentId = uid();
 					button.setAttribute("aria-controls", contentId);
 					button.className = "wc_btn_nada";
+					button.setAttribute(ROLE, "menuitem");
 					branchElement.appendChild(button);
 
 					submenuContentElement = document.createElement("div");
 					submenuContentElement.className = "wc_submenucontent";
 					submenuContentElement.id = contentId;
 					submenuContentElement.setAttribute(ROLE, "menu");
+					submenuContentElement.setAttribute("aria-expanded", "false");
 					branchElement.appendChild(submenuContentElement);
 
 					while ((menuItem = nextMenu.firstChild)) {

--- a/wcomponents-theme/src/main/js/wc/ui/menu/tree.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/tree.js
@@ -182,6 +182,7 @@ define(["wc/ui/menu/core",
 						branch.removeAttribute("data-wc-selectmode");
 						if ((opener = this._getBranchOpener(branch))) {
 							opener.removeAttribute("aria-haspopup");
+							opener.removeAttribute("role");
 						}
 						if (!branch.getAttribute(EXP_ATTRIB)) {
 							branch.setAttribute(EXP_ATTRIB, isOpen);

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.scss
@@ -59,7 +59,7 @@
 	}
 }
 
-.wc-submenu[aria-expanded='false'] >  [role='group'],
+.wc-submenu[aria-expanded='false'] > [role='group'],
 .wc-submenu > [role='menu'][aria-expanded='false'] {
 	display: none;
 }

--- a/wcomponents-theme/src/main/xslt/wc.ui.submenu.content.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.submenu.content.xsl
@@ -20,14 +20,7 @@
 			<xsl:value-of select="../@id"/>
 		</xsl:variable>
 		
-		<xsl:element name="div">
-			<xsl:attribute name="id">
-				<xsl:value-of select="@id"/>
-			</xsl:attribute>
-			<xsl:attribute name="aria-labelledby">
-				<xsl:value-of select="$submenuId"/>
-				<xsl:text>${wc.ui.menu.submenu.openerIdSuffix}</xsl:text>
-			</xsl:attribute>
+		<div id="{@id}" arial-labelledby="{concat($submenuId, '${wc.ui.menu.submenu.openerIdSuffix}')}">
 			<xsl:attribute name="class">
 				<xsl:text>wc_submenucontent</xsl:text>
 				<xsl:choose>
@@ -78,6 +71,6 @@
 				</xsl:if>
 			</xsl:if>
 			<xsl:apply-templates select="*"/>
-		</xsl:element>
+		</div>
 	</xsl:template>
 </xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.ui.submenu.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.submenu.xsl
@@ -5,6 +5,7 @@
 	<xsl:import href="wc.common.disabledElement.xsl"/>
 	<xsl:import href="wc.common.accessKey.xsl"/>
 	<xsl:import href="wc.common.n.className.xsl"/>
+	<xsl:import href="wc.common.title.xsl"/>
 	<!--
 		WSubMenu is a descendant of WMenu and is used to hold WMenuItems.
 
@@ -67,10 +68,7 @@
 			</xsl:choose>
 		</xsl:variable>
 
-		<xsl:element name="div">
-			<xsl:attribute name="id">
-				<xsl:value-of select="$id"/>
-			</xsl:attribute>
+		<div id="{$id}">
 			<!--
 				We try not to tie functionality or display to classes when we have suitable ARIA
 				attributes but the need to differentiate functionality based on whether an
@@ -82,6 +80,7 @@
 				This <<may>> change so you should try not to rely on this class for too much and
 				certainly avoid it for automated testing.
 			-->
+			<xsl:call-template name="hideElementIfHiddenSet"/>
 			<xsl:call-template name="makeCommonClass"/>
 			<xsl:if test="$type='tree'">
 				<xsl:attribute name="aria-expanded">
@@ -100,14 +99,13 @@
 					<xsl:value-of select="@selectMode"/>
 				</xsl:attribute>
 			</xsl:if>
-			<xsl:call-template name="hideElementIfHiddenSet"/>
 			<xsl:attribute name="role">
 				<xsl:choose>
 					<xsl:when test="$type='tree'"><!-- this will only be met if we can get to the ancestor menu -->
 						<xsl:text>treeitem</xsl:text>
 					</xsl:when>
 					<xsl:when test="$myAncestorMenu">
-						<xsl:text>menuitem</xsl:text>
+						<xsl:text>presentation</xsl:text>
 					</xsl:when>
 					<xsl:otherwise>
 						<xsl:text>${wc.ui.menu.dummyRole}</xsl:text>
@@ -141,34 +139,14 @@
 				</xsl:call-template>
 			</xsl:if>
 			<!-- This is the submenu opener/label element. -->
-			<xsl:element name="button">
-				<xsl:attribute name="type">
-					<xsl:text>button</xsl:text>
-				</xsl:attribute>
-				<xsl:attribute name="id">
-					<xsl:value-of select="$id"/>
-					<xsl:text>${wc.ui.menu.submenu.openerIdSuffix}</xsl:text>
-				</xsl:attribute>
+			<button type="button" id="{concat($id, '${wc.ui.menu.submenu.openerIdSuffix}')}" name="{$id}" class="wc_btn_nada" aria-controls="{ui:content/@id}">
 				<xsl:if test="not($type='tree')">
 					<xsl:attribute name="aria-haspopup">
 						<xsl:copy-of select="$t"/>
 					</xsl:attribute>
+					<xsl:attribute name="role">menuitem</xsl:attribute>
 				</xsl:if>
-				<xsl:attribute name="name">
-					<xsl:value-of select="$id"/>
-				</xsl:attribute>
-				<xsl:attribute name="class">
-					<xsl:text>wc_btn_nada</xsl:text>
-				</xsl:attribute>
-				<xsl:if test="@toolTip">
-					<xsl:attribute name="title">
-						<xsl:value-of select="normalize-space(@toolTip)"/>
-					</xsl:attribute>
-				</xsl:if>
-				<!-- This is the submenu content which is controlled by the submenu -->
-				<xsl:attribute name="aria-controls">
-					<xsl:value-of select="ui:content/@id"/>
-				</xsl:attribute>
+				<xsl:call-template name="title"/>
 				<!-- see above for how we determine disabled state: it is ugly -->
 				<xsl:if test="$disabledAncestor">
 					<xsl:call-template name="disabledElement">
@@ -201,11 +179,11 @@
 					</xsl:otherwise>
 				</xsl:choose>
 				<xsl:apply-templates select="ui:decoratedlabel"/>
-			</xsl:element>
+			</button>
 			<xsl:apply-templates select="ui:content" mode="submenu">
 				<xsl:with-param name="open" select="$open"/>
 				<xsl:with-param name="type" select="$type"/>
 			</xsl:apply-templates>
-		</xsl:element>
+		</div>
 	</xsl:template>
 </xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.ui.tree.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.tree.xsl
@@ -1,0 +1,50 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
+	<xsl:import href="wc.common.attributeSets.xsl"/>
+	<xsl:import href="wc.common.inlineError.xsl"/>
+	<xsl:import href="wc.common.invalid.xsl"/>
+	<xsl:import href="wc.common.hField.xsl"/>
+
+	<xsl:template match="ui:tree">
+		<xsl:variable name="isError" select="key('errorKey', @id)"/>
+
+
+		<div role="tree">
+			<xsl:call-template name="commonAttributes">
+				<xsl:with-param name="class">
+					<xsl:if test="@htree">
+						<xsl:text>wc_htree</xsl:text>
+					</xsl:if>
+				</xsl:with-param>
+			</xsl:call-template>
+
+			<xsl:attribute name="aria-multiselectable">
+				<xsl:choose>
+					<xsl:when test="@multiple">
+						<xsl:value-of select="@multiple"/>
+					</xsl:when>
+					<xsl:otherwise>
+						<xsl:text>false</xsl:text>
+					</xsl:otherwise>
+				</xsl:choose>
+			</xsl:attribute>
+
+			<xsl:call-template name="requiredElement"/>
+			<xsl:call-template name="ajaxController"/>
+
+			<xsl:apply-templates select="ui:margin"/>
+
+			<xsl:if test="$isError">
+				<xsl:call-template name="invalid"/>
+			</xsl:if>
+
+			<xsl:apply-templates select="ui:treeitem">
+				<xsl:with-param name="disabled" select="@disabled"/>
+			</xsl:apply-templates>
+
+			<xsl:call-template name="inlineError">
+				<xsl:with-param name="errors" select="$isError"/>
+			</xsl:call-template>
+			<xsl:call-template name="hField"/>
+		</div>
+	</xsl:template>
+</xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.ui.treeitem.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.treeitem.xsl
@@ -1,0 +1,188 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
+	<xsl:import href="wc.ui.menu.n.hasStickyOpen.xsl"/>
+	<xsl:import href="wc.ui.menu.n.menuRoleIsSelectable.xsl"/>
+	<xsl:import href="wc.ui.menu.n.menuTabIndexHelper.xsl"/>
+	<xsl:import href="wc.common.disabledElement.xsl"/>
+	<xsl:import href="wc.common.hide.xsl"/>
+	<xsl:import href="wc.common.accessKey.xsl"/>
+	<xsl:import href="wc.common.ajax.xsl"/>
+	<xsl:import href="wc.common.n.className.xsl"/>
+	<xsl:import href="wc.common.title.xsl"/>
+	<xsl:import href="wc.common.attributeSets.xsl"/>
+	<!--
+		WMenuItem forms part of a single compound widget with the WMenu at its root.
+
+		The transform for WMenuItem. In general this is pretty straightforwards. The
+		menuItem is rendered as a single control.
+	-->
+	<xsl:template match="ui:treeitem">
+		<xsl:param name="disabled" select="'false'"/>
+
+		<xsl:variable name="id" select="@id"/>
+
+		<xsl:variable name="element">
+			<xsl:choose>
+				<xsl:when test="@expandable or ui:menuitem">
+					<xsl:text>div</xsl:text>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:text>button</xsl:text>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+		<xsl:variable name="isButton">
+			<xsl:choose>
+				<xsl:when test="$element='div'">
+					<xsl:number value="0"/>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:number value="1"/>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+
+		<xsl:element name="{$element}">
+			<xsl:call-template name="commonAttributes">
+				<xsl:with-param name="isControl" select="$isButton"/>
+				<xsl:with-param name="class">
+					<xsl:text>wc-submenu</xsl:text><!-- TODO - check if this is needed in WMenu Type TREE-->
+					<xsl:if test="$isButton=1">
+						<xsl:text> wc_btn_nada</xsl:text>
+					</xsl:if>
+				</xsl:with-param>
+			</xsl:call-template>
+			
+			<xsl:attribute name="role">
+				<xsl:text>treeitem</xsl:text>
+			</xsl:attribute>
+
+			<!-- common attributes will set the correct disabled state if @disabled is set. -->
+			<xsl:if test="not(@disabled = $t) and $disabled=$t">
+				<xsl:choose>
+					<xsl:when test="$isButton=1">
+						<xsl:attribute name="disabled">disabled</xsl:attribute>
+					</xsl:when>
+					<xsl:otherwise>
+						<xsl:attribute name="aria-disabled">true</xsl:attribute>
+					</xsl:otherwise>
+				</xsl:choose>
+			</xsl:if>
+
+			<xsl:attribute name="aria-selected">
+				<xsl:choose>
+					<xsl:when test="@selected">
+						<xsl:copy-of select="$t"/>
+					</xsl:when>
+					<xsl:otherwise>
+						<xsl:text>false</xsl:text>
+					</xsl:otherwise>
+				</xsl:choose>
+			</xsl:attribute>
+
+			<xsl:if test="@expandable">
+				<xsl:attribute name="aria-expanded">
+					<xsl:choose>
+						<xsl:when test="@open">
+							<xsl:copy-of select="$t"/>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:text>false</xsl:text>
+						</xsl:otherwise>
+					</xsl:choose>
+				</xsl:attribute>
+			</xsl:if>
+
+			<xsl:variable name="myAncestorTree" select="ancestor::ui:tree[1]"/>
+			<xsl:variable name="isHtree">
+				<xsl:choose>
+					<xsl:when test="not(myAncestorTree)">
+						<xsl:number value="0"/>
+					</xsl:when>
+					<xsl:when test="myAncestorTree/@htree = $t">
+						<xsl:number value="2"/>
+					</xsl:when>
+					<xsl:otherwise>
+						<xsl:number value="1"/>
+					</xsl:otherwise>
+				</xsl:choose>
+			</xsl:variable>
+			
+			<xsl:choose>
+				<xsl:when test="$isButton=1">
+					<xsl:call-template name="title"/>
+					<xsl:if test="$isHtree &lt; 2">
+						<span class="wc_leaf_vopener" role="presentation">
+							<xsl:text>&#x0a;</xsl:text>
+						</span>
+					</xsl:if>
+					<span class="wc_leaf_img" role="presentation">
+						<xsl:choose>
+							<xsl:when test="@imageUrl">
+								<img src="{@imageUrl}" alt=""/>
+							</xsl:when>
+							<xsl:otherwise>&#x0a;</xsl:otherwise>
+						</xsl:choose>
+					</span>
+					<span class="wc_leaf_name">
+						<xsl:value-of select="@title"/>
+					</span>
+					<xsl:if test="$isHtree !=1">
+						<span class="wc_leaf_hopener" role="presentation">
+							<xsl:text>&#x0a;</xsl:text>
+						</span>
+					</xsl:if>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:variable name="contentWrapperId">
+						<xsl:value-of select="concat(@id, '-branch-content')"/>
+					</xsl:variable>
+					<xsl:variable name="nameButtonId">
+							<xsl:value-of select="concat(@id, '-branch-name')"/>
+					</xsl:variable>
+					<xsl:if test="$isHtree &lt; 2">
+						<button type="button" class="wc_btn_nada wc_leaf_vopener" aria-controls="{$contentWrapperId}">
+							<xsl:text>&#x0a;</xsl:text>
+						</button>
+					</xsl:if>
+					<button type="button" class="wc_btn_nada wc_leaf" id="{$nameButtonId}">
+						<xsl:call-template name="title"/>
+						<span class="wc_leaf_img">
+							<xsl:choose>
+								<xsl:when test="@imageUrl">
+									<img src="{@imageUrl}" alt=""/>
+								</xsl:when>
+								<xsl:otherwise>&#x0a;</xsl:otherwise>
+							</xsl:choose>
+						</span>
+						<span class="wc_leaf_name">
+							<xsl:value-of select="@title"/>
+						</span>
+					</button>
+					<xsl:if test="$isHtree != 1">
+						<button type="button" class="wc_btn_nada wc_leaf_hopener" aria-controls="{$contentWrapperId}">
+							<xsl:text>&#x0a;</xsl:text>
+						</button>
+					</xsl:if>
+					<div class="wc_submenucontent" role="group" id="{$contentWrapperId}" aria-labelledby="{$nameButtonId}">
+						<xsl:if test="not(@open = $t)">
+							<xsl:call-template name="hiddenElement"/>
+						</xsl:if>
+						<xsl:apply-templates select="ui:treeitem">
+							<xsl:with-param name="disabled">
+								<xsl:choose>
+									<xsl:when test="@disabled = $t or $disabled = $t">
+										<xsl:copy-of select="$t"/>
+									</xsl:when>
+									<xsl:otherwise>false</xsl:otherwise>
+								</xsl:choose>
+							</xsl:with-param>
+						</xsl:apply-templates>
+						<xsl:if test="not(ui:treeitem)">
+							<span role="treeitem" hidden="hidden">&#x0a;</span>
+						</xsl:if>
+					</div>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:element>
+	</xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
* Updated schema for ui:tree and ui:treeitem #263.
* First cut of possible XSLT for these.
* Fixed a major flaw in the a11y of WMenu Types BAR, COLUMN & FLYOUT. These menus had an incorrect nesting arrangement of menuitem and menu. Still looking at implications of presentation in this context: it may have to be removed.