### PR TITLE
Menu collision detection, tree simplification

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/menu/core.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/core.js
@@ -63,6 +63,7 @@ define(["wc/has",
 			AJAX_CONTEXTLESS_ITEM,
 			postAjaxTimer,
 			focusTimer,
+			collisionTimer,
 			TRUE = "true",
 			fixedWidgets,
 			CLASS = {
@@ -207,7 +208,6 @@ define(["wc/has",
 		 * Indicates if there is a viewport collision on the sides of the viewport.
 		 * @function doICollide
 		 * @private
-		 * @see {@link _doCollisionDetection}
 		 * @param {module:wc/dom/viewportCollision} collision The calculated 'collision'.
 		 * @param {Boolean} [isNotDefaultDirection] Indicates the collision direction to test. If true we test against the
 		 *    side deemed to be the DEFAULT direction of reading.
@@ -716,7 +716,6 @@ define(["wc/has",
 		 * Indicates if the parent submenu (if any) of a given submenu is itself colliding with an edge of the viewport.
 		 * @function isParentSubmenuColliding
 		 * @private
-		 * @see {@link  module:wc/ui/menu/core~_doCollisionDetection}
 		 * @param {Element} submenu The submenu currently undergoing collision detection
 		 * @param {Object} instance The subclass.
 		 * @returns {Boolean} true if the parent is also colliding.
@@ -810,12 +809,11 @@ define(["wc/has",
 			if (instance.isMobile) {
 				return;
 			}
-			if (has("ie") === 8) {
-				timers.setTimeout(_doCollisionDetection, 0, submenu, instance);  // IE needs time to repaint to be able to calculate the submenu's bounding box
+			if (collisionTimer) {
+				timers.clearTimeout(collisionTimer);
+				collisionTimer = null;
 			}
-			else {
-				_doCollisionDetection(submenu, instance);
-			}
+			collisionTimer = timers.setTimeout(_doCollisionDetection, 0, submenu, instance);
 		}
 
 		/**

--- a/wcomponents-theme/src/main/sass/_messageBox_vars.scss
+++ b/wcomponents-theme/src/main/sass/_messageBox_vars.scss
@@ -1,4 +1,4 @@
-/* wc.ui.messageBox_vars.scss */
+// wc.ui.messageBox_vars.scss
 @import 'mixins-common';
 $msg-box-header-size: 1.25rem;
 $msg-box-header-text-color: $std-color-white;

--- a/wcomponents-theme/src/main/sass/_mixins-icon.scss
+++ b/wcomponents-theme/src/main/sass/_mixins-icon.scss
@@ -12,11 +12,10 @@
 	@if($icon != -1) {
 		content: $icon;
 	}
-	// font-size: 1rem; // keep icons at 16px
 }
 
 /// Make a fixed-width icon.
-@mixin wc-icon-fw ($icon, $text-align: center, $width: 1rem) {
+@mixin wc-icon-fw ($icon: -1, $text-align: center, $width: 1rem) {
 	@include wc-icon($icon);
 	text-align: $text-align;
 	width: $width;

--- a/wcomponents-theme/src/main/sass/wc.ui.heading.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.heading.scss
@@ -1,5 +1,6 @@
 /* wc.ui.heading.scss */
-// This file is purposely left as a stub for easy over-ride
+// This file is purposely left as a stub for easy over-ride.
+// This is why this file has colors in it.
 @import 'mixins-common';
 
 h1,

--- a/wcomponents-theme/src/main/sass/wc.ui.messageBoxIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.messageBoxIcons.scss
@@ -2,7 +2,6 @@
 @import 'messageBox_vars';
 
 .wc_msgbox {
-
 	> h1:before {
 		@include wc-icon-fw($fa-var-minus-circle, $width: 1.25rem);
 		vertical-align: middle;

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.header.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.header.scss
@@ -14,15 +14,11 @@
 	[role='banner'] {
 		> .wc-content {
 			@include flex($direction: row-reverse, $wrap: wrap, $justify: space-between, $align-items: center, $align-content: flex-start);
+			padding: $hgap-small;
 
 			> * {
 				@include flex-grow(0);
 				@include flex-shrink(1);
-				padding-left: $hgap-small;
-			}
-
-			> :last-child {
-				padding-right: $hgap-small;
 			}
 		}
 

--- a/wcomponents-theme/src/main/sass/wc.ui.table.caption.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.caption.scss
@@ -1,9 +1,8 @@
 /* wc.ui.table.caption.scss */
+@import 'mixins-common';
 // NOTE: this is a stub - override it as you see fit.
 
-@import 'mixins-common';
-
 caption {
-	margin-bottom: $hgap-normal;
+	padding: $vgap-normal 0;
 	text-align: left;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.tree.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.tree.color.scss
@@ -3,15 +3,11 @@
 
 [role='tree'] {
 	[aria-selected='true'] {
-		&,
-		& > button {
-			background-color: $wc-ui-color-highlight-bg;
-			color: $wc-ui-color-highlight-fg;
-		}
+		background-color: $wc-ui-color-highlight-bg;
+		color: $wc-ui-color-highlight-fg;
 	}
 
 	&,
-	div[aria-selected='true'],
 	[role='group'] {
 		background-color: $wc-ui-color-global-bg;
 		color: $wc-ui-color-global-fg;

--- a/wcomponents-theme/src/main/sass/wc.ui.tree.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.tree.scss
@@ -43,10 +43,10 @@ button[role='treeitem'],
 	width: 1.25rem;
 }
 
-.wc_leaf_vopener { // the vertical opener button
-	@include border-box;
+.wc_leaf_vopener { // the vertical opener button and its span placeholder equivalent.
+	@include border-box; // required for the span.
 	padding: $wc-tree-item-pad-t 0 $wc-tree-item-pad-b $wc-tree-item-pad-l;
-	text-align: center;
+	text-align: left;
 }
 
 // The icon container
@@ -54,8 +54,8 @@ button[role='treeitem'],
 	padding: $wc-tree-item-pad-t 0 $wc-tree-item-pad-b;
 
 	img {
-		max-height: 16px;
-		max-width: 16px;
+		max-height: 1rem;
+		max-width: 1rem;
 	}
 }
 

--- a/wcomponents-theme/src/main/sass/wc.ui.treeIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.treeIcons.scss
@@ -5,7 +5,7 @@
 .wc_leaf_noimg,
 .wc_leaf_hopener {
 	&:before {
-		@include wc-icon;
+		@include wc-icon-fw($text-align: left);
 	}
 }
 


### PR DESCRIPTION
* Simplified tree CSS;
* fixed some inconsistencies in the WMenu Type.TREE branch opener iconography and the WTree tree item opener iconography;
* changed the way transient menus do collision detection to fix an error where collision detection would fail for lazy and dynamic WSubMenus;
* simplified the CSS for WPanel Type.HEADER mobile media query.