### PR TITLE
Style updates, POM SNAPSHOT versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.github.bordertech.wcomponents</groupId>
 	<artifactId>wcomponents-parent</artifactId>
-	<version>1.0.4-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 

--- a/wcomponents-app-archetype/pom.xml
+++ b/wcomponents-app-archetype/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.0.4-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-bundle/pom.xml
+++ b/wcomponents-bundle/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.0.4-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-core/pom.xml
+++ b/wcomponents-core/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.0.4-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-examples-lde/pom.xml
+++ b/wcomponents-examples-lde/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.0.4-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-examples/pom.xml
+++ b/wcomponents-examples/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.0.4-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-findbugs-plugin/pom.xml
+++ b/wcomponents-findbugs-plugin/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.0.4-SNAPSHOT</version>	
+		<version>1.1.0-SNAPSHOT</version>	
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-lde/pom.xml
+++ b/wcomponents-lde/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.0.4-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-test-lib/pom.xml
+++ b/wcomponents-test-lib/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.0.4-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-theme-parent/pom.xml
+++ b/wcomponents-theme-parent/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.0.4-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-theme/.scss-lint.yml
+++ b/wcomponents-theme/.scss-lint.yml
@@ -17,12 +17,6 @@ linters:
     # default same_line which does not align with our eslint rules and is slightly less readable.
     style: new_line
 
-  ImportPath:
-    enabled: true
-    leading_underscore: false
-    # default false - this should be easy enough to fix but does not gel with IDE autocomplete.
-    filename_extension: true
-
   Indentation:
     enabled: true
     allow_non_nested_indentation: false

--- a/wcomponents-theme/pom.xml
+++ b/wcomponents-theme/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-theme-parent</artifactId>
-		<version>1.0.4-SNAPSHOT</version>
+		<version>1.1.0-SNAPSHOT</version>
 		<relativePath>../wcomponents-theme-parent/pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-theme/src/main/sass/_btn-icon.scss
+++ b/wcomponents-theme/src/main/sass/_btn-icon.scss
@@ -1,0 +1,16 @@
+@import 'mixins-common';
+// Common styles for buttons which are always iconic.
+
+.wc_btn_icon {
+	@include button;
+	color: inherit;
+
+	&:before {
+		@include wc-icon;
+	}
+
+	&[disabled] {
+		background-color: $wc-ui-color-disabled-bg;
+		color: $wc-ui-color-disabled-fg;
+	}
+}

--- a/wcomponents-theme/src/main/sass/_btn-icon.scss
+++ b/wcomponents-theme/src/main/sass/_btn-icon.scss
@@ -1,7 +1,7 @@
 @import 'mixins-common';
 // Common styles for buttons which are always iconic.
 
-.wc_btn_icon {
+%wc_btn_icon {
 	@include button;
 	color: inherit;
 

--- a/wcomponents-theme/src/main/sass/_btn-link.scss
+++ b/wcomponents-theme/src/main/sass/_btn-link.scss
@@ -1,7 +1,7 @@
 // CLASS wc_btn_link is made to look like a link.
 @import 'mixins-common';
 
-.wc_btn_link {
+%wc_btn_link {
 	color: $wc-ui-color-link;
 	text-decoration: underline;
 

--- a/wcomponents-theme/src/main/sass/_btn-link.scss
+++ b/wcomponents-theme/src/main/sass/_btn-link.scss
@@ -1,0 +1,12 @@
+// CLASS wc_btn_link is made to look like a link.
+@import 'mixins-common';
+
+.wc_btn_link {
+	color: $wc-ui-color-link;
+	text-decoration: underline;
+
+	// class wc_nti (no text image) is applied to buttons and links which hold an image but no visible text.
+	&.wc_nti {
+		text-decoration: none;
+	}
+}

--- a/wcomponents-theme/src/main/sass/_btn-nada.scss
+++ b/wcomponents-theme/src/main/sass/_btn-nada.scss
@@ -1,7 +1,7 @@
 // CLASS wc_btn_nada has all style stripped.
 @import 'mixins-common';
 
-.wc_btn_nada {
+%wc_btn_nada {
 	@include button($border: 0, $padding: 0, $text-align: inherit);
 	color: inherit;
 	cursor: pointer;

--- a/wcomponents-theme/src/main/sass/_btn-nada.scss
+++ b/wcomponents-theme/src/main/sass/_btn-nada.scss
@@ -1,0 +1,13 @@
+// CLASS wc_btn_nada has all style stripped.
+@import 'mixins-common';
+
+.wc_btn_nada {
+	@include button($border: 0, $padding: 0, $text-align: inherit);
+	color: inherit;
+	cursor: pointer;
+
+	&[disabled] {
+		color: $wc-ui-color-disabled-fg;
+		cursor: auto;
+	}
+}

--- a/wcomponents-theme/src/main/sass/_colors.scss
+++ b/wcomponents-theme/src/main/sass/_colors.scss
@@ -1,5 +1,5 @@
 // Component colors
-@import 'colorscheme.scss';
+@import 'colorscheme';
 
 // disabled colours are special They are harder to get 4.5:1 and still look disabled!
 $wc-ui-color-disabled-fg: #696969;

--- a/wcomponents-theme/src/main/sass/_mixins-common.scss
+++ b/wcomponents-theme/src/main/sass/_mixins-common.scss
@@ -1,10 +1,10 @@
 // Allow Vendor Prefix in mixins.
 //scss-lint:disable VendorPrefix
 
-@import 'vars.scss';
-@import 'mixins-flex.scss'; // flex layouts.
-@import 'mixins-respond.scss'; // responsive design media queries.
-@import 'mixins-icon.scss'; // in-built iconography.
+@import 'vars';
+@import 'mixins-flex'; // flex layouts.
+@import 'mixins-respond'; // responsive design media queries.
+@import 'mixins-icon'; // in-built iconography.
 
 /// Set the elements text-align property. I am not convinced this is a useful mixin.
 /// @param {alignment} $align [$preferred-alignment] The horizontal alignment to set.

--- a/wcomponents-theme/src/main/sass/_mixins-common.scss
+++ b/wcomponents-theme/src/main/sass/_mixins-common.scss
@@ -183,9 +183,17 @@
 /// Make a container into a simple padded box with a standard border.
 /// @param {dimaension} $pad [$hgap-normal] The amount of padding.
 /// @param {color} $border [$wc-ui-color-border] The border color.
-@mixin padded-box($pad: $hgap-normal, $border: $wc-ui-color-border) {
+/// @param {color|-1} $color [-1] The foreground color. Set to -1 (default) to not set this rule.
+/// @param {color|-1} $bg-color [-1] The background color. Set to -1 (default) to not set this rule.
+@mixin padded-box($pad: $hgap-normal, $border: $wc-ui-color-border, $color: -1, $bg-color: -1) {
 	@include border($color: $border);
 	padding: $pad;
+	@if ($bg-color != -1) {
+		background-color: $bg-color;
+	}
+	@if ($color != -1) {
+		color: $color;
+	}
 }
 
 /// Set margin and padding to 0.

--- a/wcomponents-theme/src/main/sass/_mixins-icon.scss
+++ b/wcomponents-theme/src/main/sass/_mixins-icon.scss
@@ -2,9 +2,9 @@
 // Moved out of mixins-common for ease of override.
 
 // FontAwesome mixins and vars...
-@import 'mixins-animate.scss';
-@import 'libs/fa/variables.scss';
-@import 'libs/fa/mixins.scss';
+@import 'mixins-animate';
+@import 'libs/fa/variables';
+@import 'libs/fa/mixins';
 
 /// use fa-icon
 @mixin wc-icon ($icon: -1) {

--- a/wcomponents-theme/src/main/sass/_mixins-respond.scss
+++ b/wcomponents-theme/src/main/sass/_mixins-respond.scss
@@ -6,7 +6,7 @@ $small: 1000px;
 //and a common/medium screen?
 $medium: 1280px;
 //how about a BIG screen?
-$large: 1981px;//bigger than 1080p
+$large: 1921px;//bigger than 1080p
 
 @mixin respond($size, $test: max-width) {
 	@if($size == phone) { //should cover most modern phones and some smaller/older tablets

--- a/wcomponents-theme/src/main/sass/_vars.scss
+++ b/wcomponents-theme/src/main/sass/_vars.scss
@@ -1,6 +1,6 @@
 // Meta Module to import all common variables.
 //You can (probably) safely import this file rather than trying to work out which common vars files you need
-@import 'colors.scss';
-@import 'common.scss';
-@import 'fonts.scss';
-@import 'spacing.scss';
+@import 'colors';
+@import 'common';
+@import 'fonts';
+@import 'spacing';

--- a/wcomponents-theme/src/main/sass/wc.common.accesskey.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.accesskey.dt.scss
@@ -1,5 +1,5 @@
 /* wc.common.accesskey.dt.scss */
-@import 'wc.common.accesskey_vars.scss';
+@import 'wc.common.accesskey_vars';
 // Provides the styling for the accesskey indicator for componentd which implement the @accessKey XML attribute.
 
 // The accesskey character and callout will be in a label, legend, link or button.

--- a/wcomponents-theme/src/main/sass/wc.common.accesskey_vars.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.accesskey_vars.scss
@@ -1,5 +1,5 @@
 // variables used in accessKey indicators
-@import 'mixins-common.scss';
+@import 'mixins-common';
 $wc-ui-color-tooltip-fg: $std-color-primary;
 $wc-ui-color-tooltip-bg: $std-color-tertiary;
 $wc-ui-color-tooltip-border: $std-color-lines;

--- a/wcomponents-theme/src/main/sass/wc.common.buttonLinkImages.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.buttonLinkImages.scss
@@ -1,5 +1,5 @@
 /* wc.common.buttonLinkImages.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 // Positioning of an image in a WButton or WLink based on the component's imagePosition property. XS:TOKENs for this
 // property are 'n','e','s','w'.
 // Used by:

--- a/wcomponents-theme/src/main/sass/wc.common.buttons.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.buttons.scss
@@ -18,7 +18,7 @@
 // Having a button which is styled to emulate a link is to provide UI consistency in areas where buttons and links are
 // mixed. It may be more appropriate to not have a button which disguises itself as a link but to use the noStyle
 // variant.
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 /// User agent button styles are the bane of our lives. The _main_ problem is hard coded font styles rather than
 /// allowing them to inherit.
@@ -30,46 +30,9 @@ button {
 	line-height: inherit;
 }
 
-.wc_btn {
-	&_link,
-	&_nada { // CLASS wc_btn_nada has all style stripped. CLASS wc_btn_link is made to look like a link.
-		@include button($border: 0, $padding: 0, $text-align: inherit);
-		cursor: pointer;
-
-		&[disabled] {
-			color: $wc-ui-color-disabled-fg;
-			cursor: auto;
-		}
-	}
-
-	&_nada {
-		color: inherit;
-	}
-
-	&_link {
-		color: $wc-ui-color-link;
-		text-decoration: underline;
-	}
-
-	&_icon { // Common styles for buttons which are always iconic
-		@include button;
-		color: inherit;
-
-		&:before {
-			@include wc-icon;
-		}
-
-		&[disabled] {
-			background-color: $wc-ui-color-disabled-bg;
-			color: $wc-ui-color-disabled-fg;
-		}
-	}
-}
-
-// class wc_nti (no text image) is applied to buttons and links which hold an image but no visible text.
-.wc_nti {
-	text-decoration: none;
-}
+@import 'btn-nada';
+@import 'btn-link';
+@import 'btn-icon';
 
 /// Components which are not button elements but act as buttons. This is _very_ rare and is currently limited to
 /// summary elements in browsers which do not provide native details/summary behaviour.

--- a/wcomponents-theme/src/main/sass/wc.common.buttons.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.buttons.scss
@@ -34,6 +34,18 @@ button {
 @import 'btn-link';
 @import 'btn-icon';
 
+.wc_btn_nada {
+	@extend %wc_btn_nada;
+}
+
+.wc_btn_link {
+	@extend %wc_btn_link;
+}
+
+.wc_btn_icon {
+	@extend %wc_btn_icon;
+}
+
 /// Components which are not button elements but act as buttons. This is _very_ rare and is currently limited to
 /// summary elements in browsers which do not provide native details/summary behaviour.
 [role='button'] {

--- a/wcomponents-theme/src/main/sass/wc.common.checkRadioIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.checkRadioIcons.scss
@@ -1,5 +1,5 @@
 /* wc.common.checkRadioIcons.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 /// WCheckBox and WRadioButton in read-only mode.
 .wc-checkbox,

--- a/wcomponents-theme/src/main/sass/wc.common.form.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.form.scss
@@ -1,6 +1,6 @@
 /* wc.common.form.scss */
 // This document contains general css styling for generic form components. Custom components have their own css files
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 input,
 select,

--- a/wcomponents-theme/src/main/sass/wc.common.libs.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.libs.scss
@@ -1,2 +1,2 @@
 // include font-awesome
-@import 'libs/fa/font-awesome.scss';
+@import 'libs/fa/font-awesome';

--- a/wcomponents-theme/src/main/sass/wc.common.list.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.list.scss
@@ -1,6 +1,6 @@
 /* wc.common.list.scss */
 /// Styles applied to list output of many components.
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 /// represents a list with no bullets
 .wc_list_nb {

--- a/wcomponents-theme/src/main/sass/wc.common.listSort.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.listSort.scss
@@ -1,6 +1,6 @@
 /* wc.common.listSort.scss */
 // The list sort controls are the buttons used to reorder the options used by WMultiSelectPair and WShuffler
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 /// The container for the list shuffle controls.
 .wc_sortcont {

--- a/wcomponents-theme/src/main/sass/wc.common.listSortIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.listSortIcons.scss
@@ -1,7 +1,7 @@
 /* wc.common.listSortIcons.scss */
 
 // The list sort controls are the buttons used to reorder the options used by WMultiSelectPair and WShuffler
-@import 'mixins-common.scss';
+@import 'mixins-common';
 /// Each individual shuffle control's iconography
 .wc_sorter {
 	&:before {

--- a/wcomponents-theme/src/main/sass/wc.common.listbox.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.listbox.scss
@@ -1,6 +1,6 @@
 /* wc.common.listbox.scss */
 // listbox for combo and datefield
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 ul[role='listbox'] {
 	@include border;

--- a/wcomponents-theme/src/main/sass/wc.common.modalShim.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.modalShim.scss
@@ -1,5 +1,5 @@
 /* wc.common.modalShim.scss */
-@import 'wc.common.modalShim_vars.scss';
+@import 'wc.common.modalShim_vars';
 // The modal shim is a single generated artefact with a constant id.
 // TODO: maybe change this to a class rather than an ID now we do not have IE6 performance to worry about?
 // scss-lint:disable IdSelector

--- a/wcomponents-theme/src/main/sass/wc.common.modalShim_vars.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.modalShim_vars.scss
@@ -1,4 +1,4 @@
 // Variables for the modal shim
-@import 'vars.scss';
+@import 'vars';
 $wc-ui-color-modal-shim: $std-color-shim;
 $wc-ui-color-modal-shim-foreground: $wc-ui-color-inverse-fg;

--- a/wcomponents-theme/src/main/sass/wc.common.page.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.page.dt.scss
@@ -1,5 +1,5 @@
 /* wc.common.page.dt.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 body {
 	@include respond($size: 1024px, $test: min-device-width) {

--- a/wcomponents-theme/src/main/sass/wc.common.page.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.page.scss
@@ -1,6 +1,6 @@
 /* wc.common.page.scss */
 // Primary styling for the page and preliminary styling of some commonly used basic elements and layout classes.
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 // We need to have the document body fill the viewport in all browsers to correctly propagate some click events.
 html {

--- a/wcomponents-theme/src/main/sass/wc.common.rowColumn.ie10.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.rowColumn.ie10.scss
@@ -1,5 +1,5 @@
 /* wc.ui.row.ie10.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc-column {
 	@include border-box;

--- a/wcomponents-theme/src/main/sass/wc.common.rowColumn.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.rowColumn.scss
@@ -1,5 +1,5 @@
 /* wc.ui.row.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc-row {
 	@include flex($justify: space-between);

--- a/wcomponents-theme/src/main/sass/wc.common.sectionSpacing.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.sectionSpacing.scss
@@ -1,4 +1,4 @@
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 section {
 	@include border;

--- a/wcomponents-theme/src/main/sass/wc.debug.axs.scss
+++ b/wcomponents-theme/src/main/sass/wc.debug.axs.scss
@@ -1,7 +1,7 @@
 /* wc.debug.axs.scss */
 // CSS for the AXE/AXS output in debug mode
 
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc_a11y {
 	@include border;

--- a/wcomponents-theme/src/main/sass/wc.debug.common.scss
+++ b/wcomponents-theme/src/main/sass/wc.debug.common.scss
@@ -5,7 +5,7 @@
 // Next time you decide to delete all of the debug Sass and stop building it:
 // ### **DON'T** ###
 // Really, just don't otherwise you will have to put some of it back again and that is a PITA.
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 $wc-ui-color-debug-fg: $std-color-primary;
 

--- a/wcomponents-theme/src/main/sass/wc.ui.backToTop.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.backToTop.dt.scss
@@ -1,5 +1,5 @@
 /* wc.ui.backToTop.dt.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 /// The back to top of page link.
 .wc_btt:before {
 	font-size: 4rem;

--- a/wcomponents-theme/src/main/sass/wc.ui.backToTop.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.backToTop.scss
@@ -1,5 +1,5 @@
 /* wc.ui.backToTop.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 /// The back to top of page link.
 .wc_btt {

--- a/wcomponents-theme/src/main/sass/wc.ui.calendar.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.calendar.dt.scss
@@ -1,5 +1,5 @@
 /* wc.ui.calendar.dt.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 // The calendar container is a single generated element with a fixed id.
 // scss-lint:disable IdSelector
 #wc-calbox { // This is the calendar container.

--- a/wcomponents-theme/src/main/sass/wc.ui.calendar.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.calendar.scss
@@ -2,7 +2,7 @@
 
 // We use a single ID'd component for all calendar date pickers and move it around to where it is needed.
 // scss-lint:disable IdSelector
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 
 // This is the calendar container.

--- a/wcomponents-theme/src/main/sass/wc.ui.calendarIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.calendarIcons.scss
@@ -1,5 +1,5 @@
 /* wc.ui.calendarIcons.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 // use a single identified artefact for calendars
 //scss-lint:disable IdSelector

--- a/wcomponents-theme/src/main/sass/wc.ui.checkableSelect.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.checkableSelect.scss
@@ -1,6 +1,6 @@
 /* wc.ui.checkableSelect.scss */
 // CSS for WCheckBoxSelect and WRadioButtonSelect
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc_chkgrp {
 	&_bdr {

--- a/wcomponents-theme/src/main/sass/wc.ui.collapsible.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.collapsible.scss
@@ -8,7 +8,7 @@
 
 // The styles here are purposely minimal and will give you a DETAILS element pretty much like a Chrome default.
 
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 details,
 summary {

--- a/wcomponents-theme/src/main/sass/wc.ui.collapsibleIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.collapsibleIcons.scss
@@ -8,7 +8,7 @@
 
 // The styles here are purposely minimal and will give you a DETAILS element pretty much like a Chrome default.
 
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 summary {
 	&:before {

--- a/wcomponents-theme/src/main/sass/wc.ui.collapsibleToggle.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.collapsibleToggle.scss
@@ -1,5 +1,5 @@
 /* wc.ui.collapsibleToggle.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc-collapsibletoggle {
 	@include tight-box;

--- a/wcomponents-theme/src/main/sass/wc.ui.collapsibleToggleIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.collapsibleToggleIcons.scss
@@ -1,5 +1,5 @@
 /* wc.ui.collapsibleToggleIcons.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc-collapsibletoggle {
 	button:before {

--- a/wcomponents-theme/src/main/sass/wc.ui.combo.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.combo.scss
@@ -1,5 +1,5 @@
 /* wc.ui.combo.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 // This redundant rule is not as redundant as you might think so just leave it be!
 datalist {

--- a/wcomponents-theme/src/main/sass/wc.ui.comboIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.comboIcons.scss
@@ -1,5 +1,5 @@
 /* wc.ui.comboIcons.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc_list_wrapper:before {
 	@include wc-icon-fw($fa-var-caret-down);

--- a/wcomponents-theme/src/main/sass/wc.ui.dateField.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dateField.scss
@@ -4,7 +4,7 @@
 
 // We use a single ID'd component for all calendar date pickers and move it around to where it is needed.
 // scss-lint:disable IdSelector
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc-datefield {
 	display: inline-block;
@@ -29,6 +29,11 @@
 	&:focus {
 		background-color: $wc-ui-color-invite-bg;
 		color: $wc-ui-color-invite-fg;
+	}
+
+	&[disabled]:hover {
+		background-color: $wc-ui-color-disabled-bg;
+		color: $wc-ui-color-disabled-fg;
 	}
 }
 

--- a/wcomponents-theme/src/main/sass/wc.ui.dateFieldIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dateFieldIcons.scss
@@ -1,5 +1,5 @@
 /* wc.ui.dateFieldIcons.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 // calendar launch button
 .wc_wdf_cal:before {

--- a/wcomponents-theme/src/main/sass/wc.ui.decoratedLabel.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.decoratedLabel.scss
@@ -1,5 +1,5 @@
 /* wc.ui.decoratedLabel.scss */
-@import 'vars.scss';
+@import 'vars';
 
 .wc_dlbl_seg {
 	display: inline-block;

--- a/wcomponents-theme/src/main/sass/wc.ui.definitionList.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.definitionList.scss
@@ -1,5 +1,5 @@
 /* wc.ui.definitionList.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 // NOTE: the dl element is required here to differentiate from WFieldLayout with the same classNames generated from
 // LAYOUT attribute in XML

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog.dt.scss
@@ -1,5 +1,5 @@
 /* wc.ui.dialog.dt.scss */
-@import 'wc.ui.dialog_vars.scss';
+@import 'wc.ui.dialog_vars';
 
 dialog {
 	left: auto;

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog.ie9.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog.ie9.scss
@@ -1,5 +1,5 @@
 /* wc.ui.dialogue.ie9.scss */
-@import 'wc.ui.dialog_vars.scss';
+@import 'wc.ui.dialog_vars';
 
 dialog {
 	&[open] {

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog.pattern_safari.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog.pattern_safari.scss
@@ -1,5 +1,5 @@
 /* wc.ui.dialog.pattern_safari.scss */
-@import 'wc.ui.dialog_vars.scss';
+@import 'wc.ui.dialog_vars';
 
 dialog > [aria-live] { // dialog content container
 	// need to work around a Safari-OSX bug but not for full screen dialogs.

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog.scss
@@ -1,7 +1,7 @@
 /* wc.ui.dialog.scss */
 // The actual dialog. Its position is set on open such that it sits in the middle of the viewport. Margin:auto only
 // works in Chrome and Webkit.
-@import 'wc.ui.dialog_vars.scss';
+@import 'wc.ui.dialog_vars';
 
 dialog {
 	@include border($width: 0); // oh chrome, you try so hard to annoy me

--- a/wcomponents-theme/src/main/sass/wc.ui.dialogIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialogIcons.scss
@@ -1,7 +1,7 @@
 /* wc.ui.dialogIcons.scss */
 // The actual dialog. Its position is set on open such that it sits in the middle of the viewport. Margin:auto only
 // works in Chrome and Webkit.
-@import 'wc.ui.dialog_vars.scss';
+@import 'wc.ui.dialog_vars';
 
 // dialog close control
 // NOTE: for resize handle and max/restore control see wc.ui.resizeable.scss.

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog_vars.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog_vars.scss
@@ -1,5 +1,5 @@
 // Override this for some simple colour/size over-rides for dialogs
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 $wc-ui-color-dialog-head-bg: $std-color-primary;
 $wc-ui-color-dialog-head-fg: $std-color-primary-accent;

--- a/wcomponents-theme/src/main/sass/wc.ui.feedback.messages.colors.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.feedback.messages.colors.scss
@@ -6,7 +6,7 @@
 //    Client side validation error messages if plugin enabled
 
 // Colors for inline messages
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 ul {
 	&.error {

--- a/wcomponents-theme/src/main/sass/wc.ui.feedback.messages.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.feedback.messages.scss
@@ -1,5 +1,5 @@
 /* wc.ui.feedback.messages.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 // Common states for foreground aspects of messages
 // NOTE: the element selector is required here for error messages as we need to differentiate the message from the

--- a/wcomponents-theme/src/main/sass/wc.ui.feedback.messagesIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.feedback.messagesIcons.scss
@@ -9,7 +9,7 @@
 // This is split out from the main feedback CSS for ease of overriding as it is a lot of
 // CSS to do a very small job and overriding the whole lot in an implementation would require all
 // this just to turn off the pseudo elements plus the styling needed for the indicators.
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .error,
 .success,

--- a/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.scss
@@ -1,5 +1,5 @@
 /* wc.ui.fieldLayout.scss */
-@import 'wc.ui.fieldLayout_vars.scss';
+@import 'wc.ui.fieldLayout_vars';
 
 // field layouts may be an ordered list, in which case we want to expose the numbers so need the element qualifier
 //scss-lint:disable QualifyingElement

--- a/wcomponents-theme/src/main/sass/wc.ui.fieldLayout_vars.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fieldLayout_vars.scss
@@ -1,4 +1,4 @@
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 $default-label-width: 50;
 $label-width: $default-label-width * 1%;

--- a/wcomponents-theme/src/main/sass/wc.ui.fieldset.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fieldset.scss
@@ -1,5 +1,5 @@
 /* wc.ui.fieldset.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 fieldset {
 	@include padded-box($pad: $hgap-small);

--- a/wcomponents-theme/src/main/sass/wc.ui.figure.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.figure.scss
@@ -1,5 +1,5 @@
 /* wc.ui.figure.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 figure {
 	@include flex($direction: column, $align-content: center);

--- a/wcomponents-theme/src/main/sass/wc.ui.fileUpload.ie11.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fileUpload.ie11.scss
@@ -1,5 +1,5 @@
 /* wc.ui.fileUpload.ie11.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc-fileupload .wc-file {
 	padding-right: 3px; // IE11 cannot calc 100% - 1.333 em and set a right pad in em at the same time. Useless POS.

--- a/wcomponents-theme/src/main/sass/wc.ui.fileUpload.pattern_edge.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fileUpload.pattern_edge.scss
@@ -1,5 +1,5 @@
 /* wc.ui.fileUpload.pattern_edge.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 // The default file upload in Edge is a bit ugly if anything is styled at all. This CSS may be considered lipstick.
 // Yes: Edge uses the -ms- shadow elements.

--- a/wcomponents-theme/src/main/sass/wc.ui.fileUpload.pattern_ff.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fileUpload.pattern_ff.scss
@@ -1,5 +1,5 @@
 /* wc.ui.fileUpload.pattern_ff.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 // Firefox file uploads.
 //scss-lint:disable VendorPrefix

--- a/wcomponents-theme/src/main/sass/wc.ui.fileUpload.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fileUpload.scss
@@ -1,5 +1,5 @@
 /* wc.ui.fileUpload.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc-fileupload {
 	a {

--- a/wcomponents-theme/src/main/sass/wc.ui.fileUploadIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fileUploadIcons.scss
@@ -1,5 +1,5 @@
 /* wc.ui.fileUploadIcons.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc-fileupload  a ~ button:before {
 	content: $fa-var-trash;

--- a/wcomponents-theme/src/main/sass/wc.ui.heading.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.heading.scss
@@ -1,6 +1,6 @@
 /* wc.ui.heading.scss */
 // This file is purposely left as a stub for easy over-ride
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 h1,
 h2,

--- a/wcomponents-theme/src/main/sass/wc.ui.hr.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.hr.scss
@@ -1,5 +1,5 @@
 /* wc.ui.hr.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 hr {
 	//we want  to reset the border then set it only on the bottom.

--- a/wcomponents-theme/src/main/sass/wc.ui.image.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.image.scss
@@ -1,5 +1,5 @@
 /* wc.ui.image.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 img {
 	@include border($width: 0);

--- a/wcomponents-theme/src/main/sass/wc.ui.imageEdit.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.imageEdit.scss
@@ -1,5 +1,5 @@
 /* wc.ui.imageEdit.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc_img_editor {
 	background-color: $wc-ui-color-global-bg;

--- a/wcomponents-theme/src/main/sass/wc.ui.imageEditIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.imageEditIcons.scss
@@ -1,5 +1,5 @@
 /* wc.ui.imageEditIcons.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 button[data-img][data-editor]:before {
 	content: $fa-var-picture-o;

--- a/wcomponents-theme/src/main/sass/wc.ui.label.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.label.scss
@@ -1,6 +1,6 @@
 /* wc.ui.label.scss */
 // styles for WLabel and the label emulators
-@import 'wc.ui.label_vars.scss';
+@import 'wc.ui.label_vars';
 
 .hint {// .hint is additional text for labels that describe other information for the related form element
 	@include label-hint;

--- a/wcomponents-theme/src/main/sass/wc.ui.label_vars.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.label_vars.scss
@@ -1,4 +1,4 @@
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 @mixin label-hint {
 	color: $std-color-secondary;

--- a/wcomponents-theme/src/main/sass/wc.ui.legend.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.legend.scss
@@ -1,5 +1,5 @@
 /* wc.ui.legend.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 legend {
 	.wc_noborder > & {

--- a/wcomponents-theme/src/main/sass/wc.ui.listLayout.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.listLayout.ie8.scss
@@ -1,6 +1,6 @@
 /* wc.ui.listLayout.ie8.scss */
 //striped lists need an extra class as :nth-child is not supported.
-@import 'vars.scss';
+@import 'vars';
 
 .wc_iestripe {
 	background-color: $wc-ui-color-highlight-bg;

--- a/wcomponents-theme/src/main/sass/wc.ui.listLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.listLayout.scss
@@ -1,5 +1,5 @@
 /* wc.ui.listLayout.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc-listlayout {
 	margin: 0;

--- a/wcomponents-theme/src/main/sass/wc.ui.listLayoutIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.listLayoutIcons.scss
@@ -1,5 +1,5 @@
 /* wc.ui.listLayout.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc-listlayout.flat.dot > li + li:before { // dot bullets should be default but need pseudo-elements for flat lists.
 	@include wc-icon($fa-var-circle);

--- a/wcomponents-theme/src/main/sass/wc.ui.loading.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.loading.scss
@@ -1,6 +1,6 @@
 /* wc.ui.loading.scss */
 // styling for the loading indicator that appears for page reloads and AJAX regions
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 // loading indicator is generated and identified
 //scss-lint:disable IdSelector

--- a/wcomponents-theme/src/main/sass/wc.ui.loadingIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.loadingIcons.scss
@@ -1,6 +1,6 @@
 /* wc.ui.loadingIcons.scss */
 // styling for the loading indicator that appears for page reloads and AJAX regions
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 // loading indicator is generated and identified
 //scss-lint:disable IdSelector

--- a/wcomponents-theme/src/main/sass/wc.ui.mediaPlayer.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.mediaPlayer.scss
@@ -1,6 +1,6 @@
 /* wc.ui.media.player.scss */
 // styles for WAudio and WVideo when the media is not able to be handled by the user agent natively. */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc-src,
 .wc-track {

--- a/wcomponents-theme/src/main/sass/wc.ui.mediaPlayerIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.mediaPlayerIcons.scss
@@ -1,6 +1,6 @@
 /* wc.ui.media.playerIcons.scss */
 // styles for WAudio and WVideo when the media is not able to be handled by the user agent natively. */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc-src,
 .wc-track {

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.bar.pattern_ff.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.bar.pattern_ff.scss
@@ -1,5 +1,5 @@
 /* wc.ui.menu.bar.ff.scss */
-@import 'wc.ui.menu_vars.scss';
+@import 'wc.ui.menu_vars';
 
 $wc-ff-vseparator-pad-top: $wc-ui-menu-item-pad-topbottom * 2;
 

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.bar.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.bar.scss
@@ -1,7 +1,7 @@
 /* wc.ui.menu.bar.scss */
 // These styles apply to WMenus of type BAR and FLYOUT
 // NOTE: role menuitemradio and menuitemcheckbox can be shorthanded to aria-checked.
-@import 'wc.ui.menu_vars.scss';
+@import 'wc.ui.menu_vars';
 
 [role='menubar'] {
 	&.flyout {
@@ -71,7 +71,7 @@
 	}
 }
 
-@import 'wc.ui.panel_vars.scss'; // for the header foreground color
+@import 'wc.ui.panel_vars'; // for the header foreground color
 
 [role='banner'] [role='menubar'][data-wc-menufixed] {
 	display: inline-block;

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.dt.scss
@@ -1,6 +1,6 @@
 /* wc.ui.menu.barColumn.dt.scss */
 // Desktop styles for WMenu type BAR, type FLYOUT, type COLUMN
-@import 'wc.ui.menu_vars.scss';
+@import 'wc.ui.menu_vars';
 
 .wc-submenu {
 	[role='menubar'] &,

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.scss
@@ -1,6 +1,6 @@
 /* wc.ui.menu.barColumn.scss */
 // for WMenu type BAR, type FLYOUT, type COLUMN
-@import 'wc.ui.menu_vars.scss';
+@import 'wc.ui.menu_vars';
 
 [role='menu'] { //this role is any part of a COLUMN menu and submenus of a BAR or FLYOUT
 	> [role],

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumnIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumnIcons.scss
@@ -1,6 +1,6 @@
 /* wc.ui.menu.barColumn.icon.scss */
 // The opener iconoiography for WMenu type BAR, type FLYOUT, type COLUMN.
-@import 'wc.ui.menu_vars.scss';
+@import 'wc.ui.menu_vars';
 
 .wc-submenu > button {
 	[role='menubar'] > &:after {

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barIcons.scss
@@ -1,7 +1,7 @@
 /* wc.ui.menu.bar.scss */
 // These styles apply to WMenus of type BAR and FLYOUT
 // NOTE: role menuitemradio and menuitemcheckbox can be shorthanded to aria-checked.
-@import 'wc.ui.menu_vars.scss';
+@import 'wc.ui.menu_vars';
 
 [role='banner'] [data-wc-menufixed] > [role='menuitem']:first-child > button::before {
 	@include wc-icon($fa-var-bars);

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.color.scss
@@ -1,7 +1,7 @@
 /* wc.ui.menu.color.scss */
 // Colour styles common to all menus: made to ease theme overrides a little.
 // See wc.ui.menu.css for generic structure.
-@import 'wc.ui.menu_vars.scss';
+@import 'wc.ui.menu_vars';
 
 .wc-menu {
 	[role],

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.scss
@@ -12,7 +12,7 @@
 // would no longer need to submit. It is handy for other clickable/focusable/disableable goodness though.
 
 // TODO (wishful thinking): Where the WMenu type allows use the menu element in the popup mode and its label/button.
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 // Item default styles.
 // NOTE: an item may be a WMenuItem or a WSubMenu. Remember each submenu has an item role in [role='menu'] and

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.tree.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.tree.scss
@@ -1,5 +1,5 @@
 /* wc.ui.menu.tree.scss */
-@import 'wc.ui.menu_vars.scss';
+@import 'wc.ui.menu_vars';
 
 [role='tree'] [role='treeitem'],
 [role='treeitem'][aria-expanded] > button {

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.treeIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.treeIcons.scss
@@ -1,6 +1,6 @@
 /* wc.ui.menu.tree.icon.scss */
 // tree menu branch indicators
-@import 'wc.ui.menu_vars.scss';
+@import 'wc.ui.menu_vars';
 
 [role='treeitem'] {
 	&[aria-expanded] > button:before {

--- a/wcomponents-theme/src/main/sass/wc.ui.menu_vars.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu_vars.scss
@@ -1,4 +1,4 @@
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 //generic menu structure
 $wc-ui-menu-item-pad-topbottom: $vgap-normal;

--- a/wcomponents-theme/src/main/sass/wc.ui.messageBox.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.messageBox.scss
@@ -1,5 +1,5 @@
 /* wc.ui.messagesBox.scss */
-@import 'wc.ui.messageBox_vars.scss';
+@import 'wc.ui.messageBox_vars';
 
 .wc_msgbox {
 	@include border;

--- a/wcomponents-theme/src/main/sass/wc.ui.messageBoxIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.messageBoxIcons.scss
@@ -1,5 +1,5 @@
 /* wc.ui.messagesBoxIcons.scss */
-@import 'wc.ui.messageBox_vars.scss';
+@import 'wc.ui.messageBox_vars';
 
 .wc_msgbox {
 

--- a/wcomponents-theme/src/main/sass/wc.ui.messageBox_vars.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.messageBox_vars.scss
@@ -1,4 +1,4 @@
 /* wc.ui.messageBox_vars.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 $msg-box-header-size: 1.25rem;
 $msg-box-header-text-color: $std-color-white;

--- a/wcomponents-theme/src/main/sass/wc.ui.multiFormComponent.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.multiFormComponent.scss
@@ -1,6 +1,6 @@
 /* wc.ui.multiFormComponent.scss */
 // WMultiTextField and WMultiDropdown
-@import 'vars.scss';
+@import 'vars';
 
 .wc_mfc {
 	white-space: nowrap;

--- a/wcomponents-theme/src/main/sass/wc.ui.multiFormComponentIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.multiFormComponentIcons.scss
@@ -1,6 +1,6 @@
 /* wc.ui.multiFormComponentIcons.scss */
 // WMultiTextField and WMultiDropdown action buttons (+/-)
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc_mfc {
 	input,

--- a/wcomponents-theme/src/main/sass/wc.ui.multiSelectPair.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.multiSelectPair.scss
@@ -1,5 +1,5 @@
 /* wc.ui.multiSelectPair.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc-multiselectpair {
 	white-space: nowrap;

--- a/wcomponents-theme/src/main/sass/wc.ui.multiSelectPairIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.multiSelectPairIcons.scss
@@ -1,5 +1,5 @@
 /* wc.ui.multiSelectPairIcons.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc_msp_btncol button {
 	&:before {

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.action.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.action.scss
@@ -8,7 +8,7 @@
 
 // This inference leads us to make the ACTION panel into a piece of sectioning content using a SECTION element and set
 // its title as the H1 of the section.
-@import 'wc.ui.panel_vars.scss';
+@import 'wc.ui.panel_vars';
 
 .action {
 	background-color: $wc-ui-color-panel-action-background;

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.block.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.block.scss
@@ -4,7 +4,7 @@
 // type 'block' should do nothing?' But that would be too easy. A WPanel with no type is just a container. Type
 // BLOCK does (according to the javadoc): 'A 'block' type panel has padding around the edges.'
 
-@import 'wc.ui.panel_vars.scss';
+@import 'wc.ui.panel_vars';
 
 .block {
 	padding: $hgap-normal;

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.borderLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.borderLayout.scss
@@ -1,5 +1,5 @@
 /* wc.ui.panel.borderLayout.scss */
-@import 'wc.ui.panel_vars.scss';
+@import 'wc.ui.panel_vars';
 
 .wc_borderlayout_middle {
 	@include flex($justify: space-between);

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.box.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.box.scss
@@ -1,7 +1,7 @@
 /* wc.ui.panel.box.scss */
 // type BOX:
 // 'A box panel has a border.' therefore has a pad to remove the content from the border.
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .box {
 	@include padded-box;

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.chrome.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.chrome.scss
@@ -2,7 +2,7 @@
 // type CHROME
 // 'A panel with a title displayed in a border.'
 
-@import 'wc.ui.panel_vars.scss';
+@import 'wc.ui.panel_vars';
 
 .chrome > h1 {
 	background-color: $wc-ui-color-section-heading-bg;

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.feature.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.feature.scss
@@ -1,7 +1,7 @@
 /* wc.ui.panel.feature.scss */
 // type FEATURE
 // 'The feature panel is highlighted by a background colour and border.'
-@import 'wc.ui.panel_vars.scss';
+@import 'wc.ui.panel_vars';
 
 .feature {
 	@include padded-box;

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.flowLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.flowLayout.scss
@@ -1,5 +1,5 @@
 /* wc.ui.panel.flowLayout.scss */
-@import 'wc.ui.panel_vars.scss';
+@import 'wc.ui.panel_vars';
 
 .wc-flowlayout {
 	@include flex($wrap: wrap, $justify: flex-start, $align-items: flex-start, $align-content: flex-start);

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.footer.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.footer.scss
@@ -1,7 +1,7 @@
 /* wc.ui.panel.footer.scss */
 // WPanel Type.FOOTER
 // This CSS for the page footer
-@import 'wc.ui.panel_vars.scss';
+@import 'wc.ui.panel_vars';
 
 footer.wc-panel {
 	background-color: $wc-ui-color-panel-footer-background;

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.gridLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.gridLayout.scss
@@ -1,5 +1,5 @@
 /* wc.ui.panel.gridLaout.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 // We need to override the regular row flex model.
 .wc-gridlayout > .wc-row {

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.header.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.header.scss
@@ -1,7 +1,7 @@
 /* wc.ui.panel.header.scss */
 // This contains CSS for WPanel Type.HEADER which is used to make the page header (role banner) and is most commonly
 // over-ridden.
-@import 'wc.ui.panel_vars.scss';
+@import 'wc.ui.panel_vars';
 
 [role='banner'] {
 	background-color: $wc-ui-color-panel-header-background;

--- a/wcomponents-theme/src/main/sass/wc.ui.panel_vars.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel_vars.scss
@@ -1,4 +1,4 @@
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 $wc-ui-color-panel-action-header-background: $std-color-secondary;
 $wc-ui-color-panel-action-header-foreground: $std-color-secondary-accent;

--- a/wcomponents-theme/src/main/sass/wc.ui.progressBar.ie9.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.progressBar.ie9.scss
@@ -1,6 +1,6 @@
 /* wc.ui.progressBar.ie9.scss */
 // Description: Show the fake progress bar spans
-@import 'wc.ui.progress_var.scss';
+@import 'wc.ui.progress_var';
 
 progress {
 	display: inline-block;

--- a/wcomponents-theme/src/main/sass/wc.ui.progress_var.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.progress_var.scss
@@ -1,4 +1,4 @@
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 $wc-ui-color-progress-bg: $std-color-white;
 $wc-ui-color-progress-fg: $std-color-primary;

--- a/wcomponents-theme/src/main/sass/wc.ui.resizeable.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.resizeable.scss
@@ -1,5 +1,5 @@
 /* wc.ui.resizeable.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc_max { // maximised:
 	// scss-lint:disable ImportantRule

--- a/wcomponents-theme/src/main/sass/wc.ui.resizeableIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.resizeableIcons.scss
@@ -1,5 +1,5 @@
 /* wc.ui.resizeableIcons.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc_resize:before {
 	@include wc-icon($fa-var-hand-lizard-o);

--- a/wcomponents-theme/src/main/sass/wc.ui.root.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.root.scss
@@ -1,5 +1,5 @@
 /* wc.ui.root.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 noscript p {
 	@include border($width: 3px, $color: $wc-ui-color-error-fg);

--- a/wcomponents-theme/src/main/sass/wc.ui.section.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.section.scss
@@ -1,5 +1,5 @@
 /* wc.ui.section.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc-section > .wc-decoratedlabel {
 	background-color: $wc-ui-color-section-heading-bg;

--- a/wcomponents-theme/src/main/sass/wc.ui.selectToggle.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.selectToggle.scss
@@ -1,14 +1,19 @@
 /* wc.ui.selectToggle.scss */
 // only text mode
 
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc_seltog {
 	> button {
 		margin-left: $hgap-normal;
+		text-decoration: underline;
+
+		&:first-child {
+			margin-left: 0;
+		}
 
 		&[aria-checked='true'] {
-			font-weight: bold;
+			text-decoration: none;
 		}
 	}
 

--- a/wcomponents-theme/src/main/sass/wc.ui.selectToggleIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.selectToggleIcons.scss
@@ -19,7 +19,7 @@
 	> button {
 		&:before {
 			@include wc-icon-fw($fa-var-check-square-o, left);
-			opacity: 0.5;
+			opacity: 0.3333;
 		}
 
 		+ button:before {

--- a/wcomponents-theme/src/main/sass/wc.ui.selectToggleIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.selectToggleIcons.scss
@@ -1,16 +1,29 @@
 /* wc.ui.selectToggleIcons.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
-.wc_seltog[role='checkbox'] { // Rendered as a control
-	&:before {
-		@include wc-icon-fw($fa-var-square-o, left);
+.wc_seltog {
+	&[role='checkbox'] { // Rendered as a control
+		&:before {
+			@include wc-icon-fw($fa-var-square-o, left);
+		}
+
+		&[aria-checked='true']:before {
+			content: $fa-var-check-square-o;
+		}
+
+		&[aria-checked='mixed']:before {
+			content: $fa-var-square;
+		}
 	}
 
-	&[aria-checked='true']:before {
-		content: $fa-var-check-square-o;
-	}
+	> button {
+		&:before {
+			@include wc-icon-fw($fa-var-check-square-o, left);
+			opacity: 0.5;
+		}
 
-	&[aria-checked='mixed']:before {
-		content: $fa-var-square;
+		+ button:before {
+			content: $fa-var-square-o;
+		}
 	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.selectboxSearch.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.selectboxSearch.scss
@@ -1,5 +1,5 @@
 /* wc.ui.selectboxSearch.scss */
-@import 'vars.scss';
+@import 'vars';
 
 .wc_selsch {
 	background-color: $wc-ui-color-highlight-bg;

--- a/wcomponents-theme/src/main/sass/wc.ui.skipLinks.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.skipLinks.scss
@@ -1,5 +1,5 @@
 /* wc.ui.skipLinks.scss */
-@import 'vars.scss';
+@import 'vars';
 
 .wc-skiplinks {
 	height: 0;

--- a/wcomponents-theme/src/main/sass/wc.ui.table.caption.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.caption.scss
@@ -1,7 +1,7 @@
 /* wc.ui.table.caption.scss */
 // NOTE: this is a stub - override it as you see fit.
 
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 caption {
 	margin-bottom: $hgap-normal;

--- a/wcomponents-theme/src/main/sass/wc.ui.table.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.ie8.scss
@@ -1,5 +1,5 @@
 /* wc.ui.table.ie8.scss */
-@import 'vars.scss';
+@import 'vars';
 
 // tr required to differentiate from col
 // scss-lint:disable QualifyingElement

--- a/wcomponents-theme/src/main/sass/wc.ui.table.pagination.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.pagination.ie8.scss
@@ -1,5 +1,5 @@
 /* wc.ui.table.pagination.ie8.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc_table_pag_cont {
 	label,

--- a/wcomponents-theme/src/main/sass/wc.ui.table.pagination.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.pagination.scss
@@ -1,5 +1,5 @@
 /* wc.ui.table.pagination.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc_table_pag_cont {
 	> span,

--- a/wcomponents-theme/src/main/sass/wc.ui.table.paginationIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.paginationIcons.scss
@@ -1,5 +1,5 @@
 /* wc.ui.table.paginationIcons.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 // The deep nesting and repition here is necessitated by IE8's (and earlier)) lack of nth-child
 .wc_table_pag_cont button {

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansion.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansion.scss
@@ -1,6 +1,6 @@
 /* wc.ui.table.rowExpansion.scss */
-@import 'mixins-common.scss';
-@import 'wc.ui.table_vars.scss';
+@import 'mixins-common';
+@import 'wc.ui.table_vars';
 
 .wc-rowexpansion {
 	&[role='radiogroup'] {

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansionIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansionIcons.scss
@@ -1,5 +1,5 @@
 /* wc.ui.table.rowExpansionIcons.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 // ROW EXPANSION iconography and expand/collapse all iconography.
 // .wc_table_rowexp_container is the expandable row's expander holding cell or header

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.ie8.scss
@@ -1,5 +1,5 @@
 /* wc.ui.table.rowSelection.scss */
-@import 'wc.ui.table.rowSelection_vars.scss';
+@import 'wc.ui.table.rowSelection_vars';
 
 // IE9 bug: in IE9 we have to reset the width of the selector cell to auto because when it is 1em the cell takes over
 // all available space in the table, so in IE8 and below we have to reset it.

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection.scss
@@ -1,6 +1,6 @@
 /* wc.ui.table.rowSelection.scss */
-@import 'wc.ui.table.rowSelection_vars.scss';
-@import 'wc.ui.menu_vars.scss';
+@import 'wc.ui.table.rowSelection_vars';
+@import 'wc.ui.menu_vars';
 
 // only want to style aria-selected rows, nothing else
 tr[aria-selected] {

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowSelectionIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowSelectionIcons.scss
@@ -1,6 +1,6 @@
 /* wc.ui.table.rowSelectionIcons.scss */
-@import 'wc.ui.table.rowSelection_vars.scss';
-@import 'wc.ui.menu_vars.scss';
+@import 'wc.ui.table.rowSelection_vars';
+@import 'wc.ui.menu_vars';
 
 // only want to style aria-selected rows, nothing else
 .wc_table_sel_wrapper:before {

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection_vars.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowSelection_vars.scss
@@ -1,5 +1,5 @@
-@import 'wc.ui.table_vars.scss';
-@import 'mixins-common.scss';
+@import 'wc.ui.table_vars';
+@import 'mixins-common';
 
 $row-disable-opacity: 0.33;
 

--- a/wcomponents-theme/src/main/sass/wc.ui.table.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.scss
@@ -1,8 +1,8 @@
 /* wc.ui.table.scss */
 // This is the core of the table CSS. The other CSS files are used for functional images and other items which are less
 // likely to be implementation specific
-@import 'wc.ui.table_vars.scss';
-@import 'mixins-common.scss';
+@import 'wc.ui.table_vars';
+@import 'mixins-common';
 
 .wc-table.wc_error {
 	@include outline($color: $wc-ui-color-error-fg, $offset: -1px);

--- a/wcomponents-theme/src/main/sass/wc.ui.table.separators.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.separators.scss
@@ -2,8 +2,8 @@
 // Row and Column Separators
 // .wc_table_rowsep is applied to the tbody
 // .wc_table_colsep is applied to the colgroup
-@import 'mixins-common.scss';
-@import 'wc.ui.table_vars.scss';
+@import 'mixins-common';
+@import 'wc.ui.table_vars';
 
 .wc_table_rowsep > tr + tr {
 	@include border($pos: top);

--- a/wcomponents-theme/src/main/sass/wc.ui.table.sort.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.sort.color.scss
@@ -1,7 +1,7 @@
 /* wc.ui.table.sort.color.scss */
 // Column sorting relate to the sorting of data in sortable tables.
 // This css covers control elements in the heading cells and the rendering of sorted columns.
-@import 'wc.ui.table_vars.scss';
+@import 'wc.ui.table_vars';
 
 // differentiate col from row.
 // scss-lint:disable QualifyingElement

--- a/wcomponents-theme/src/main/sass/wc.ui.table.sort.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.sort.scss
@@ -1,5 +1,5 @@
 /* wc.ui.table.sort.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 th[aria-sort] {
 	cursor: pointer;

--- a/wcomponents-theme/src/main/sass/wc.ui.table.sortIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.sortIcons.scss
@@ -1,5 +1,5 @@
 /* wc.ui.table.sortIcons.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 th {
 	&[aria-sort]:after {

--- a/wcomponents-theme/src/main/sass/wc.ui.table.topControls.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.topControls.scss
@@ -1,5 +1,5 @@
 /* wc.ui.table.caption.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .wc-table > div:first-child { //row container for select all and expand all controls.
 	@include flex($wrap: wrap, $justify: space-between, $align-items: baseline); // ($direction: row, $wrap: nowrap, $justify: flex-start, $align-items: stretch, $align-content: stretch)

--- a/wcomponents-theme/src/main/sass/wc.ui.table_vars.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table_vars.scss
@@ -1,4 +1,4 @@
-@import 'vars.scss';
+@import 'vars';
 
 $wc-ui-color-table-head-bg: $std-color-primary;
 $wc-ui-color-table-head-fg: $std-color-primary-accent;

--- a/wcomponents-theme/src/main/sass/wc.ui.tabset.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.tabset.scss
@@ -1,6 +1,6 @@
 /* wc.ui.tabset.scss */
-@import 'mixins-common.scss';
-@import 'wc.ui.tabset_vars.scss';
+@import 'mixins-common';
+@import 'wc.ui.tabset_vars';
 
 [role='tablist'] {
 	&,

--- a/wcomponents-theme/src/main/sass/wc.ui.tabset.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.tabset.scss
@@ -66,11 +66,7 @@
 }
 
 [role='tab'] {
-	@include padded-box();
-	background-color: $wc-ui-color-tab-inactive;
-	color: $wc-ui-color-global-fg;
-	cursor: pointer;
-	margin: 0;
+	@include padded-box($bg-color: $wc-ui-color-tab-inactive, $color: $wc-ui-color-global-fg);
 
 	&[aria-selected='true'] {
 		position: relative;

--- a/wcomponents-theme/src/main/sass/wc.ui.tabset_vars.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.tabset_vars.scss
@@ -2,7 +2,7 @@
 $wc-ui-tabset-left-right-tab-width: 15%;
 
 // colors
-@import 'vars.scss';
+@import 'vars';
 $wc-ui-color-tab-inactive: $std-color-tertiary;
 $wc-ui-color-tab-focus: $std-color-invite-bg;
 $wc-ui-color-tab-active: $std-color-white;

--- a/wcomponents-theme/src/main/sass/wc.ui.text.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.text.scss
@@ -1,6 +1,6 @@
 /* wc.ui.text.scss */
 //WStyledText - not WText
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 .highPriority { //strong element
 	// @include outline($color: $wc-ui-color-error-fg, $style: double, $width: 3px);

--- a/wcomponents-theme/src/main/sass/wc.ui.textArea.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.textArea.scss
@@ -1,5 +1,5 @@
 /* wc.ui.textarea.scss */
-@import 'mixins-common.scss';
+@import 'mixins-common';
 
 // the ticker
 textarea + output {

--- a/wcomponents-theme/src/main/sass/wc.ui.timeoutWarn.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.timeoutWarn.scss
@@ -1,5 +1,5 @@
 /* wc.ui.timeoutWarn.scss */
-@import 'vars.scss';
+@import 'vars';
 
 // timeout warning container is generated and identified.
 // scss-lint:disable IdSelector

--- a/wcomponents-theme/src/main/xslt/wc.common.button.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.button.xsl
@@ -57,7 +57,7 @@
 						</xsl:if>
 					</xsl:if>
 					<xsl:if test="@type='link'">
-						<xsl:text> wc_btn_link</xsl:text>
+						<xsl:text> wc_btn_nada wc_btn_link</xsl:text>
 					</xsl:if>
 				</xsl:with-param>
 			</xsl:call-template>

--- a/wcomponents-theme/src/main/xslt/wc.common.selectToggle.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.selectToggle.xsl
@@ -127,7 +127,7 @@
 					</xsl:if>
 					<xsl:choose>
 						<xsl:when test="self::ui:rowselection">
-							<xsl:call-template name="disabledElement">
+							<xsl:call-template name="disabledElement"><!-- WDataTable compatibility only. -->
 								<xsl:with-param name="field" select=".."/>
 							</xsl:call-template>
 						</xsl:when>
@@ -140,7 +140,7 @@
 						<xsl:text>${wc.ui.selectToggle.id.suffix.label}</xsl:text>
 					</xsl:variable>
 					
-					<span id="{$defaultLabelId}">
+					<xsl:variable name="labelContent">
 						<xsl:choose>
 							<xsl:when test="$label!=''">
 								<xsl:value-of select="$label"/>
@@ -152,9 +152,14 @@
 								<xsl:value-of select="$$${wc.common.toggles.i18n.select.label}"/>
 							</xsl:when>
 						</xsl:choose>
-					</span>
+					</xsl:variable>
+					<xsl:if test="$labelContent != ''">
+						<span id="{$defaultLabelId}">
+							<xsl:value-of select="$labelContent"/>
+						</span>
+					</xsl:if>
 					
-					<xsl:variable name="labelId">
+					<xsl:variable name="realLabelId">
 						<xsl:choose>
 							<xsl:when test="self::ui:rowselection">
 								<xsl:value-of select="$defaultLabelId"/>
@@ -181,7 +186,7 @@
 								<xsl:number value="1"/>
 							</xsl:if>
 						</xsl:with-param>
-						<xsl:with-param name="labelId" select="$labelId"/>
+						<xsl:with-param name="labelId" select="$realLabelId"/>
 					</xsl:call-template>
 	
 					<xsl:call-template name="toggleElement">
@@ -197,7 +202,7 @@
 								<xsl:number value="1"/>
 							</xsl:if>
 						</xsl:with-param>
-						<xsl:with-param name="labelId" select="$labelId"/>
+						<xsl:with-param name="labelId" select="$realLabelId"/>
 					</xsl:call-template>
 				</span>
 			</xsl:when>

--- a/wcomponents-theme/src/main/xslt/wc.ui.link.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.link.xsl
@@ -51,7 +51,7 @@
 				<xsl:with-param name="elementType" select="$elementType"/>
 				<xsl:with-param name="class">
 					<xsl:if test="$elementType='button' and not($type='button')">
-						<xsl:text> wc_btn_link</xsl:text>
+						<xsl:text> wc_btn_nada wc_btn_link</xsl:text>
 					</xsl:if>
 				</xsl:with-param>
 			</xsl:call-template>


### PR DESCRIPTION
* Updated SNAPSHOT version numbers in the POMS to reflect that Version 1.0.4 was built from Branch “Release2” and the next release is expected to be 1.1.0. 
* Changed the scss-config.yaml to remove one of our unusual rules. I have removed the requirement for the file extension on import. This was
originally done to make import autocomplete work better in NetBeans but a better option is to make NetBeans behave in the more commonly accepted manner.
* Split up wc.common.buttons.scss to move rules for selectors `.wc_btn_nada`, `.wc_btn_link` and `.wc_btn_icon` into their own files
for easier override.
* Added the class `wc_btn_nada` to elements which previously had `wc_btn_link` so that we have _only_ one rule to remove button styles
and a separate rule to add link-like styles.
* Fixed a flaw in WSelectToggle’s XSLT which resulted in an empty pseudo-label if the WSelectToggle is associated with a WLabel.
* Updated the default style for WSelectToggle in the `text` form to make it _slightly_ more obvious that the controls are, in fact, interactive and not just text.