### PR TITLE
344 Mobile Sass

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/table.js
+++ b/wcomponents-theme/src/main/js/wc/ui/table.js
@@ -10,7 +10,7 @@
  * @requires module:wc/ui/table/rowExpansion
  * @requires module:wc/ui/table/sort
  */
-define(["wc/ui/table/action", "wc/ui/table/pagination", "wc/ui/rowAnalog", "wc/ui/table/rowExpansion", "wc/ui/table/sort"],
+define(["wc/ui/table/action", "wc/ui/table/pagination", "wc/ui/rowAnalog", "wc/ui/table/rowExpansion", "wc/ui/table/sort", "wc/ui/selectToggle"],
 	function() {
 		"use strict";
 		return 1;

--- a/wcomponents-theme/src/main/resource/wc.ui.dateField.calendar.xml
+++ b/wcomponents-theme/src/main/resource/wc.ui.dateField.calendar.xml
@@ -9,12 +9,12 @@
 				</select>
 				<input id="wc-calyear" value="{{fullYear}}" autocomplete="off" type="number" title="{{yearLabel}}" min="1000" max="9999"/><!-- DON'T GIVE NAME! -->
 
-				<button type="button" class="wc_wdf_mv" value="-1" title="{{lastMonth}}"> </button>
-				<button type="button" class="wc_wdf_mv" value="t" title="{{today}}"> </button>
-				<button type="button" class="wc_wdf_mv" value="1" title="{{nextMonth}}"> </button>
+				<button type="button" class="wc_wdf_mv wc_btn_icon" value="-1" title="{{lastMonth}}"> </button>
+				<button type="button" class="wc_wdf_mv wc_btn_icon" value="t" title="{{today}}"> </button>
+				<button type="button" class="wc_wdf_mv wc_btn_icon" value="1" title="{{nextMonth}}"> </button>
 			</td>
 			<td>
-				<button type="button" class="wc_wdf_cls" title="{{closeLabel}}"></button>
+				<button type="button" class="wc_wdf_cls wc_btn_icon" title="{{closeLabel}}"></button>
 			</td>
 		</tr>
 		<tr>

--- a/wcomponents-theme/src/main/sass/README.md
+++ b/wcomponents-theme/src/main/sass/README.md
@@ -33,12 +33,9 @@ If you need CSS for IE for IE8 or before I recommend adding a conditional commen
 
 ### Comments
 
-* Each CSS and SCSS file must commence with a CSS comment which includes **only** its file name. This makes CSS debugging much easier (remember that CSS style comments are stripped in the final compressed output but Sass comments are stripped in all circumstances).
+* Each Sass file must commence with a CSS comment which includes **only** its file name. This makes CSS debugging much easier (remember that CSS style comments are stripped in the final compressed output but Sass comments are stripped in all circumstances).
 * Comments **must be in Sass single line** style unless they are pertinent to debugging and then they must have a local override of the `Comments` scss-lint rule. If a particular declaration in a declaration block requires a comment it **must be in Sass single line form** under all circumstances.
-* There must be a single space between the start of a comment and the first character of the comment content.
-* If a rule is commented there must not be any empty lines between the last line of the comment and the first selector.
 * Do not place a CSS style comment inside a declaration block (it causes issues with Safari's developer tools). Sass single line comments are permitted inside rule blocks.
-* If a particular selector in a multi-selector rule requires a comment it should be placed on the same line as the selector.
 
 #### Example
 
@@ -68,7 +65,7 @@ The take-home message of this is: there is no hard and fast rule for when to use
 ## Things to do
 
 * The conversion from CSS is still early so there is a lot of optimization which could happen.
-* We need to get on top of the documentation: there is currently no SassDoc for example.
+* We need to get on top of the documentation: there is currently little or no SassDoc for example.
 * A lot of this CSS was inherited and has grown like topsy so we also need to standardize class names and some data-* attribute names.
 
 ## References

--- a/wcomponents-theme/src/main/sass/_common.scss
+++ b/wcomponents-theme/src/main/sass/_common.scss
@@ -12,11 +12,6 @@ $preferred-line-size-px: 16; // Your iconography should be this big
 $font-size: $preferred-font-size-px / 16 * 100%;
 $line-height: 1.33333;
 
-
-
-// This variable is used to construct boxes where the width of the box is equal to the line height of the text.
-$line-size: $line-height * 1em;
-
 // BORDERS
 // Many things have borders and it is nice to have a common look to all of them. You may want to cross reference this to
 // the mixins makeBorder and makePartBorder which use these as default values but allow override.

--- a/wcomponents-theme/src/main/sass/_mixins-common.scss
+++ b/wcomponents-theme/src/main/sass/_mixins-common.scss
@@ -57,17 +57,7 @@
 	box-sizing: border-box;
 }
 
-/// Style a button with a (usually) transparent background. Handy for holding iconography! The default call to this
-/// mixin will style a button to:
-///
-/// * be a fixed square size eqivalent to the default line size;
-/// * have a small amount of padding on all sides;
-/// * will have a box-model of content-box;
-/// * will inherit font styles;
-/// * have a standard border on all sides (see the border mixin);
-/// * have center text-alignment;
-/// * will reset the linear dimensions from $line-size to 1em using the reset-large-screen mixin;
-/// * then apply content.
+/// Style a button with a (usually) transparent background. Handy for holding iconography!
 ///
 /// @param {color} $background [transparent] Set the button background. Set -1 to ignore this rule.
 /// @param {boolean|int} $border [true] If true then the border mixin is called with no params (get a default border).

--- a/wcomponents-theme/src/main/sass/_mixins-icon.scss
+++ b/wcomponents-theme/src/main/sass/_mixins-icon.scss
@@ -7,14 +7,17 @@
 @import 'libs/fa/mixins.scss';
 
 /// use fa-icon
-@mixin wc-icon ($icon) {
+@mixin wc-icon ($icon: -1) {
 	@include fa-icon;
-	content: $icon;
+	@if($icon != -1) {
+		content: $icon;
+	}
+	font-size: 1rem; // keep icons at 16px
 }
 
 /// Make a fixed-width icon.
-@mixin wc-icon-fw ($icon, $text-align: center) {
+@mixin wc-icon-fw ($icon, $text-align: center, $width: 1rem) {
 	@include wc-icon($icon);
 	text-align: $text-align;
-	width: (18em / 14);
+	width: $width;
 }

--- a/wcomponents-theme/src/main/sass/_mixins-old.scss
+++ b/wcomponents-theme/src/main/sass/_mixins-old.scss
@@ -6,19 +6,20 @@
 
 $symbol-font: 'Lucida Sans Unicode', 'Arial Unicode MS';
 
+// This variable is used to construct boxes where the width of the box is equal to the line height of the text.
+//$line-size: $line-height * 1em;
 
-/// Add a background-image to almost anything. The default for this macro will add a small, centered,
-///   non-repeateing background image to the element.
+/// Add a background-image to almost anything.
 ///
 /// @param {string} $url The URL of your image.
-/// @param {dimension} $height [$line-size] The vertical aspect of background-size. Set -1 to omit the background-size rule.
+/// @param {dimension} $height [-1] The vertical aspect of background-size. Set -1 to omit the background-size rule.
 /// @param {repetition} $repeat [no-repeat] The repeat rule for your image.
-/// @param {dimension} $width [$line-size] The horizontal aspect of background-size. Set -1 to omit the background-size rule.
+/// @param {dimension} $width [-1] The horizontal aspect of background-size. Set -1 to omit the background-size rule.
 /// @param {position|dimension} $x [50%] The x-position aspect of background-position. The background-position rule is
 /// omitted if both $x and $y are 0.
 /// @param {position|dimension} $y [50%] The y-position aspect of background-position. The background-position rule is
 /// omitted if both $x and $y are 0.
-@mixin background-image($url, $height: $line-size, $repeat: no-repeat, $width: $line-size, $x: 50%, $y: 50%) {
+@mixin background-image($url, $height: -1, $repeat: no-repeat, $width: -1, $x: 50%, $y: 50%) {
 	background-image: url($url);
 	@if ($x != 0 or $y != 0) {
 		background-position: $x $y;
@@ -39,8 +40,7 @@ $symbol-font: 'Lucida Sans Unicode', 'Arial Unicode MS';
 }
 
 /// Add a scaled, centred background-image (as an icon). This is basically a cut-down version of the background-image
-/// mixin for adding iconic images to things (usually buttons). The image is always a square of edge length $line-size.
-/// @todo Delete this and replace calls with a call directly to background-image.
+/// mixin for adding iconic images to things (usually buttons).
 ///
 /// @param {string} $url The URL of your image.
 /// @param {position|dimension} $x [50%] The x-position aspect of background-position. The background-position rule is
@@ -53,9 +53,9 @@ $symbol-font: 'Lucida Sans Unicode', 'Arial Unicode MS';
 
 /// Makes a square box (for exampe to put a 100% scaled SVG in).
 /// @param {display} $display [inline-block] How you want your box to display.
-/// @param {dimension} $height [$line-size] The height of the box. Set auto to omit this rule.
-/// @param {dimension} $width [$line-size] The width of the box. Set auto to omit this rule.
-@mixin make-box($display: inline-block, $height: $line-size, $width: $line-size) {
+/// @param {dimension} $height [auto] The height of the box. Set auto to omit this rule.
+/// @param {dimension} $width [auto] The width of the box. Set auto to omit this rule.
+@mixin make-box($display: inline-block, $height: $auto, $width: auto) {
 	display: $display;
 	@if ($height != auto) {
 		height: $height;

--- a/wcomponents-theme/src/main/sass/_spacing.scss
+++ b/wcomponents-theme/src/main/sass/_spacing.scss
@@ -1,7 +1,7 @@
 // Common spacing variables
-$hgap-small: 0.25em;
-$hgap-normal: 0.5em;
-$hgap-large: 1em;
+$hgap-small: 0.25rem;
+$hgap-normal: 0.5rem;
+$hgap-large: 1rem;
 $vgap-small: $hgap-small;
 $vgap-normal: $hgap-normal;
 $vgap-large: $hgap-large;
@@ -9,5 +9,5 @@ $vgap-large: $hgap-large;
 $section-content-spacing: $hgap-normal;
 $section-header-spacing: $hgap-normal;
 
-$list-layout-dot-spacing: 1.5em;
-$list-layout-ordered-spacing: 2em;
+$list-layout-dot-spacing: 1.5rem;
+$list-layout-ordered-spacing: 2rem;

--- a/wcomponents-theme/src/main/sass/wc.common.accesskey.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.accesskey.dt.scss
@@ -26,8 +26,8 @@ span[role='tooltip'] {
 	// important to over-ride menu rules which may also apply.
 	// scss-lint:disable ImportantRule
 	font-weight: bold !important;
-	margin-top: -2.25em;
-	padding: 0.25em !important;
+	margin-top: -2.25rem;
+	padding: $hgap-small !important;
 	position: absolute;
 	text-align: center;
 	width: auto !important;
@@ -36,12 +36,12 @@ span[role='tooltip'] {
 	&:before,
 	&:after {
 		border-style: solid;
-		border-width: 0.5em 0.25em 0;
+		border-width: 0.5rem 0.25rem 0;
 		bottom: 0;
 		content: '';
 		display: inline-block;
 		left: 30%;
-		margin-bottom: -0.5em;
+		margin-bottom: -0.5rem;
 		position: absolute;
 	}
 

--- a/wcomponents-theme/src/main/sass/wc.common.buttons.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.buttons.scss
@@ -55,6 +55,10 @@ button {
 		@include button;
 		color: inherit;
 
+		&:before {
+			@include wc-icon;
+		}
+
 		&[disabled] {
 			background-color: $wc-ui-color-disabled-bg;
 			color: $wc-ui-color-disabled-fg;

--- a/wcomponents-theme/src/main/sass/wc.common.listSortIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.listSortIcons.scss
@@ -5,7 +5,7 @@
 /// Each individual shuffle control's iconography
 .wc_sorter {
 	&:before {
-		@include wc-icon($fa-var-angle-double-up);
+		content: $fa-var-angle-double-up;
 	}
 
 	// NOTE this will need a .ie8.scss file if your implementation needs to support ie8.

--- a/wcomponents-theme/src/main/sass/wc.common.sectionSpacing.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.sectionSpacing.scss
@@ -3,6 +3,13 @@
 section {
 	@include border;
 
+	> h1,
+	> header h1 {
+		@include margin($size: 0);
+		font-size: 1rem;
+		font-weight: normal;
+	}
+
 	// First the header. There are two options. a header element for WSection, a H1 for WPanel
 	// WSection
 	> header {
@@ -15,7 +22,6 @@ section {
 		}
 
 		> h1 {
-			@include margin($size: 0);
 			width: 100%;
 		}
 
@@ -27,7 +33,6 @@ section {
 
 	// WPanel types CHROME and ACTION
 	> h1 {
-		@include margin($size: 0);
 		padding: $section-header-spacing;
 	}
 

--- a/wcomponents-theme/src/main/sass/wc.debug.axs.scss
+++ b/wcomponents-theme/src/main/sass/wc.debug.axs.scss
@@ -13,8 +13,6 @@
 
 	&.warning { // I have never seen a warning level issue in WComponents which has NOT been a false negative.
 		border-color: $wc-ui-color-warning-fg;
-		// max-height: 5em;
-		// overflow: auto;
 
 		&:before {
 			background-color: $wc-ui-color-warning-fg;

--- a/wcomponents-theme/src/main/sass/wc.debug.common.scss
+++ b/wcomponents-theme/src/main/sass/wc.debug.common.scss
@@ -15,7 +15,7 @@ body {
 		color: $wc-ui-color-highlight-fg;
 		content: 'Client debug/diagnostic mode: document has ' attr(data-wc-nodeCount) ' elements.';
 		display: block;
-		padding: 0.5em;
+		padding: $hgap-normal;
 	}
 
 	&.wc_loggedwarn {

--- a/wcomponents-theme/src/main/sass/wc.ui.backToTop.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.backToTop.dt.scss
@@ -2,5 +2,5 @@
 @import 'mixins-common.scss';
 /// The back to top of page link.
 .wc_btt:before {
-	font-size: 4em;
+	font-size: 4rem;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.backToTop.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.backToTop.scss
@@ -4,6 +4,7 @@
 /// The back to top of page link.
 .wc_btt {
 	bottom: 1em;
+	opacity: 0.5;
 	position: fixed;
 	right: 1em;
 	text-decoration: none;

--- a/wcomponents-theme/src/main/sass/wc.ui.backToTop.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.backToTop.scss
@@ -3,16 +3,16 @@
 
 /// The back to top of page link.
 .wc_btt {
-	bottom: 1em;
+	bottom: 1rem;
 	opacity: 0.5;
 	position: fixed;
-	right: 1em;
+	right: 1rem;
 	text-decoration: none;
 
 	&:before {
 		@include wc-icon($fa-var-chevron-circle-up);
 		display: block;
-		font-size: 1.5em;
+		font-size: 1.5rem;
 		line-height: inherit;
 		text-align: center;
 		vertical-align: middle;

--- a/wcomponents-theme/src/main/sass/wc.ui.collapsible.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.collapsible.scss
@@ -29,10 +29,10 @@ summary {
 		@include tight-box;
 		color: $wc-ui-color-global-fg;
 		display: inline-block;
-		font-size: 1em;
+		font-size: 1rem;
 		font-weight: bold;
 		vertical-align: text-top;
-		width: calc(100% - 2em); // allow for the iconography
+		width: calc(100% - 2rem); // allow for the iconography
 	}
 }
 

--- a/wcomponents-theme/src/main/sass/wc.ui.combo.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.combo.scss
@@ -7,11 +7,12 @@ datalist {
 }
 
 input[role='combobox'] { // not the combo wrapper of datefield.
-	padding-right: $line-size; // allow for icon
+	@include border-box;
+	padding-right: 1rem; // allow for icon
 
 	&[aria-expanded = 'true'] ~ [role='listbox'] {
 		display: block;
-		max-height: (7 * ($line-size + (2 * $hgap-small))); // allow for up to seven visible options.
+		max-height: (7 * ($hgap-normal + (2 * $hgap-small))); // allow for up to seven visible options.
 		max-width: 100%;
 		overflow: auto;
 	}

--- a/wcomponents-theme/src/main/sass/wc.ui.comboIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.comboIcons.scss
@@ -2,8 +2,8 @@
 @import 'mixins-common.scss';
 
 .wc_list_wrapper:before {
-	@include wc-icon($fa-var-caret-down);
+	@include wc-icon-fw($fa-var-caret-down);
 	position: absolute;
-	right: ($line-size / 4);
-	top: ($line-size / 4);
+	right: 0.25rem; // The fixed icon width div 4 - it works!
+	top: 0.25rem;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.dateField.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dateField.scss
@@ -76,7 +76,7 @@
 
 		input { //year field:
 			margin: 0 $hgap-large;
-			width: 5em; //  FF and IE do not size by max.
+			width: 5rem; //  FF and IE do not size by max.
 		}
 	}
 
@@ -104,7 +104,7 @@
 	min-width: 100%;
 	padding: $vgap-small $hgap-small;
 	text-align: center;
-	width: 3em;
+	width: 3rem;
 
 	&:hover,
 	&:focus {
@@ -141,7 +141,7 @@
 	}
 
 	#wc-calendar {
-		font-size: 1.5em;
+		font-size: 1.5rem;
 		height: 100%;
 
 		thead {
@@ -160,7 +160,7 @@
 		}
 
 		th { // The th contain the day name addreviations.
-			font-size: 1em;
+			font-size: 1rem;
 		}
 	}
 

--- a/wcomponents-theme/src/main/sass/wc.ui.dateFieldIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dateFieldIcons.scss
@@ -3,14 +3,14 @@
 
 // calendar launch button
 .wc_wdf_cal:before {
-	@include wc-icon($fa-var-calendar);
+	content: $fa-var-calendar;
 }
 
 // use a single identified artefact for calendars
 //scss-lint:disable IdSelector
 #wc-calendar thead button {
 	&:before {
-		@include wc-icon($fa-var-calendar-times-o);
+		content: $fa-var-calendar-times-o;
 	}
 
 	&[value = '-1']:before {

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog.ie9.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog.ie9.scss
@@ -9,7 +9,7 @@ dialog {
 
 	> [aria-live] {
 		@include border-box;
-		padding: 2em $hgap-normal;
+		padding: 2rem $hgap-normal;
 	}
 
 	> header,

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog.scss
@@ -69,13 +69,13 @@ dialog {
 			@include flex-grow(1);
 			@include margin($size: 0);
 			color: $wc-ui-color-dialog-head-fg;
-			font-size: 1em;
+			font-size: 1rem;
 		}
 
 		> span { // the header control 'block'
 			@include flex-align-self(flex-start);
 			line-height: 0;
-			margin-right: 0.25em;
+			margin-right: $hgap-small;
 		}
 
 		.wc_btn_icon {

--- a/wcomponents-theme/src/main/sass/wc.ui.dialogIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialogIcons.scss
@@ -6,5 +6,5 @@
 // dialog close control
 // NOTE: for resize handle and max/restore control see wc.ui.resizeable.scss.
 .wc_dialog_close:before {
-	@include wc-icon($fa-var-times);
+	content: $fa-var-times;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog_vars.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog_vars.scss
@@ -4,8 +4,8 @@
 $wc-ui-color-dialog-head-bg: $std-color-primary;
 $wc-ui-color-dialog-head-fg: $std-color-primary-accent;
 
-$wc-ui-dialog-min-width: 15em;
-$wc-ui-dialog-min-height: 7em;
+$wc-ui-dialog-min-width: 15rem;
+$wc-ui-dialog-min-height: 7rem;
 
 $wc-ui-dialog-transition-delay: 0s;
 $wc-ui-dialog-transition-duration: 0.5s;

--- a/wcomponents-theme/src/main/sass/wc.ui.fieldset.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fieldset.scss
@@ -1,15 +1,4 @@
 /* wc.ui.fieldset.scss */
-
-// Just a few notes regarding fieldset defaults:
-
-//  * Firefox padding:  0.35em 0.625em 0.75em
-//  * Chrome padding:  0.35em 0.75em 0.625em
-//  * IE padding: 0 2px 3px
-// All three default margin: 0 2px
-
-// Legend:
-//  * Firefox & Chrome padding: 0 2px, margin:0. border:0
-//  * IE padding: 0 2px, border-width:medium (transparent but changes box)
 @import 'mixins-common.scss';
 
 fieldset {

--- a/wcomponents-theme/src/main/sass/wc.ui.fileUpload.pattern_edge.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fileUpload.pattern_edge.scss
@@ -1,7 +1,8 @@
 /* wc.ui.fileUpload.pattern_edge.scss */
 @import 'mixins-common.scss';
 
-// The default file upload in IE/Edge is a bit ugly if anything is styled at all. This CSS may be considered lipstick.
+// The default file upload in Edge is a bit ugly if anything is styled at all. This CSS may be considered lipstick.
+// Yes: Edge uses the -ms- shadow elements.
 //scss-lint:disable VendorPrefix
 input[type='file'] {
 	@include border($width: 0);
@@ -10,9 +11,14 @@ input[type='file'] {
 
 	// pseudo-element ::-ms-browse on its own has detrimental effects on all buttons!!
 	&::-ms-browse {
-		@include border($pos: left, $width: 0);
 		@include button;
+		@include border($pos: left, $width: 0);
 	}
+
+	// &::-webkit-file-upload-button {
+	// 	@include button();
+	// 	@include border($pos: left, $width:0);
+	// }
 
 	&::-ms-value {
 		@include border;

--- a/wcomponents-theme/src/main/sass/wc.ui.fileUpload.pattern_ff.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fileUpload.pattern_ff.scss
@@ -1,0 +1,9 @@
+/* wc.ui.fileUpload.pattern_ff.scss */
+@import 'mixins-common.scss';
+
+// Firefox file uploads.
+//scss-lint:disable VendorPrefix
+input[type='file'] {
+	@include border($width: 0);
+	padding: 0;
+}

--- a/wcomponents-theme/src/main/sass/wc.ui.fileUpload.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fileUpload.scss
@@ -93,3 +93,8 @@
 	padding: $hgap-small;
 	word-wrap: break-word;
 }
+
+input[type='file']::-webkit-file-upload-button {
+	@include button($border: 0);
+	@include border($pos: right, $width: 1px);
+}

--- a/wcomponents-theme/src/main/sass/wc.ui.fileUploadIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fileUploadIcons.scss
@@ -2,9 +2,9 @@
 @import 'mixins-common.scss';
 
 .wc-fileupload  a ~ button:before {
-	@include wc-icon($fa-var-trash);
+	content: $fa-var-trash;
 }
 
 .wc_btn_camera:before {
-	@include wc-icon($fa-var-video-camera);
+	content: $fa-var-video-camera;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.heading.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.heading.scss
@@ -1,6 +1,6 @@
 /* wc.ui.heading.scss */
 // This file is purposely left as a stub for easy over-ride
-@import 'vars.scss';
+@import 'mixins-common.scss';
 
 h1,
 h2,
@@ -22,13 +22,5 @@ h4 {
 		img {
 			vertical-align: middle;
 		}
-	}
-}
-
-section {
-	> h1,
-	> header h1 {
-		font-size: 1em;
-		font-weight: normal;
 	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.imageEditIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.imageEditIcons.scss
@@ -1,81 +1,76 @@
 /* wc.ui.imageEditIcons.scss */
 @import 'mixins-common.scss';
 
-$button-neg-margin-normal: -1 * ($line-size + 2 * $hgap-small);
-$double-border-width: 2 * $border-width;
-
-button[data-img][data-editor] { // edit image button
-	margin-left: calc(#{$button-neg-margin-normal} - #{$double-border-width});
-
-	&:before {
-		@include wc-icon($fa-var-picture-o);
-	}
+button[data-img][data-editor]:before {
+	content: $fa-var-picture-o;
 }
 
 .wc_img_editor {
-	button {
-		&:before {
-			@include wc-icon($fa-var-caret-up);
-		}
+	button:before {
+		min-width: 1rem;
+	}
 
-		&.wc_btn_anticlock:before {
-			content: $fa-var-undo;
-		}
+	.wc_btn_anticlock:before {
+		content: $fa-var-undo;
+	}
 
-		&.wc_btn_anticlock90:before {
-			content: $fa-var-reply;
-		}
+	.wc_btn_anticlock90:before {
+		content: $fa-var-reply;
+	}
 
-		&.wc_btn_camera:before {
-			content: $fa-var-camera;
-		}
+	.wc_btn_camera:before {
+		content: $fa-var-camera;
+	}
 
-		&.wc_btn_cancel:before {
-			content: $fa-var-trash;
-		}
+	.wc_btn_cancel:before {
+		content: $fa-var-trash;
+	}
 
-		&.wc_btn_clock:before {
-			content: $fa-var-repeat;
-		}
+	.wc_btn_clock:before {
+		content: $fa-var-repeat;
+	}
 
-		&.wc_btn_clock90:before {
-			content: $fa-var-share;
-		}
+	.wc_btn_clock90:before {
+		content: $fa-var-share;
+	}
 
-		&.wc_btn_down:before {
-			content: $fa-var-caret-down;
-		}
+	.wc_btn_down:before {
+		content: $fa-var-caret-down;
+	}
 
-		&.wc_btn_face:before {
-			content: $fa-var-user;
-		}
+	.wc_btn_face:before {
+		content: $fa-var-user;
+	}
 
-		&.wc_btn_in:before {
-			content: $fa-var-search-plus;
-		}
+	.wc_btn_in:before {
+		content: $fa-var-search-plus;
+	}
 
-		&.wc_btn_left:before {
-			content: $fa-var-caret-left;
-		}
+	.wc_btn_left:before {
+		content: $fa-var-caret-left;
+	}
 
-		&.wc_btn_out:before {
-			content: $fa-var-search-minus;
-		}
+	.wc_btn_out:before {
+		content: $fa-var-search-minus;
+	}
 
-		&.wc_btn_reset:before {
-			content: $fa-var-history;
-		}
+	.wc_btn_reset:before {
+		content: $fa-var-history;
+	}
 
-		&.wc_btn_save:before {
-			content: $fa-var-floppy-o;
-		}
+	.wc_btn_right:before {
+		content: $fa-var-caret-right;
+	}
 
-		&.wc_btn_right:before {
-			content: $fa-var-caret-right;
-		}
+	.wc_btn_save:before {
+		content: $fa-var-floppy-o;
+	}
 
-		&.wc_btn_snap:before {
-			content: $fa-var-camera;
-		}
+	.wc_btn_snap:before {
+		content: $fa-var-camera;
+	}
+
+	.wc_btn_up:before {
+		content: $fa-var-caret-up;
 	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.listLayoutIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.listLayoutIcons.scss
@@ -3,5 +3,8 @@
 
 .wc-listlayout.flat.dot > li + li:before { // dot bullets should be default but need pseudo-elements for flat lists.
 	@include wc-icon($fa-var-circle);
+	font-size: 6px;
+	line-height: 1;
 	margin-right: $hgap-normal;
+	vertical-align: 3px;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.loading.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.loading.scss
@@ -18,7 +18,7 @@
 		color: $wc-ui-color-global-fg;
 		display: inline-block;
 		margin: 0 auto;
-		padding: 1em;
+		padding: $hgap-large;
 		vertical-align: middle;
 		width: auto;
 
@@ -35,7 +35,7 @@
 	// Some of these properties have to be important to over-ride specific component's rules
 	// scss-lint:disable ImportantRule
 	background-color: transparent !important;
-	// border-color: transparent !important; busy stuff should keep borders - we should ensure they keep the same dimensions too so it doesn't look stupid
+	// scss-lint:enable ImportantRule
 	color: $wc-ui-color-disabled-fg;
 
 	// Make any interactive child element of a busy region invisible. We want them to take up their space but not be

--- a/wcomponents-theme/src/main/sass/wc.ui.loadingIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.loadingIcons.scss
@@ -14,18 +14,19 @@
 // We make the background of the busy element transparent and set all of its children to visibility:hidden so the
 // element appears to just vanish and leave its loading indicator You may want to change this (a Cheshire cat maybe?).
 [aria-busy='true'] {
-	text-align: center;
+	// min-height: 1rem; // because we made the spinner position absolute so it no longer occupies space.
+	text-align: center; // center the spinner
 
-	&:before { // yeah - I know this won't work for replaced content...
+	&:before { // yeah - I know this won't work for replaced content... see below
 		@include wc-icon($fa-var-spinner);
 		@include wc-spin; // fa do not yet have a mixin for this.
+		// position: absolute; // auto top etc
 	}
 }
 
 input,
 select,
-textarea,
-img {
+textarea {
 	&[aria-busy='true'] {
 		background: url('../images/loading-dark.gif') 50% 50% no-repeat transparent;
 		text-align: left;

--- a/wcomponents-theme/src/main/sass/wc.ui.mediaPlayerIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.mediaPlayerIcons.scss
@@ -2,7 +2,6 @@
 // styles for WAudio and WVideo when the media is not able to be handled by the user agent natively. */
 @import 'mixins-common.scss';
 
-.wc_av_play,
 .wc-src,
 .wc-track {
 	&:before {
@@ -10,10 +9,16 @@
 	}
 }
 
-.wc_av_play[aria-pressed='true']:before {
-	content: $fa-var-pause;
-}
-
 .wc-track:before {
 	content: $fa-var-file-text;
+}
+
+.wc_av_play {
+	&:before {
+		content: $fa-var-play;
+	}
+
+	&[aria-pressed='true']:before {
+		content: $fa-var-pause;
+	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.dt.scss
@@ -20,7 +20,6 @@
 		// override aria-busy transparency
 		// scss-lint:disable ImportantRule
 		background-color: $wc-ui-color-menu-bg !important;
-		min-height: $line-size;
 	}
 }
 

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.scss
@@ -20,9 +20,6 @@
 [data-wc-menufixed='true'] {
 	.wc-submenu > [role='menu'][aria-expanded='true'] {
 		@include border-box;
-		// important to override the default for aria-busy areas. Transparent sub-menus help no-one and it may seem that we are not loading.
-		// scss-lint:disable ImportantRule
-		background-color: $wc-ui-color-global-bg !important;
 		height: 100%;
 		left: 0;
 		overflow: auto;
@@ -31,7 +28,7 @@
 		width: 100%;
 
 		> [role] {
-			font-size: 1.25em;
+			font-size: 1.25rem;
 		}
 	}
 

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumnIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumnIcons.scss
@@ -17,5 +17,5 @@
 
 .closesubmenu::before {
 	@include wc-icon($fa-var-caret-left);
-	margin-right: 0.5em;
+	margin-right: $hgap-normal;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.menu_vars.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu_vars.scss
@@ -20,6 +20,5 @@ $wc-ui-menu-flyout-vseparator-pad: $hgap-small 0;
 $wc-ui-menu-bar-column-opener-indicator-before-after: $hgap-small;
 
 //type TREE
-$wc-ui-menu-tree-indent: 1em;
+$wc-ui-menu-tree-indent: 0.75rem;
 $wc-ui-menu-tree-item-pad: $hgap-small $vgap-normal;
-$wc-ui-menu-tree-icon-size: 1em;

--- a/wcomponents-theme/src/main/sass/wc.ui.messageBoxIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.messageBoxIcons.scss
@@ -4,7 +4,7 @@
 .wc_msgbox {
 
 	> h1:before {
-		@include wc-icon-fw($fa-var-minus-circle);
+		@include wc-icon-fw($fa-var-minus-circle, $width: 1.25rem);
 		vertical-align: middle;
 	}
 

--- a/wcomponents-theme/src/main/sass/wc.ui.messageBox_vars.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.messageBox_vars.scss
@@ -1,4 +1,4 @@
 /* wc.ui.messageBox_vars.scss */
 @import 'mixins-common.scss';
-$msg-box-header-size: 1.25em;
+$msg-box-header-size: 1.25rem;
 $msg-box-header-text-color: $std-color-white;

--- a/wcomponents-theme/src/main/sass/wc.ui.multiFormComponentIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.multiFormComponentIcons.scss
@@ -12,8 +12,8 @@
 		margin-left: $hgap-small;
 
 		&:before {
-			@include wc-icon($fa-var-minus-square);
 			color: $wc-ui-color-error-fg;
+			content: $fa-var-minus-square;
 		}
 
 		&[disabled]:before {

--- a/wcomponents-theme/src/main/sass/wc.ui.multiSelectPair.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.multiSelectPair.scss
@@ -22,17 +22,8 @@
 	}
 
 	select { //Allow the select to grow with the label. NOTE: min-height is roughly the height of the four buttons.
-		min-height: 8em;
+		min-height: 8rem;
 		min-width: 100%;
-	}
-
-	// Attempt to align the sort buttons with the top of the SELECTs by using the default line height. This could be
-	// done by adding a non-breaking-space in a simple span to the button block but that would involve an extra dom node
-	// and  having sightly different transform for the list order buttons of WShuffler and WMultiSelectPair. This
-	// padding hack works for all usual cases.
-	.wc_sortcont,
-	.wc_msp_btncol {
-		padding-top: $line-size;
 	}
 
 	.wc_msp_btncol button { // the add and remove buttons

--- a/wcomponents-theme/src/main/sass/wc.ui.multiSelectPairIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.multiSelectPairIcons.scss
@@ -3,7 +3,8 @@
 
 .wc_msp_btncol button {
 	&:before {
-		@include wc-icon-fw($fa-var-angle-right);
+		content: $fa-var-angle-right;
+		width: 1rem;
 	}
 
 	// NOTE this will need a .ie8.scss file if your implementation needs to support ie8.

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.header.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.header.scss
@@ -9,10 +9,10 @@
 
 	h1 {
 		color: $wc-ui-color-panel-header-foreground;
-		font-size: 3em;
+		font-size: 3rem;
 		font-weight: lighter;
 		margin: 0;
-		padding: 0.25em 0.3333em;
+		padding: $vgap-normal $hgap-normal;
 	}
 
 	a,
@@ -38,7 +38,7 @@
 		}
 
 		h1 {
-			font-size: 1.25em;
+			font-size: 1.25rem;
 			font-weight: bold;
 			margin: 0;
 			padding: 0;

--- a/wcomponents-theme/src/main/sass/wc.ui.progressBar.ie11.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.progressBar.ie11.scss
@@ -7,7 +7,7 @@
 // If you do remove this file, or remove the explicit width, then you should take a look at the faux-progress bars in
 // wc.ui.progressBar.ie9.css to make sure you have not proken them.
 progress {
-	height: 1em;
-	vertical-align: -0.2em;
-	width: 10em;
+	height: 1rem;
+	vertical-align: -0.2rem;
+	width: 10rem;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.progressBar.ie9.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.progressBar.ie9.scss
@@ -15,7 +15,7 @@ progress {
 	@include border;
 	background-color: $wc-ui-color-progress-bg;
 	display: block;
-	height: $line-size;
+	height: 1em;
 	position: relative;
 	width: 100%;
 

--- a/wcomponents-theme/src/main/sass/wc.ui.progressBar.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.progressBar.scss
@@ -30,6 +30,6 @@ progress {
 	max-width: 100%;
 
 	&.small {
-		font-size: 0.67em;
+		font-size: 0.67rem;
 	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.resizeableIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.resizeableIcons.scss
@@ -9,7 +9,7 @@
 // scss-lint:disable QualifyingElement
 button.wc_maxcont {
 	&:before {
-		@include wc-icon($fa-var-plus);
+		content: $fa-var-plus;
 	}
 
 	&[aria-pressed='true']:before {

--- a/wcomponents-theme/src/main/sass/wc.ui.section.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.section.scss
@@ -17,12 +17,9 @@
 		color: $wc-ui-color-section-heading-fg;
 	}
 
-	// Only change disabled state of a elements.
-	// scss-lint:disable QualifyingElement
 	.wc_btn_nada[disabled],
 	.wc_btn_nada[disabled],
 	a[aria-disabled='true'] {
 		color: $wc-ui-color-section-heading-fg-disabled;
 	}
-	// scss-lint:enable QualifyingElement
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.shuffler.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.shuffler.scss
@@ -1,7 +1,6 @@
 /* wc.ui.shuffler.scss */
 // Shuffler is a select element where the option order is able to be changed.
 // we have a bunch of buttons next to this component, we better make the select at least as high as the button tower.
-//scss-lint:disable QualifyingElement
-select.wc-shuffler {
-	min-height: 8em;
+.wc-shuffler select {
+	min-height: 8rem;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.table.pagination.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.pagination.ie8.scss
@@ -8,27 +8,21 @@
 		margin-left: $hgap-large;
 	}
 
-	button {
+	button + button {
 		&:before {
-			@include wc-icon-fw($fa-var-angle-double-left);
+			content: $fa-var-angle-left;
 		}
-
+		// IE8 sucks, we need this nesting depth
+		//scss-lint:disable NestingDepth
 		+ button {
 			&:before {
-				content: $fa-var-angle-left;
+				content: $fa-var-angle-right;
 			}
-			// IE8 sucks, we need this nesting depth
-			//scss-lint:disable NestingDepth
-			+ button {
-				&:before {
-					content: $fa-var-angle-right;
-				}
 
-				+ button:before {
-					content: $fa-var-angle-double-right;
-				}
-
+			+ button:before {
+				content: $fa-var-angle-double-right;
 			}
+
 		}
 	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.table.paginationIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.paginationIcons.scss
@@ -4,7 +4,8 @@
 // The deep nesting and repition here is necessitated by IE8's (and earlier)) lack of nth-child
 .wc_table_pag_cont button {
 	&::before {
-		@include wc-icon-fw($fa-var-angle-double-left);
+		content: $fa-var-angle-double-left;
+		min-width: 1rem;
 	}
 
 	&:nth-of-type(2) {

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansionIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansionIcons.scss
@@ -6,13 +6,11 @@
 
 tr[role='row'] {
 	> td[role='button']:before {
-		// @include wc-icon($fa-var-chevron-circle-right);
 		@include wc-icon-fw($fa-var-caret-right);
 	}
 
 	&[aria-expanded='true'] {
 		> td[role='button']:before {
-			// content: $fa-var-chevron-circle-down;
 			content: $fa-var-caret-down;
 		}
 	}

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.scss
@@ -12,6 +12,8 @@ tr[aria-selected] {
 }
 
 .wc_table_sel_wrapper {
+	white-space: nowrap;
+
 	[role='menubar'] {
 		button {
 			margin-left: 0; // override .wc_seltog style.
@@ -30,9 +32,4 @@ tr[aria-selected] {
 			}
 		}
 	}
-}
-
-.wc_table_col_hasmenu {
-	// text-align: right;
-	width: ($line-size * 2);
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowSelectionIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowSelectionIcons.scss
@@ -3,14 +3,14 @@
 @import 'wc.ui.menu_vars.scss';
 
 // only want to style aria-selected rows, nothing else
-tr[aria-selected]  > .wc_table_sel_wrapper:before {
-	@include wc-icon($fa-var-circle-o);
-	text-align: left;
-	width: 1em;
-}
+.wc_table_sel_wrapper:before {
+	tr[aria-selected] > & {
+		@include wc-icon-fw($fa-var-circle-o, left);
+	}
 
-.wc_table_sel_wrapper  tr[aria-selected='true'] > &:before {
-	content: $fa-var-dot-circle-o;
+	tr[aria-selected='true'] > & {
+		content: $fa-var-dot-circle-o;
+	}
 }
 
 [aria-multiselectable='true'] {
@@ -29,11 +29,11 @@ tr[aria-selected]  > .wc_table_sel_wrapper:before {
 	}
 
 	> tbody  > tr {
-		&[aria-selected]  > .wc_table_sel_wrapper:before {
+		&[aria-selected] > .wc_table_sel_wrapper:before {
 			content: $fa-var-square-o;
 		}
 
-		&[aria-selected='true']  > .wc_table_sel_wrapper:before {
+		&[aria-selected='true'] > .wc_table_sel_wrapper:before {
 			content: $fa-var-check-square-o;
 		}
 	}

--- a/wcomponents-theme/src/main/sass/wc.ui.table.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.scss
@@ -52,7 +52,7 @@ th.wc_table_sel_wrapper { // reset the vertical alignment of th with these class
 }
 
 .wc_table_colauto {
-	width: 0.5em; // actually anything small but more than zero.
+	width: 0.5rem; // actually anything small but more than zero.
 }
 
 // Column Striping.

--- a/wcomponents-theme/src/main/sass/wc.ui.table.sortIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.sortIcons.scss
@@ -4,7 +4,7 @@
 th {
 	&[aria-sort]:after {
 		@include wc-icon($fa-var-caret-down);
-		margin-left: $hgap-small; //allow for 16px image, image position and 0.25em between text and image.
+		margin-left: $hgap-small;
 	}
 
 	&[sorted]:after {

--- a/wcomponents-theme/src/main/sass/wc.ui.timeoutWarn.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.timeoutWarn.scss
@@ -8,6 +8,6 @@
 	bottom: 0;
 	position: fixed;
 	right: 0;
-	width: 35em;
+	width: 35rem;
 	z-index: $z-index-unloading-message; // z-index needs to be above dialogs, unloading shims etc
 }

--- a/wcomponents-theme/src/main/xslt/wc.common.listSortControls.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.listSortControls.xsl
@@ -12,6 +12,7 @@
 	<xsl:template name="listSortControls">
 		<xsl:param name="id" select="@id"/>
 		<span class="wc_sortcont">
+			<xsl:if test="self::ui:multiselectpair">&#x00a0;</xsl:if>
 			<xsl:call-template name="listSortControl">
 				<xsl:with-param name="id" select="$id"/>
 				<xsl:with-param name="value" select="'top'"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.fileUpload.file.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.fileUpload.file.xsl
@@ -39,7 +39,7 @@
 				</xsl:otherwise>
 			</xsl:choose>
 			<xsl:if test="not($readOnly=$t)">
-				<button type="button" class="wc_btn_nada" title="{$removeTxt}"></button>
+				<button type="button" class="wc_btn_icon" title="{$removeTxt}"></button>
 			</xsl:if>
 		</li>
 	</xsl:template>

--- a/wcomponents-theme/src/main/xslt/wc.ui.multiSelectPair.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.multiSelectPair.xsl
@@ -92,6 +92,7 @@
 					</span>
 					<!-- BUTTONS -->
 					<span class="wc_msp_btncol">
+						&#x00a0;
 						<xsl:call-template name="multiSelectPairButton">
 							<xsl:with-param name="value" select="'add'"/>
 							<xsl:with-param name="buttonText" select="$$${wc.ui.multiSelectPair.i18n.button.add}"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.xsl
@@ -205,13 +205,7 @@
 							</xsl:if>
 
 							<xsl:if test="$rowSelection=1">
-								<col>
-									<xsl:attribute name="class">
-										<xsl:text>wc_table_colauto</xsl:text>
-										<xsl:if test="$hasToggleSelectMode = 1">
-											<xsl:text> wc_table_col_hasmenu</xsl:text>
-										</xsl:if>
-									</xsl:attribute>
+								<col class="wc_table_colauto">
 									<xsl:if test="$isDebug=1">
 										<xsl:comment>row selection column</xsl:comment>
 									</xsl:if>


### PR DESCRIPTION
Fixed a few issues in the CSS for file inputs. They should now be a bit
less awful.

Added a bit of transparency to the back to top link.

Removed more superfluous styles:
* Made icon buttons control the icon mixin so the different types of
icon button only have to worry about their content.
* Re-jigged sizes into rems to improve consistency.
* Reset icon sizes to 1rem to ensure iconified components have a hit
zone of at least 16x16px (a11y).
* Removed all the line-size related calculations as these are no longer
needed.
* Removed the top pad from the multiselectpair button containers and
replaced it with a text character which is guaranteed to be the same
height as a single-line label.