### PR TITLE
WTree ajax, timeout warnings

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ajax/triggerManager.js
+++ b/wcomponents-theme/src/main/js/wc/ajax/triggerManager.js
@@ -111,16 +111,16 @@ define(["wc/dom/getAncestorOrSelf", "wc/dom/tag"],
 						}
 					}
 					else {  // it must be a DOM element
-						if ((id = ref.getAttribute(ALIAS))) {
-							console.log("Finding trigger by alias match");
-							result = this.getTrigger(id);
-						}
-						if (!result && (id = ref.id)) {  // try id
+						if ((id = ref.id)) {  // try id
 							console.log("Found trigger by element (id match)");
 							result = this.getTrigger(id);
 						}
 						if (!result && (id = ref.name)) {  // try name (esp. radio buttons)
 							console.log("Found trigger by element (name match)");
+							result = this.getTrigger(id);
+						}
+						if (!result && (id = ref.getAttribute(ALIAS))) {
+							console.log("Finding trigger by alias match");
 							result = this.getTrigger(id);
 						}
 						if (!result && !ignoreAncestor) {

--- a/wcomponents-theme/src/main/js/wc/ui/menu/tree.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/tree.js
@@ -502,12 +502,6 @@ define(["wc/ui/menu/core",
 					if (!this.isInVOpen(target)) {
 						return; // do nothing, do not prevent default, do not pass go.
 					}
-
-//					if ((item = this.getItem(target)) && !shed.isDisabled(item) && this._isBranch(item)) {
-//						if (!this.isInVOpen(target)) {
-//							return; // do nothing, do not prevent default, do not pass go.
-//						}
-//					}
 				}
 				// if we get here things are odd....
 				this.constructor.prototype.clickEvent.call(this, $event);

--- a/wcomponents-theme/src/main/sass/_mixins-common.scss
+++ b/wcomponents-theme/src/main/sass/_mixins-common.scss
@@ -109,9 +109,9 @@
 // Allow duplicate width declarations
 // scss-lint:disable DuplicateProperty
 /// Size a container to fit its content.
-@mixin fit-content($what: width, $imp: 0) {
+@mixin fit-content($what: width, $imp: 0, $fallback: auto) {
 	@if ($imp == 0) {
-		#{$what}: auto;
+		#{$what}: $fallback;
 		#{$what}: -webkit-fit-content;
 		#{$what}: -moz-fit-content;
 		#{$what}: fit-content;
@@ -119,7 +119,7 @@
 	@else {
 		// Important needed for some reason!
 		// scss-lint:disable ImportantRule
-		#{$what}: auto !important;
+		#{$what}: $fallback !important;
 		#{$what}: -webkit-fit-content !important;
 		#{$what}: -moz-fit-content !important;
 		#{$what}: fit-content !important;

--- a/wcomponents-theme/src/main/sass/wc.ui.timeoutWarn.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.timeoutWarn.scss
@@ -1,13 +1,19 @@
 /* wc.ui.timeoutWarn.scss */
-@import 'vars';
+@import 'mixins-common';
 
 // timeout warning container is generated and identified.
 // scss-lint:disable IdSelector
 #wc_session_container {
+	@include fit-content($fallback: 25rem);
 	background-color: $wc-ui-color-global-bg; // to make it opaque;
 	bottom: 0;
+	max-width: 100%;
 	position: fixed;
 	right: 0;
-	width: 35rem;
 	z-index: $z-index-unloading-message; // z-index needs to be above dialogs, unloading shims etc
+
+	ul {
+		list-style-type: none;
+		padding-left: $hgap-small; 
+	}
 }


### PR DESCRIPTION
* Fixed a flaw which caused tree items to POST instead of GET when the WTree was an ajax trigger and one POST had already been sent by
[de]selection.
* Fixed a CSS flaw in the timeout warning which made it unreadable on small screens.