### PR TITLE
WTree

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/menu/core.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/core.js
@@ -1867,10 +1867,8 @@ define(["wc/has",
 						event.add(root, event.TYPE.mouseover, mouseoverEvent.bind(this));
 					}
 				}
-				else if (this._isBranchOrOpener(target)) {
-					this._remapKeys(target, root);
-				}
 				if ((item = this.getItem(target)) && !shed.isDisabled(item)) {
+					this._remapKeys(item, root);
 					if (this._isBranch(item)) {
 						item = this._getBranchOpener(item);
 					}

--- a/wcomponents-theme/src/main/js/wc/ui/menu/tree.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/tree.js
@@ -582,7 +582,7 @@ define(["wc/ui/menu/core",
 					obj = {
 						id: elId,
 						alias: root.id,
-						loads: [elId],
+						loads: [elId + "-content"],
 						oneShot: (mode === 'lazy'),
 						getData: "wc_tiid=" + elId,
 						serialiseForm: false,

--- a/wcomponents-theme/src/main/xslt/wc.ui.treeitem.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.treeitem.xsl
@@ -105,7 +105,8 @@
 						<xsl:call-template name="title"/>
 						<xsl:call-template name="treeitemContent"/>
 					</button>
-					<div role="group" aria-labelledby="{$nameButtonId}">
+					<!-- The content ID here is just for theme AJAX purposes. -->
+					<div role="group" aria-labelledby="{$nameButtonId}" id="{concat(@id, '-content')}">
 						<xsl:if test="not(ui:treeitem)">
 							<xsl:attribute name="aria-busy">
 								<xsl:copy-of select="$t"/>


### PR DESCRIPTION
* Update ui/ajax/processResponse to allow for a new action “in” which
targets elements inside another element.
* Changed the treeItem ajax target list to target the treeItems’s
content wrapper.
* Added an id to the treeItem content wrapper to facilitate the above.

These are required for #263.