### PR TITLE
Subordinate and XSLT fixes.

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/dateField.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dateField.js
@@ -161,10 +161,10 @@ define(["wc/has",
 				}
 				childEl.removeAttribute("aria-owns");
 				if ((childEl = getSuggestionList(element, -1))) {
-					element.removeChild(childEl);
+					childEl.parentElement.removeChild(childEl);
 				}
 				if ((childEl = LAUNCHER.findDescendant(element))) {
-					element.removeChild(childEl);
+					childEl.parentElement.removeChild(childEl);
 				}
 			}
 
@@ -973,12 +973,19 @@ define(["wc/has",
 			 * @returns {String} The date in transfer format or an empty string if the field has no value.
 			 */
 			this.getValue = function(element, guess) {
-				var result, textbox;
-				if (element && (element = DATE_FIELD.findAncestor(element))) {
-					result = element.getAttribute(VALUE_ATTRIB);
-					if (!result && (textbox = instance.getTextBox(element)) && textbox.value) {
+				var result, textbox, _element;
+				if (element && (_element = DATE_FIELD.findAncestor(element))) {
+					if ((result = _element.getAttribute(VALUE_ATTRIB))) {
+						return result;
+					}
+
+					if (this.isNativeInput(element) && (result = element.value)) {
+						return result;
+					}
+
+					if (!result && (textbox = instance.getTextBox(_element)) && textbox.value) {
 						// we don't have a recorded xfer date for this element, check its value
-						result = reverseFormat(textbox, guess);
+						return reverseFormat(textbox, guess);
 					}
 				}
 				return result || "";

--- a/wcomponents-theme/src/main/js/wc/ui/numberField.js
+++ b/wcomponents-theme/src/main/js/wc/ui/numberField.js
@@ -171,11 +171,9 @@ define(["wc/dom/attribute",
 				if (result && (result = result.trim())) {
 					// can't just use parseFloat because it accepts the first number before a space, test with isNumeric
 					if (isNumeric(result)) {
-						result = parseFloat(result);
+						return parseFloat(result);
 					}
-					else {
-						result = NaN;
-					}
+					return NaN;
 				}
 				return result;
 			};

--- a/wcomponents-theme/src/main/js/wc/ui/subordinate.js
+++ b/wcomponents-theme/src/main/js/wc/ui/subordinate.js
@@ -448,7 +448,7 @@ define(["wc/dom/tag",
 					result = parseRegex(val);
 				}
 				else if (type === "date") {
-					getDateCompareValue(val);
+					result = getDateCompareValue(val);
 				}
 				else if (type === "number") {
 					result = getNumberCompareValue(val);
@@ -513,23 +513,23 @@ define(["wc/dom/tag",
 					if (dateField && dateField.isOneOfMe(element)) {
 						result = dateField.getValue(element);
 					}
-					if (!interchange.isComplete(result)) {
-						result = null;
+					if (result !== "" && !interchange.isComplete(result)) {
+						return null;
 					}
+					return result;
 				}
-				else if (type === "number") {
+
+				if (type === "number") {
 					if (numberField) {
 						result = numberField.getValueAsNumber(element);
 					}
-					if (isNaN(result)) {// if the result is NaN we can't use it
+					if (result !== "" && isNaN(result)) { // if the result is NaN we can't use it
 						result = null;
 					}
+					return result;
 				}
-				else {
-					// don't check element.text, it is not necessary on option elements from IE8 up and is actually harmful because it will bypass a legit value attribute that equates to false (empty string)
-					result = element.value || element.getAttribute("data-wc-value") || "";
-				}
-				return result;
+				// don't check element.text, it is not necessary on option elements from IE8 up and is actually harmful because it will bypass a legit value attribute that equates to false (empty string)
+				return (element.value || element.getAttribute("data-wc-value") || "");
 			}
 
 			/**

--- a/wcomponents-theme/src/main/sass/wc.ui.dateField.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dateField.scss
@@ -7,7 +7,6 @@
 @import 'mixins-common';
 
 .wc-datefield {
-	display: inline-block;
 	position: relative;
 }
 

--- a/wcomponents-theme/src/main/xslt/wc.common.textInput.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.textInput.xsl
@@ -42,40 +42,54 @@
 						<xsl:with-param name="force" select="1"/>
 					</xsl:call-template>
 				</xsl:if>
-				<div id="{$id}">
-					<xsl:attribute name="class">
-						<xsl:text>wc_input_wrapper</xsl:text>
-						<xsl:if test="@list">
-							<xsl:text> wc_list_wrapper</xsl:text>
-						</xsl:if>
-					</xsl:attribute>
-					<xsl:variable name="type">
-						<xsl:choose>
-							<xsl:when test="self::ui:textfield">
-								<xsl:text>text</xsl:text>
-							</xsl:when>
-							<xsl:when test="self::ui:numberfield">
-								<xsl:text>number</xsl:text>
-							</xsl:when>
-							<xsl:when test="self::ui:passwordfield">
-								<xsl:text>password</xsl:text>
-							</xsl:when>
-							<xsl:when test="self::ui:emailfield">
-								<xsl:text>email</xsl:text>
-							</xsl:when>
-							<xsl:when test="self::ui:phonenumberfield">
-								<xsl:text>tel</xsl:text>
-							</xsl:when>
-						</xsl:choose>
-					</xsl:variable>
+				<span>
+					<xsl:call-template name="commonAttributes">
+						<xsl:with-param name="isWrapper" select="1"/>
+						<xsl:with-param name="live" select="'off'"/>
+						<xsl:with-param name="class">
+							<xsl:text>wc_input_wrapper</xsl:text>
+							<xsl:if test="@list">
+								<xsl:text> wc_list_wrapper</xsl:text>
+							</xsl:if>
+						</xsl:with-param>
+					</xsl:call-template>
 					<xsl:element name="input">
-						<xsl:call-template name="commonControlAttributes">
-							<xsl:with-param name="id" select="concat($id, '-input')"/>
-							<xsl:with-param name="isError" select="$isError"/>
-							<xsl:with-param name="name" select="@id"/>
-							<xsl:with-param name="live" select="'off'"/>
-							<xsl:with-param name="myLabel" select="$myLabel[1]"/>
-						</xsl:call-template>
+						<xsl:attribute name="id">
+							<xsl:value-of select="concat($id, '-input')"/>
+						</xsl:attribute>
+						<xsl:attribute name="type">
+							<xsl:choose>
+								<xsl:when test="self::ui:textfield">
+									<xsl:text>text</xsl:text>
+								</xsl:when>
+								<xsl:when test="self::ui:numberfield">
+									<xsl:text>number</xsl:text>
+								</xsl:when>
+								<xsl:when test="self::ui:passwordfield">
+									<xsl:text>password</xsl:text>
+								</xsl:when>
+								<xsl:when test="self::ui:emailfield">
+									<xsl:text>email</xsl:text>
+								</xsl:when>
+								<xsl:when test="self::ui:phonenumberfield">
+									<xsl:text>tel</xsl:text>
+								</xsl:when>
+								<xsl:otherwise>
+									<xsl:text>text</xsl:text>
+								</xsl:otherwise>
+							</xsl:choose>
+						</xsl:attribute>
+						<xsl:attribute name="name">
+							<xsl:value-of select="@id"/>
+						</xsl:attribute>
+						<xsl:if test="not(self::ui:passwordfield)">
+							<xsl:attribute name="value">
+								<xsl:value-of select="."/>
+							</xsl:attribute>
+						</xsl:if>
+						<xsl:if test="$isError and $isError !=''">
+							<xsl:call-template name="invalid"/>
+						</xsl:if>
 						<xsl:if test="@maxLength">
 							<xsl:attribute name="maxLength">
 								<xsl:value-of select="@maxLength"/>
@@ -110,12 +124,6 @@
 								</xsl:choose>
 							</xsl:attribute>
 						</xsl:if>
-						<xsl:attribute name="type">
-							<xsl:value-of select="$type"/>
-						</xsl:attribute>
-						<xsl:attribute name="value">
-							<xsl:value-of select="."/>
-						</xsl:attribute>
 						<xsl:if test="@size and not(self::ui:numberfield)">
 							<xsl:attribute name="size">
 								<xsl:value-of select="@size"/>
@@ -179,11 +187,14 @@
 								</xsl:attribute>
 							</xsl:if>
 						</xsl:if>
+						<xsl:if test="not($myLabel)">
+							<xsl:call-template name="ariaLabel"/>
+						</xsl:if>
 					</xsl:element>
-				</div>
-				<xsl:call-template name="inlineError">
-					<xsl:with-param name="errors" select="$isError"/>
-				</xsl:call-template>
+					<xsl:call-template name="inlineError">
+						<xsl:with-param name="errors" select="$isError"/>
+					</xsl:call-template>
+				</span>
 			</xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>

--- a/wcomponents-theme/src/main/xslt/wc.ui.dateField.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.dateField.xsl
@@ -94,30 +94,20 @@
 					necessity which changes its content type to non-phrase.
 				-->
 				<div id="{$id}">
-					<xsl:call-template name="hideElementIfHiddenSet"/>
-					<xsl:call-template name="ajaxTarget">
-						<xsl:with-param name="live" select="'off'"/>
+					<xsl:call-template name="makeCommonClass">
+						<xsl:with-param name="additional">
+							<xsl:text>wc_input_wrapper</xsl:text>
+						</xsl:with-param>
 					</xsl:call-template>
-					<xsl:call-template name="disabledElement">
-						<xsl:with-param name="isControl" select="0"/>
-					</xsl:call-template>
-					<xsl:call-template name="makeCommonClass"/>
 					<xsl:attribute name="role">
 						<xsl:text>combobox</xsl:text>
 					</xsl:attribute>
-					<xsl:call-template name="requiredElement">
-						<xsl:with-param name="useNative" select="0"/>
-					</xsl:call-template>
 					<xsl:attribute name="aria-autocomplete">
 						<xsl:text>both</xsl:text>
 					</xsl:attribute>
-					<xsl:call-template name="disabledElement"/>
 					<xsl:attribute name="aria-expanded">
 						<xsl:text>false</xsl:text>
 					</xsl:attribute>
-					<xsl:if test="$isError">
-						<xsl:call-template name="invalid"/>
-					</xsl:if>
 					<xsl:attribute name="data-wc-name">
 						<xsl:value-of select="@id"/>
 						<xsl:text>${wc.ui.dateField.name.suffix}</xsl:text>
@@ -126,6 +116,19 @@
 						<xsl:attribute name="data-wc-value">
 							<xsl:value-of select="@date"/>
 						</xsl:attribute>
+					</xsl:if>
+					<xsl:call-template name="hideElementIfHiddenSet"/>
+					<xsl:call-template name="ajaxTarget">
+						<xsl:with-param name="live" select="'off'"/>
+					</xsl:call-template>
+					<xsl:call-template name="disabledElement">
+						<xsl:with-param name="isControl" select="0"/>
+					</xsl:call-template>
+					<xsl:call-template name="requiredElement">
+						<xsl:with-param name="useNative" select="0"/>
+					</xsl:call-template>
+					<xsl:if test="$isError">
+						<xsl:call-template name="invalid"/>
 					</xsl:if>
 					<xsl:if test="not($myLabel)">
 						<xsl:call-template name="ariaLabel"/>
@@ -161,9 +164,6 @@
 						<xsl:attribute name="aria-owns">
 							<xsl:value-of select="$pickId"/>
 						</xsl:attribute>
-						<xsl:call-template name="title">
-							<xsl:with-param name="contentAfter" select="$$${wc.ui.dateField.i18n.title.default}"/>
-						</xsl:call-template>
 
 						<xsl:if test="@min">
 							<xsl:choose>
@@ -198,44 +198,28 @@
 								<xsl:value-of select="$$${wc.common.i18n.requiredPlaceholder}"/>
 							</xsl:attribute>
 						</xsl:if>
+						<xsl:call-template name="title">
+							<xsl:with-param name="contentAfter" select="$$${wc.ui.dateField.i18n.title.default}"/>
+						</xsl:call-template>
 						<xsl:call-template name="ajaxController"/>
 						<xsl:call-template name="disabledElement">
 							<xsl:with-param name="isControl" select="1"/>
 						</xsl:call-template>
 					</xsl:element>
-					<!-- This is the date picker launch control element. -->
-					<xsl:element name="button">
-						<xsl:attribute name="value">
-							<xsl:value-of select="$inputId"/>
-						</xsl:attribute>
-						<xsl:attribute name="tabindex">
-							<xsl:text>-1</xsl:text>
-						</xsl:attribute>
-						<!--
-							Calendar needs an ID so that if the date input itself is the target of an AJAX
-							"replace" the calendar icon will get cleaned up by our duplicate ID prevention
-							logic (assumes the new date field has the same ID which in WComponents is always the case).
+					<!-- This is the date picker launch control element.
+						
+						Calendar needs an ID so that if the date input itself is the target of an AJAX
+						"replace" the calendar icon will get cleaned up by our duplicate ID prevention
+						logic (assumes the new date field has the same ID which in WComponents is always the case).
 						-->
-						<xsl:attribute name="id">
-							<xsl:value-of select="$pickId"/>
-						</xsl:attribute>
-						<xsl:attribute name="type">
-							<xsl:text>button</xsl:text>
-						</xsl:attribute>
-						<xsl:attribute name="aria-haspopup">
-							<xsl:copy-of select="$t"/>
-						</xsl:attribute>
-						<xsl:attribute name="class">
-							<xsl:text>wc_wdf_cal wc_btn_icon wc_invite</xsl:text>
-						</xsl:attribute>
-						<xsl:call-template name="hideElementIfHiddenSet"/>
+					<button value="{$inputId}" tabindex="-1" id="{$pickId}" type="button" aria-haspopup="true" class="wc_wdf_cal wc_btn_icon wc_invite">
 						<xsl:call-template name="disabledElement">
 							<xsl:with-param name="isControl" select="1"/>
 						</xsl:call-template>
 						<xsl:attribute name="title">
 							<xsl:value-of select="$$${wc.ui.dateField.i18n.calendarLaunchButton}"/>
 						</xsl:attribute>
-					</xsl:element>
+					</button>
 					<ul role="listbox" aria-busy="true"></ul>
 				</div>
 				<xsl:call-template name="inlineError">


### PR DESCRIPTION
Subordinate was not correctly handling matching empty fields for Date or Number. There were problems with the XSLT for wrapped text inputs. Wrapped inputs were no longer able to accurately find their labels. The following items were fixed to address these issues:

1. subordinate had a bug caused by a missing assignment;
2. empty fields were not correctly returning match values of “”;
3. wc/ui/dateField.getValue was not correctly handling native date inputs;
4. fixed the dogs breakfast which was the dateField and textInput XSLT - I had managed to completely mess these up;
5. beefed up wc/dom/getLabelsForElement to work with the wrapped inputs.

Fixes #452.