### PR TITLE
Sass rendering bugs

### DIFF
--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/validation/fields/CoreFields.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/validation/fields/CoreFields.java
@@ -26,6 +26,7 @@ import com.github.bordertech.wcomponents.layout.BorderLayout;
 import com.github.bordertech.wcomponents.util.DateUtilities;
 import com.github.bordertech.wcomponents.validator.DateFieldPivotValidator;
 import com.github.bordertech.wcomponents.validator.RegExFieldValidator;
+import java.util.Date;
 
 /**
  * <p>
@@ -117,6 +118,7 @@ public class CoreFields extends WPanel {
 		WDateField df = new WDateField();
 		WField dateField = fields.addField("WDateField", df);
 		dateField.getLabel().setHint("before today");
+		df.setMaxDate(DateUtilities.roundToDay(new Date()));
 		dateField.addValidator(new DateFieldPivotValidator(DateFieldPivotValidator.BEFORE));
 		df.setToolTip("Set a date before today");
 

--- a/wcomponents-theme/src/main/js/wc/dom/ariaAnalog.js
+++ b/wcomponents-theme/src/main/js/wc/dom/ariaAnalog.js
@@ -371,11 +371,12 @@ define(["wc/has",
 
 			if (event.canCapture) {
 				event.add(element, event.TYPE.focus, eventWrapper.bind(this), null, null, true);
+				event.add(element, event.TYPE.click, eventWrapper.bind(this), null, null, true);
 			}
 			else {
 				event.add(element, event.TYPE.focusin, eventWrapper.bind(this));
+				event.add(element, event.TYPE.click, eventWrapper.bind(this));
 			}
-			event.add(element, event.TYPE.click, eventWrapper.bind(this));
 			event.add(element, event.TYPE.keydown, eventWrapper.bind(this));
 			shed.subscribe(shed.actions.SELECT, this.shedObserver.bind(this));
 			shed.subscribe(shed.actions.DESELECT, this.shedObserver.bind(this));

--- a/wcomponents-theme/src/main/js/wc/ui/menu/tree.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/tree.js
@@ -484,8 +484,7 @@ define(["wc/ui/menu/core",
 			 */
 			this.clickEvent = function($event) {
 				var target = $event.target,
-					root,
-					item;
+					root;
 				if ($event.defaultPrevented || target === window) {
 					return;
 				}
@@ -500,11 +499,15 @@ define(["wc/ui/menu/core",
 						return;
 					}
 
-					if ((item = this.getItem(target)) && !shed.isDisabled(item) && this._isBranch(item)) {
-						if (!this.isInVOpen(target)) {
-							return; // do nothing, do not prevent default, do not pass go.
-						}
+					if (!this.isInVOpen(target)) {
+						return; // do nothing, do not prevent default, do not pass go.
 					}
+
+//					if ((item = this.getItem(target)) && !shed.isDisabled(item) && this._isBranch(item)) {
+//						if (!this.isInVOpen(target)) {
+//							return; // do nothing, do not prevent default, do not pass go.
+//						}
+//					}
 				}
 				// if we get here things are odd....
 				this.constructor.prototype.clickEvent.call(this, $event);

--- a/wcomponents-theme/src/main/js/wc/ui/menu/treeItem.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/treeItem.js
@@ -49,29 +49,22 @@ define(["wc/dom/ariaAnalog",
 			 * @returns {Boolean} true if the element may be activated.
 			 */
 			function isAcceptable (element, target) {
-				var result = isAcceptableTarget(element, target),
-					candidate, root;
-				if (result) {
-					return true;
-				}
+				var root, result = isAcceptableTarget(element, target);
 
 				if (tree && (root = tree.getRoot(target))) {
-					opener = opener || tree._wd.opener;
+					if (tree.isInVOpen(target)) {
+						return false;
+					}
 
-					if (opener) {
-						candidate = opener.findAncestor(target);
-						if (!candidate) {
-							return false;
+					if (!result) {
+						opener = opener || tree._wd.opener;
+
+						if (opener) {
+							return !!opener.findAncestor(target);
 						}
-
-						if (tree.isHTreeOrMenu(root)) {
-							return true;
-						}
-
-						return !tree.isInVOpen(target);
 					}
 				}
-				return false;
+				return result;
 			}
 
 			/**

--- a/wcomponents-theme/src/main/sass/_colors.scss
+++ b/wcomponents-theme/src/main/sass/_colors.scss
@@ -26,6 +26,7 @@ $wc-ui-color-inverse-bg: $std-color-black;
 // highlights colours
 $wc-ui-color-highlight-bg: $std-color-highlight-bg;
 $wc-ui-color-highlight-fg: $std-color-highlight-fg;
+$wc-ui-color-highlight-bg-rgba: $std-color-highlight-bg-rgba;
 
 // generic hover/focus
 $wc-ui-color-invite-bg: $std-color-invite-bg;

--- a/wcomponents-theme/src/main/sass/_colorscheme.scss
+++ b/wcomponents-theme/src/main/sass/_colorscheme.scss
@@ -32,6 +32,8 @@ $std-color-invite-bg-rgba: rgba(204, 229, 255, 0.5);
 $std-color-highlight-bg: #f2f2f2;
 // The foreground must meet 4.5:1;
 $std-color-highlight-fg: $std-color-black;
+// Table row zebra-striping must be translucent with alpha no greater than 0.5 on a white background.
+$std-color-highlight-bg-rgba: rgba(0, 0, 0, 0.02);
 
 // Line accents (usually borders)
 $std-color-lines: #ccc;

--- a/wcomponents-theme/src/main/sass/_tree-vars.scss
+++ b/wcomponents-theme/src/main/sass/_tree-vars.scss
@@ -14,3 +14,6 @@ $wc-htree-branch-right-border-width: $hgap-small;
 
 // used for WMenu type TREE. Under review.
 $wc-tree-item-pad: $hgap-small 0;
+
+// the start width of a htree group when the browser is rubbish.
+$wc-htree-branch-width-lame: 10rem;

--- a/wcomponents-theme/src/main/sass/wc.common.listbox.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.listbox.scss
@@ -11,6 +11,7 @@ ul[role='listbox'] {
 	z-index: $z-index-common;
 
 	dialog & {
+		position: fixed;
 		z-index: $z-index-common-in-dialog;
 	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.dateField.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dateField.scss
@@ -19,8 +19,11 @@
 }
 
 [role='combobox'] { // NOTE: all of the nested rules apply to nested selectors. This differentiates datefield from combo.
+	white-space: nowrap;
+
 	> input {
 		border: 0 none;
+		//max-width: calc(100% - 2rem); // allow for icon with button artefacts.
 	}
 
 	&[aria-expanded='true'] > [role='listbox'] {
@@ -28,5 +31,10 @@
 		display: block;
 		left: $border-width * -1;
 		min-width: 100%;
+
+		dialog & {
+			left: auto;
+			min-width: initial;
+		}
 	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.htree.ie11.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.htree.ie11.scss
@@ -1,0 +1,8 @@
+/* wc.ui.htree.scss */
+@import 'tree-vars';
+
+// htree extends and replaces parts of tree.scss
+[role='tree'].wc_htree [role='group'] {
+	min-width: 0;
+	width: $wc-htree-branch-width-lame;
+}

--- a/wcomponents-theme/src/main/sass/wc.ui.htree.pattern_edge.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.htree.pattern_edge.scss
@@ -1,0 +1,9 @@
+/* wc.ui.htree.scss */
+@import 'tree-vars';
+
+// htree extends and replaces parts of tree.scss
+
+[role='tree'].wc_htree [role='group'] {
+	min-width: 0;
+	width: $wc-htree-branch-width-lame;
+}

--- a/wcomponents-theme/src/main/sass/wc.ui.htree.pattern_ff.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.htree.pattern_ff.scss
@@ -1,0 +1,23 @@
+/* wc.ui.htree.patter_ff.scss */
+// Necessitated by a complete cop-out in https://bugzilla.mozilla.org/show_bug.cgi?id=984869
+@import 'tree-vars';
+
+[role='tree'].wc_htree {
+
+	[aria-expanded] > .wc_leaf {
+		display: table;
+
+		> .wc_leaf_hopener {
+			display: table-cell;
+		}
+	}
+
+	.wc_leaf_img {
+		display: table-cell;
+	}
+
+	.wc_leaf_name {
+		display: table-cell;
+		width: 100%;
+	}
+}

--- a/wcomponents-theme/src/main/sass/wc.ui.htree.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.htree.scss
@@ -28,8 +28,9 @@
 		overflow-y: scroll;
 	}
 
-	[aria-expanded] > button {
+	[aria-expanded] > .wc_leaf {
 		@include flex($align-items: baseline);
+		width: 100%; // override .wc_leaf_vopener + button from wc.ui.tree.scss
 
 		> .wc_leaf_hopener {
 			@include flex-grow(1);

--- a/wcomponents-theme/src/main/sass/wc.ui.listLayout.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.listLayout.color.scss
@@ -1,7 +1,7 @@
 /* wc.ui.listLayout.color.scss */
 @import 'mixins-common';
 
-.wc-listlayout.striped > :nth-child(odd) {
+.wc-listlayout.striped > :nth-child(even) {
 	background-color: $wc-ui-color-highlight-bg;
 	color: $wc-ui-color-highlight-fg;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.dt.scss
@@ -44,6 +44,20 @@
 }
 
 [role='menu'] {
+	 // nested sub-menus. These must appear before the colision detection overrides below.
+	[role='menu'] {
+		left: 100%;
+		top: 0;
+
+		&.wc_coleast { // nested collisions
+			right: 100%;
+		}
+
+		&.wc_colwest {
+			right: 100%;
+		}
+	}
+
 	// viewport edge collisions
 	&.wc_coleast {
 		left: auto;
@@ -60,17 +74,4 @@
 		top: auto;
 	}
 
-	 // nested sub-menus
-	[role='menu'] {
-		left: 100%;
-		top: 0;
-
-		&.wc_coleast { // nested collisions
-			right: 100%;
-		}
-
-		&.wc_colwest {
-			right: 100%;
-		}
-	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.table.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.color.scss
@@ -17,7 +17,7 @@ thead {
 // Row striping: You'd think tr:nth-child(even) would be enough. You'd be wrong - that does not account for sub rows.
 col.wc_table_stripe,
 tr.wc_table_stripe {
-	background-color: $wc-ui-color-highlight-bg;
+	background-color: $wc-ui-color-highlight-bg-rgba;
 }
 
 tr.wc_invite {

--- a/wcomponents-theme/src/main/sass/wc.ui.table.sort.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.sort.color.scss
@@ -7,6 +7,13 @@
 // scss-lint:disable QualifyingElement
 col.wc_table_sort_sorted,
 th[sorted] {
-	background-color: $wc-ui-color-highlight-bg;
 	color: $wc-ui-color-highlight-fg;
+}
+
+th[sorted] { // the TH needs to be opague to over-ride the thead background color rather than over-lay it.
+	background-color: $wc-ui-color-highlight-bg;
+}
+
+col.wc_table_sort_sorted {
+	background-color: $wc-ui-color-highlight-bg-rgba;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.tree.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.tree.scss
@@ -17,15 +17,23 @@
 	}
 }
 
+button[role='treeitem'],
+[role='treeitem'] > button {
+	width: 100%;
+}
+
 [role='treeitem'] {
 	@include border-box;
 	display: block;
 	width: 100%;
-}
 
-button[role='treeitem'],
-[role='treeitem'] > button {
-	width: 100%;
+	> .wc_leaf_vopener {
+		width: 1.25rem;
+
+		+ button {
+			width: calc(100% - 1.25rem);
+		}
+	}
 }
 
 .wc_leaf_vopener,
@@ -36,6 +44,7 @@ button[role='treeitem'],
 }
 
 .wc_leaf_vopener { // the vertical opener button
+	@include border-box;
 	padding: $wc-tree-item-pad-t 0 $wc-tree-item-pad-b $wc-tree-item-pad-l;
 	text-align: center;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.treeIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.treeIcons.scss
@@ -10,11 +10,11 @@
 }
 
 .wc_leaf_vopener:before {
-	[aria-expanded] > button > & {
+	[aria-expanded] > & {
 		content: $fa-var-caret-right;
 	}
 
-	[aria-expanded='true'] > button > & {
+	[aria-expanded='true'] > & {
 		content: $fa-var-caret-down;
 	}
 }

--- a/wcomponents-theme/src/main/xslt/wc.common.listSortControls.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.listSortControls.xsl
@@ -12,7 +12,9 @@
 	<xsl:template name="listSortControls">
 		<xsl:param name="id" select="@id"/>
 		<span class="wc_sortcont">
-			<xsl:if test="self::ui:multiselectpair">&#x00a0;</xsl:if>
+			<xsl:if test="self::ui:multiselectpair">
+				<xsl:text>&#x00a0;</xsl:text>
+			</xsl:if>
 			<xsl:call-template name="listSortControl">
 				<xsl:with-param name="id" select="$id"/>
 				<xsl:with-param name="value" select="'top'"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.multiSelectPair.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.multiSelectPair.xsl
@@ -92,7 +92,7 @@
 					</span>
 					<!-- BUTTONS -->
 					<span class="wc_msp_btncol">
-						&#x00a0;
+						<xsl:text>&#x00a0;</xsl:text>
 						<xsl:call-template name="multiSelectPairButton">
 							<xsl:with-param name="value" select="'add'"/>
 							<xsl:with-param name="buttonText" select="$$${wc.ui.multiSelectPair.i18n.button.add}"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.n.autocol.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.n.autocol.xsl
@@ -6,6 +6,6 @@
 		Creates a caption element if required. Called from the transform for ui:table.
 	-->
 	<xsl:template name="autocol">
-		<col class="wc_table_colauto">&#x00a0;</col>
+		<col class="wc_table_colauto"></col>
 	</xsl:template>
 </xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.ui.treeitem.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.treeitem.xsl
@@ -84,6 +84,9 @@
 						<xsl:text>0</xsl:text>
 					</xsl:attribute>
 					<xsl:call-template name="title"/>
+					<span class="wc_leaf_vopener" aria-hidden="true">
+						<xsl:text>&#x0a;</xsl:text>
+					</span>
 					<xsl:call-template name="treeitemContent"/>
 				</xsl:when>
 				<xsl:otherwise>
@@ -100,7 +103,10 @@
 					<xsl:variable name="nameButtonId">
 							<xsl:value-of select="concat(@id, '-branch-name')"/>
 					</xsl:variable>
-					<!-- leave tabindex on this butten, it is used as a short-hand to find fousable controls in the core menu JavaScript. -->
+					<button class="wc_btn_nada wc_invite wc_leaf_vopener" aria-hidden="true" type="button" tabindex="-1">
+						<xsl:text>&#x0a;</xsl:text>
+					</button>
+					<!-- leave tabindex="0" on this button, it is used as a short-hand to find focusable controls in the core menu JavaScript. -->
 					<button type="button" class="wc_btn_nada wc_invite wc_leaf" id="{$nameButtonId}" aria-controls="{@id}" tabindex="0">
 						<xsl:call-template name="title"/>
 						<xsl:call-template name="treeitemContent"/>
@@ -135,9 +141,6 @@
 	</xsl:template>
 
 	<xsl:template name="treeitemContent">
-		<span class="wc_leaf_vopener" aria-hidden="true">
-			<xsl:text>&#x0a;</xsl:text>
-		</span>
 		<span aria-hidden='true'>
 			<xsl:attribute name="class">
 				<xsl:text>wc_leaf_img</xsl:text>


### PR DESCRIPTION
* DateField/Combo listbox in a dialog had same collision issues as calendar, fixed in same way.
* Striped ListLayout/WList had odd numbers striped in modern browsers instead of even (which were striped in IE 8).
WMenu Type COLUMN CSS was written such that a colliding submenu was not overriding the position of the nested submenu correctly.
* WMultiSelectPair XSLT had a floating non-breaking-space causing unexpected appearance in some browsers (thanks pre-webkit Opera!)
* XSLT for auto-generated cols for table row expansion and selection columns was incorrect leading to _very_ unusual rendering.
* Fixed very subtle a11y issue in tables with all of row selection, row expansion and rowSelection toggle.
* Updated zebra stripe and sorted column to use rgba color to allow striped row on sorted column to have a viewable difference.
* Fixed an error in the date field validation example. A date comparator should **never** be added without setting constraints on the date input as these constraints are then used by the browser to set limits in the client.
* Recode the tree openers to make WTree work in IE11.
* Add Edge and IE specific Sass to make WTree/htree groups size reasonably without access to max-content/fit-content.
* Added some firefox specific Sass to make HTree group openers behave in the **buggy** implementation of button.