### PR TITLE
A11y bugs

### DIFF
--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WDialogExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WDialogExample.java
@@ -94,6 +94,7 @@ public class WDialogExample extends WPanel implements MessageContainer {
 		defList.addTerm("Dialog opened by", new WText(dialogOpeningButton.getText()));
 		nonModalDialog = new WDialog(defList, dialogOpeningButton);
 		nonModalDialog.setTitle("View list with time");
+		nonModalDialog.setWidth(600);
 
 		dialogOpeningButton.setAction(new Action() {
 			@Override

--- a/wcomponents-theme/src/main/js/wc/ui/dialogFrame.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dialogFrame.js
@@ -167,11 +167,11 @@ define(["wc/dom/classList",
 						// mobile browsers dialog is auto max'ed and not resizeable or positionable
 						initDialogControls(dialog, dto);
 						initDialogDimensions(dialog, dto);
-						setModality(dialog, true); // all dialogs are modal on mobile as non-modal dialogs make no sense when they are full screen
-					}
-					else {
 						isModal = (dto && typeof dto.modal !== "undefined") ? dto.modal : true;
 						setModality(dialog, isModal);
+					}
+					else {
+						setModality(dialog, true); // all dialogs are modal on mobile as non-modal dialogs make no sense when they are full screen
 					}
 					// show the dialog
 					shed.show(dialog);

--- a/wcomponents-theme/src/main/js/wc/ui/menu/tree.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/tree.js
@@ -417,8 +417,14 @@ define(["wc/ui/menu/core",
 			 * @param {Element} component The component which was brought in with AJAX.
 			 */
 			this._setMenuItemRole = function(component) {
+				var opener;
 				component.setAttribute("role", this._role.LEAF.noSelection);
 				component.removeAttribute("data-wc-selectable");
+
+				if (this._isBranch(component) && (opener = this._getBranchOpener(component))) {
+					opener.removeAttribute("role");
+					opener.removeAttribute("aria-haspopup");
+				}
 			};
 
 			/**


### PR DESCRIPTION
* Fixed an issue in which all dialogs were modal.
* Fixed an issue in which WSubMenus in a WMenu of Type.TREE had
incorrect aria attributes if the WSubMenu was loaded via ajax.
* Updated the WDialogExample to provide a better sample of how to
implement a dialog.