### PR TITLE
Remove AJAX ambiguity

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/ajaxRegion.js
+++ b/wcomponents-theme/src/main/js/wc/ui/ajaxRegion.js
@@ -130,9 +130,10 @@ define(["wc/dom/event",
 			 * @public
 			 * @param {Element} element The element which is being changed.
 			 * @param {Object} [obj] A trigger definition dto.
+			 * @param {Boolean} [ignoreAncestor] Indicates to not look up the tree when trying to find a trigger.
 			 */
-			this.requestLoad = function(element, obj) {
-				var trigger = triggerManager.getTrigger(element),
+			this.requestLoad = function(element, obj, ignoreAncestor) {
+				var trigger = triggerManager.getTrigger(element, ignoreAncestor),
 					alias,
 					loads,
 					id;

--- a/wcomponents-theme/src/main/js/wc/ui/menu/tree.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/tree.js
@@ -587,7 +587,7 @@ define(["wc/ui/menu/core",
 						formRegion: root.id
 					};
 
-					ajaxRegion.requestLoad(element, obj);
+					ajaxRegion.requestLoad(element, obj, true);
 				}
 			};
 


### PR DESCRIPTION
WTree can have internal AJAX via get  (on item expansion) and it is an AjaxTrigger so can POST (on item selection). This lead to an error when both were enabled caused by ajaxRegion.requestLoad doing an ancestor search whilst hunting for a trigger. To fix this added an ignoreAncestor arg to requestLoad which is passed into getTrigger.