### PR TITLE
Checkstyle EOF character is now LF

### DIFF
--- a/sun_checks_wc.xml
+++ b/sun_checks_wc.xml
@@ -53,7 +53,14 @@
 
 	<!-- Checks whether files end with a new line.                        -->
 	<!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
-	<module name="NewlineAtEndOfFile"/>
+	<module name="NewlineAtEndOfFile">
+		<!-- WC
+			Choosing "lf" should allow eof to be either "LF" or "CRLF" (both end with "LF").
+			This is more permissive and more predicatable than the default "enforce whatever line separator is default on the current platform".
+			When fetching code via git newlines are usually normalized anyway.
+		-->
+		<property name="lineSeparator" value="lf"/>
+	</module>
 
 	<!-- Checks that property files contain the same keys.         -->
 	<!-- See http://checkstyle.sf.net/config_misc.html#Translation -->


### PR DESCRIPTION
Downloading the source zip file and building currently fails because EOF characters are a combination of `CRLF` and `LF`. Git normalises EOF characters but obviously this does not work when the source is not obtained thru git.

This change allows both `CRLF` and `LF` at the end of file.
