### PR TITLE
WFieldLayout labelWidth/inputWidth fixes

### DIFF
--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WFieldInputWidthExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WFieldInputWidthExample.java
@@ -15,13 +15,13 @@ import com.github.bordertech.wcomponents.WHeading;
 import com.github.bordertech.wcomponents.WImage;
 import com.github.bordertech.wcomponents.WLabel;
 import com.github.bordertech.wcomponents.WPanel;
+import com.github.bordertech.wcomponents.WPartialDateField;
 import com.github.bordertech.wcomponents.WProgressBar;
 import com.github.bordertech.wcomponents.WRadioButton;
 import com.github.bordertech.wcomponents.WStyledText;
+import com.github.bordertech.wcomponents.WSuggestions;
 import com.github.bordertech.wcomponents.WTextArea;
 import com.github.bordertech.wcomponents.WTextField;
-import com.github.bordertech.wcomponents.examples.common.ExplanatoryText;
-import com.github.bordertech.wcomponents.layout.ColumnLayout;
 import com.github.bordertech.wcomponents.layout.FlowLayout;
 
 /**
@@ -31,7 +31,7 @@ import com.github.bordertech.wcomponents.layout.FlowLayout;
  * @author Mark Reeves
  * @since 1.0.0
  */
-public class WLabelExample extends WPanel {
+public class WFieldInputWidthExample extends WPanel {
 
 	/**
 	 * just a sample WTextField for one of the more obscure examples.
@@ -41,30 +41,41 @@ public class WLabelExample extends WPanel {
 	/**
 	 * Creates a WLabelExample.
 	 */
-	public WLabelExample() {
+	public WFieldInputWidthExample() {
 		add(new WHeading(HeadingLevel.H2, "WLabel Patterns"));
 
 		WFieldLayout fieldsFlat = new WFieldLayout();
-		// fieldsFlat.setLabelWidth(33);
-		fieldsFlat.setMargin(new com.github.bordertech.wcomponents.Margin(0, 0, 24, 0));
+		// fieldsFlat.setLabelWidth(25);
+		// fieldsFlat.setMargin(new com.github.bordertech.wcomponents.Margin(0, 0, 24, 0));
 		add(fieldsFlat);
 
 		/*
 		 * WLabel inferred by WFieldLayout.addField(String, WComponent)
 		 */
-		fieldsFlat.addField("Normal input component", new WTextField());
+		fieldsFlat.addField("Normal input component", new WTextField()).setInputWidth(100);
 
 		/* hidden WLabel (real label) */
 		WLabel hiddenLabel = new WLabel("Address line two");
 		hiddenLabel.setHidden(true);
-		fieldsFlat.addField(hiddenLabel, new WTextField());
+		fieldsFlat.addField(hiddenLabel, new WTextField()).setInputWidth(100);
 		/* hidden WLabel (fake label) */
 		hiddenLabel = new WLabel("A hidden label for a read only field");
 		hiddenLabel.setHidden(true);
 		WTextField roField = new WTextField();
 		roField.setReadOnly(true);
 		roField.setText("This is a read only field with a hidden label");
-		fieldsFlat.addField(hiddenLabel, roField);
+		fieldsFlat.addField(hiddenLabel, roField).setInputWidth(100);
+
+		fieldsFlat.addField("A date", new WDateField()).setInputWidth(100);
+		fieldsFlat.addField("A partial date", new WPartialDateField()).setInputWidth(100);
+
+
+
+		WSuggestions suggestions = new WSuggestions("icao");
+		add(suggestions);
+		WTextField text = new WTextField();
+		text.setSuggestions(suggestions);
+		fieldsFlat.addField("Suggestions", text).setInputWidth(100);
 		/*
 		 * WFieldLayout does magic things with radio buttons and check boxes
 		 */
@@ -73,8 +84,8 @@ public class WLabelExample extends WPanel {
 		add(group1);
 		WRadioButton rb1 = group1.addRadioButton(1);
 		WRadioButton rb2 = group1.addRadioButton(2);
-		fieldsFlat.addField("I like bananas", rb1);
-		fieldsFlat.addField("I dislike bananas", rb2);
+		fieldsFlat.addField("I like bananas", rb1).setInputWidth(100);
+		fieldsFlat.addField("I dislike bananas", rb2).setInputWidth(100);
 
 		/*
 		 * WLabel can be 'for' a form input component which is NOT a labellable
@@ -86,7 +97,7 @@ public class WLabelExample extends WPanel {
 		WCheckBoxSelect cbSelect = new WCheckBoxSelect(
 				new String[]{"Apple", "Cherry", "Orange", "Pineapple"});
 		cbSelect.setFrameless(true);
-		fieldsFlat.addField("Select one or more options", cbSelect);
+		fieldsFlat.addField("Select one or more options", cbSelect).setInputWidth(100);
 
 		/*
  * Explicit use of WLabel in addField
@@ -99,7 +110,7 @@ public class WLabelExample extends WPanel {
 			"option two",
 			"option three"});
 		theDropdown.setMandatory(true);
-		fieldsFlat.addField(theLabel, theDropdown);
+		fieldsFlat.addField(theLabel, theDropdown).setInputWidth(100);
 
 		/*
 		 * Some things are labellable, even though it does not seem sensible. You
@@ -109,7 +120,7 @@ public class WLabelExample extends WPanel {
 		WProgressBar pBar = new WProgressBar(100); //yes, WProgressBar outputs a labellable control but please don't do this!
 		pBar.setValue(67);
 		WLabel pBarLabel = new WLabel("WProgressBar", pBar);
-		fieldsFlat.addField(pBarLabel, pBar);
+		fieldsFlat.addField(pBarLabel, pBar).setInputWidth(100);
 
 		/*
 		 * You would also have to do that if you needed the WLabel elsewhere or
@@ -130,7 +141,7 @@ public class WLabelExample extends WPanel {
 				}
 			}
 		};
-		fieldsFlat.addField(theLabel, whatTextField);
+		fieldsFlat.addField(theLabel, whatTextField).setInputWidth(100);
 
 		/*
 		 * Adding another WComponent to WLabel. WARNING: very few components are
@@ -161,12 +172,12 @@ public class WLabelExample extends WPanel {
 		//Make a WFieldLayout to add the WDateFields */
 		WFieldLayout innerLayout = new WFieldLayout(WFieldLayout.LAYOUT_FLAT);
 		innerLayout.setLabelWidth(17);
-		innerLayout.addField("from", new WDateField());
-		innerLayout.addField("to", new WDateField());
+		innerLayout.addField("from", new WDateField()).setInputWidth(100);
+		innerLayout.addField("to", new WDateField()).setInputWidth(100);
 		//add the WFieldLayout to the WFieldSet
 		dateRangeFS.add(innerLayout);
 		//then just call addField using the WFieldSet as the input WComponent.
-		fieldsFlat.addField(labelText, dateRangeFS);
+		fieldsFlat.addField(labelText, dateRangeFS).setInputWidth(100);
 
 
 		/* WLabel as null - convoluted example:
@@ -210,7 +221,7 @@ public class WLabelExample extends WPanel {
 		rbContainer.add(rb2);
 		rbContainer.add(rb2Label);
 		//finally we add the WPanel to the WFieldLayout using a null label
-		fieldsFlat.addField((WLabel) null, rbLayout);
+		fieldsFlat.addField((WLabel) null, rbLayout).setInputWidth(100);
 
 
 		/*
@@ -222,113 +233,5 @@ public class WLabelExample extends WPanel {
 		 */
 		fieldsFlat.addField((WLabel) null, new WButton("Save"));
 
-
-		/*
-		 * Examples showing WLabel with a nested input control WComponent.
-		 * This is VERY dangerous as only a very few WComponents are valid for
-		 * this scenario. If you go down this route: stop!!
-		 * These are really here for framework testing, not as examples as to
-		 * how to do things.
-		 */
-		add(new WHeading(HeadingLevel.H2, "Label nesting which is technically OK"));
-		/*
-		 * Just because it is OK to do this does not mean you should!
-		 * So these examples have far fewer comments.
-		 */
-		WPanel errorLayoutPanel = new WPanel();
-		errorLayoutPanel.setLayout(new FlowLayout(FlowLayout.VERTICAL, 0, 12));
-		errorLayoutPanel.setMargin(new com.github.bordertech.wcomponents.Margin(0, 0, 24, 0));
-		add(errorLayoutPanel);
-		errorLayoutPanel.add(new ExplanatoryText(
-				"This example shows WLabels with a single nested simple form control WTextField. This is not a contravention of the HTML specification but you should not do it."));
-		WLabel outerLabel = new WLabel("Label with nested WTextField and not 'for' anything");
-		errorLayoutPanel.add(outerLabel);
-		outerLabel.add(new WTextField());
-
-		WTextField innerField = new WTextField();
-		outerLabel = new WLabel("Label 'for' nested WTextField", innerField);
-		errorLayoutPanel.add(outerLabel);
-		outerLabel.add(innerField);
-
-
-		/*
-		 * DO NOT use the following as examples of what to do: these are examples
-		 * of what NOT to do.
-		 */
-		add(new WHeading(WHeading.MAJOR, "WLabel anti-patterns"));
-		add(new ExplanatoryText(
-				"These are here for testing purposes and must not be used as examples to follow.\nTurn on client debugging to get much more information."));
-		add(new WHeading(HeadingLevel.H3, "Poor but not erroneous uses of WLabel"));
-		errorLayoutPanel = new WPanel();
-		errorLayoutPanel.setLayout(new FlowLayout(FlowLayout.VERTICAL, 0, 12));
-		add(errorLayoutPanel);
-		//label not for anything should not be a WLabel
-		errorLayoutPanel.add(new WLabel("I am not 'for' anything"));
-		//WLabel for something which is not labellable
-		errorLayoutPanel.add(new WLabel("I am for a component which should not be labelled",
-				fieldsFlat));
-		//If the WLabel is 'for' something that is not in the tree it becomes 'for' the WApplication
-		//TODO: this is not necessarily a good thing!!!
-		WCheckBox notHere = new WCheckBox();
-		errorLayoutPanel.add(new WLabel("My component wasn't added", notHere));
-
-		/*
-		 * The examples which follow MUST NEVER BE USED! They cause ERRORS.
-		 * They are here purely for framework testing.
-		 */
-		add(new WHeading(HeadingLevel.H3, "Very bad uses of WLabel"));
-		errorLayoutPanel = new WPanel();
-		errorLayoutPanel.setLayout(new FlowLayout(FlowLayout.VERTICAL, 0, 12));
-		add(errorLayoutPanel);
-
-		/*
-		 * Nested WLabels: very bad
-		 */
-		errorLayoutPanel.add(new ExplanatoryText(
-				"This example shows nested WLabels. This is a contravention of the HTML specification."));
-
-		WPanel nestingErrorPanel = new WPanel();
-		//nestingErrorPanel.setLayout(new FlowLayout(FlowLayout.LEFT,12,0,FlowLayout.ContentAlignment.BASELINE));
-		nestingErrorPanel.setLayout(new ColumnLayout(new int[]{50, 50}, 12, 6));
-		errorLayoutPanel.add(nestingErrorPanel);
-		WTextField outerField = new WTextField();
-		outerLabel = new WLabel("I am an outer label", outerField);
-		nestingErrorPanel.add(outerLabel);
-
-		innerField = new WTextField();
-		WLabel innerLabel = new WLabel("Inner label", innerField);
-		//add the inner label to the outer label: this is the ERROR
-		outerLabel.add(innerLabel);
-		nestingErrorPanel.add(innerField);
-		nestingErrorPanel.add(outerField);
-
-		/*
-		 * It is permissible to place certain simple form control components into
-		 * a WLabel under the following conditions:
-		 * there must be no more than one such component in the WLabel;
-		 * the component MUST be one which outputs a simple HTML form control
-		 * (and I am not going to tell you which they are);
-		 * The WLabel must be 'for' the nested component or not 'for' anything.
-		 */
-		errorLayoutPanel.add(new ExplanatoryText(
-				"This example shows a WLabel with a nested simple form control WTextField but the WLabel is not 'for' the WTextField. This is a contravention of the HTML specification."));
-
-		WTextField notMyField = new WTextField();
-		notMyField.setToolTip("This field should not be in the label it is in");
-
-		WTextField myField = new WTextField();
-		WLabel myFieldLabel = new WLabel("I am not the label for my nested text field", myField);
-		nestingErrorPanel = new WPanel();
-		nestingErrorPanel.setLayout(new ColumnLayout(new int[]{50, 50}, 12, 6));
-		errorLayoutPanel.add(nestingErrorPanel);
-		nestingErrorPanel.add(myFieldLabel);
-		nestingErrorPanel.add(myField);
-		//adding the 'wrong' WTextField to a WLabel is what causes this error
-		myFieldLabel.add(notMyField);
-		add(new ExplanatoryText("The next field has a label explicitly set to only white space."));
-		WTextField emptyLabelTextField = new WTextField();
-		WLabel emptyLabel = new WLabel(" ", emptyLabelTextField);
-		add(emptyLabel);
-		add(emptyLabelTextField);
 	}
 }

--- a/wcomponents-theme/src/main/js/wc/ui/field.js
+++ b/wcomponents-theme/src/main/js/wc/ui/field.js
@@ -19,8 +19,9 @@ define(["wc/ui/ajax/processResponse", "wc/dom/Widget", "wc/dom/initialise", "wc/
 		 * @private
 		 */
 		function FieldAjaxSubscriber() {
-			var FIELD = new Widget("li", "wc-field"),
-				NO_PARENT_ATTRIB = "data-wc-nop";
+			var FIELD = new Widget("", "wc-field"),
+				NO_PARENT_ATTRIB = "data-wc-nop",
+				PLACEHOLDER;
 
 			/**
 			 * Before inserting a container into the DOM we may need to manipulate some properties which are not
@@ -35,46 +36,35 @@ define(["wc/ui/ajax/processResponse", "wc/dom/Widget", "wc/dom/initialise", "wc/
 			function ajaxSubscriber(element, documentFragment) {
 				var fieldElement,
 					layout,
-					labelWidth,
-					inputContainer,
-					labelContainer,
-					isStacked,
-					PC = "%";
+					pl;
 
-				if (element && FIELD.isOneOfMe(element)) {
-					// we have to have a field layout to reference, it should be element's parent element and we only care if it has a data-wc-labelwidth attribute
-					if (!(((layout = element.parentNode)) && (labelWidth = layout.getAttribute("data-wc-labelwidth")))) {
-						return;
-					}
+				if (!(element && FIELD.isOneOfMe(element))) {
+					return;
+				}
 
-					labelWidth = parseInt(labelWidth, 10);
-					if (!labelWidth || isNaN(labelWidth)) {
-						return;
-					}
+				// we have to have a field layout to reference, it should be element's parent element and we only care if it has a data-wc-labelwidth attribute
+				if (!(layout = element.parentNode)) {
+					return;
+				}
 
-					if (documentFragment.getElementById) {
-						// IE, perhaps some others
-						fieldElement = documentFragment.getElementById(element.id);
-					}
-					else if (documentFragment.querySelector) {
-						fieldElement = documentFragment.querySelector("#" + element.id);
-					}
+				if (documentFragment.getElementById) {
+					// IE, perhaps some others
+					fieldElement = documentFragment.getElementById(element.id);
+				}
+				else if (documentFragment.querySelector) {
+					fieldElement = documentFragment.querySelector("#" + element.id);
+				}
 
-					if (fieldElement && fieldElement.getAttribute(NO_PARENT_ATTRIB) === "true") {
-						fieldElement.removeAttribute(NO_PARENT_ATTRIB);
-						isStacked = classList.contains(layout, "stacked");
+				if (!fieldElement) {
+					return;
+				}
 
-						if (!isStacked && (labelContainer = fieldElement.firstChild)) {
-							labelContainer.style.width = labelWidth + PC;
-						}
-
-						if ((inputContainer = fieldElement.lastChild)) {
-							inputContainer.style.width = (100 - labelWidth) + PC;
-							inputContainer.style.maxWidth = (100 - labelWidth) + PC;
-							// stacked field layouts or inputs where the label is rendered off-screen need a left margin.
-							if (isStacked || (labelContainer && classList.contains(labelContainer, "wc_off"))) {
-								inputContainer.style.marginLeft = labelWidth + PC;
-							}
+				if (fieldElement.getAttribute(NO_PARENT_ATTRIB) === "true") {
+					fieldElement.removeAttribute(NO_PARENT_ATTRIB);
+					if (classList.contains(layout, "stacked")) {
+						PLACEHOLDER = PLACEHOLDER || new Widget("", "wc_fld_pl");
+						if ((pl = PLACEHOLDER.findDescendant(fieldElement))) {
+							pl.parentElement.removeChild(pl);
 						}
 					}
 				}

--- a/wcomponents-theme/src/main/sass/_fieldLayout-mixins.scss
+++ b/wcomponents-theme/src/main/sass/_fieldLayout-mixins.scss
@@ -1,0 +1,52 @@
+@import 'fieldLayout_vars';
+
+@mixin wc-fld-layout-flat {
+	.flat > .wc-field {
+		> label,
+		> span,
+		> div {
+			display: inline-block;
+			vertical-align: text-top;
+
+			&:first-child { //the first child is the label or stand-in or merely an empty placeholder/spacer
+				width: $label-width;
+			}
+		}
+
+		> .wc-input {
+			max-width: $input-width;
+			width: $input-width;
+		}
+
+		.wc-input { // reset
+			margin-top: 0;
+		}
+	}
+}
+
+$wc-label-width-slug: wc_fld_lblwth;
+$wc-input-width-slug: wc_fld_inpw;
+
+@mixin wc-fld-layout($lwdth) {
+	$lw: $lwdth * 1%;
+	$iw: 100% - $lw;
+
+	.#{$wc-label-width-slug}_#{$lwdth} {
+		&.flat > .wc-field > :first-child {
+			width: $lw;
+		}
+
+		&.stacked > .wc-field > .wc-input {
+			margin-left: $lw;
+		}
+
+		> .wc-field > .wc-input {
+			max-width: $iw;
+			width: $iw;
+		}
+	}
+
+	.#{$wc-input-width-slug}_#{$lwdth} > .wc-input {
+		width: $lw;
+	}
+}

--- a/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.dt.scss
@@ -1,0 +1,59 @@
+/* wc.ui.fieldLayout.dt.scss */
+@import 'fieldLayout-mixins';
+
+// Flat is the most common use, but shouldn't be (due to a11y concerns which are not covered by WCAG 2.0)
+@include wc-fld-layout-flat;
+
+// @for $i from 1 through 100 {
+// 	$wc-fld-lblw: $i * 1%;
+@for $i from 1 through 20 {
+	$j: $i * 5;
+	@include wc-fld-layout($j);
+}
+
+$wc-fld-list: 33, 67;
+@each $w in $wc-fld-list {
+	@include wc-fld-layout($w);
+}
+
+// special case for 66: it _should_ be 67
+.#{$wc-label-width-slug}_66 {
+	&.flat > .wc-field > :first-child {
+		width: 67%;
+	}
+
+	&.stacked > .wc-field > .wc-input {
+		margin-left: 67%;
+	}
+
+	> .wc-field > .wc-input {
+		max-width: 33%;
+		width: 33%;
+	}
+}
+
+.#{$wc-input-width-slug}_66 .wc-input {
+	width: 67%;
+}
+
+@include respond(small) {
+	.wc-field {
+		// Important to override all the above gubbins without another thousand rules.
+		// scss-lint:disable ImportantRule
+		> :first-child,
+		> .wc-input {
+			display: block;
+			margin-left: 0 !important;
+			max-width: 100% !important;
+			width: 100% !important;
+		}
+
+		> .wc_fld_pl { //this is the placeholder for a null or moved label (moved for checkbox or radio). Remove on narrow viewports.
+			display: none !important;
+		}
+
+		> .wc-label + .wc-input {
+			margin-top: $vgap-small;
+		}
+	}
+}

--- a/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.ie11.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.ie11.scss
@@ -5,7 +5,7 @@
 // applications a way to control overflow without having internal scroll bars on random text areas.
 
 //scss-lint:disable QualifyingElement
-.wc-input.wc_inputwidth > pre.wc_ro {
+.wc_inputwidth > .wc-input > pre.wc_ro {
 	display: block;
 	overflow: auto;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.scss
@@ -16,71 +16,140 @@ ul.wc-fieldlayout {
 
 	// Flat is the most common use, but shouldn't be (due to a11y concerns which are not covered by WCAG 2.0)
 	.flat > & {
-		> * {
+		> label,
+		> span,
+		> div {
 			display: inline-block;
 			vertical-align: text-top;
-		}
 
-		> :first-child { //the first child is the label or standing or merely an empty placeholder/spacer
-			width: $label-width;
+			&:first-child { //the first child is the label or stand-in or merely an empty placeholder/spacer
+				width: $label-width;
+			}
 		}
 
 		> .wc-input {
 			max-width: $input-width;
 			width: $input-width;
 		}
-
-		> .wc_off + .wc-input { // if the label is off screen we need some margin.
-			margin-left: $label-width;
-		}
 	}
 
+	// Stacked is pretty easy, just need to put in a vertical spacer between the label and the controls. This should
+	// probably be smaller than the gap between fields.
 	.stacked > & {
-		// Stacked is pretty easy, just need to put in a vertical spacer between the label and the controls. This should
-		// probably be smaller than the gap between fields.
+		display: block;
+
 		> .wc-label + .wc-input {
 			margin-top: $vgap-small;
 		}
 	}
 }
 
-// InputWidth is placed inline but a class is added to the input part of the field to signify that an inputWidth is
-// in use so we can size the components
-.wc_inputwidth {
-	> [type='text'],
-	> [type='date'],
-	> .wc-datefield,
-	> [type='password'],
-	> [type='email'],
-	> [type='tel'],
-	> [type='number'],
+$wc-label-width-slug: wc_fld_lblwth;
+$wc-input-width-slug: wc_fld_inpw;
+
+@mixin wc-fld-layout($lwdth) {
+	$lw: $lwdth * 1%;
+	$iw: 100% - $lw;
+
+	.#{$wc-label-width-slug}_#{$lwdth} {
+		&.flat > .wc-field > :first-child {
+			width: $lw;
+		}
+
+		&.stacked > .wc-field > .wc-input {
+			margin-left: $lw;
+		}
+
+		> .wc-field > .wc-input {
+			max-width: $iw;
+			width: $iw;
+		}
+	}
+
+	.#{$wc-input-width-slug}_#{$lwdth} > .wc-input {
+		width: $lw;
+	}
+}
+
+// @for $i from 1 through 100 {
+// 	$wc-fld-lblw: $i * 1%;
+@for $i from 1 through 20 {
+	$j: $i * 5;
+	@include wc-fld-layout($j);
+}
+
+$wc-fld-list: 33, 67;
+@each $w in $wc-fld-list {
+	@include wc-fld-layout($w);
+}
+
+// special case for 66: it _should_ be 67
+.#{$wc-label-width-slug}_66 {
+	&.flat > .wc-field > :first-child {
+		width: 67%;
+	}
+
+	&.stacked > .wc-field > .wc-input {
+		margin-left: 67%;
+	}
+
+	> .wc-field > .wc-input {
+		max-width: 33%;
+		width: 33%;
+	}
+}
+
+.#{$wc-input-width-slug}_66 .wc-input {
+	width: 67%;
+}
+
+// InputWidth class is added to the field to signify that an inputWidth is in use so we can size the components.
+.wc_inputwidth > .wc-input {
+	> .wc_input_wrapper {
+		width: 100%;
+
+		> input {
+			@include border-box;
+			width: 100%;
+		}
+
+		//&.wc-datefield > input[type="date"] { // native date iput
+			// max-width: calc(100% - 2rem);
+			// width: initial;
+		//}
+
+		&[role='combobox'] > input[type] { // fake date input
+			max-width: calc(100% - 2rem);
+			// width: initial;
+		}
+	}
+
 	> textarea,
 	> select,
 	> fieldset {
 		@include border-box;
 		width: 100%;
 	}
-
-	> .wc-datefield[role='combobox'] {
-		width: auto;
-	}
 }
 
-
 @include respond(small) {
-	.flat > .wc-field {
+	.wc-field {
+		// Important to override all the above gubbins without another thousand rules.
+		// scss-lint:disable ImportantRule
 		> :first-child,
 		> .wc-input {
-			// important to override inline CSS from XSLT
-			//scss-lint:disable ImportantRule
-			@include fit-content($imp: 1);
 			display: block;
 			margin-left: 0 !important;
 			max-width: 100% !important;
+			width: 100% !important;
 		}
 
 		> .wc_fld_pl { //this is the placeholder for a null or moved label (moved for checkbox or radio). Remove on narrow viewports.
-			display: none;
+			display: none !important;
+		}
+
+		> .wc-label + .wc-input {
+			margin-top: $vgap-small;
 		}
 	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.scss
@@ -1,5 +1,5 @@
 /* wc.ui.fieldLayout.scss */
-@import 'fieldLayout_vars';
+@import 'fieldLayout-mixins';
 
 // field layouts may be an ordered list, in which case we want to expose the numbers so need the element qualifier
 //scss-lint:disable QualifyingElement
@@ -10,146 +10,53 @@ ul.wc-fieldlayout {
 //scss-lint:enable QualifyingElement
 
 .wc-field {
+	> label,
+	> span {
+		display: block;
+	}
+
+	.wc_fld_pl { //this is the placeholder for a null or moved label (moved for checkbox or radio). Remove on narrow viewports.
+		display: none;
+	}
+
 	+ .wc-field {
 		margin-top: $vgap-normal;
 	}
+}
 
-	// Flat is the most common use, but shouldn't be (due to a11y concerns which are not covered by WCAG 2.0)
-	.flat > & {
-		> label,
-		> span,
-		> div {
-			display: inline-block;
-			vertical-align: text-top;
+.wc-input {
+	margin-top: $vgap-small;
 
-			&:first-child { //the first child is the label or stand-in or merely an empty placeholder/spacer
-				width: $label-width;
+	// InputWidth class is added to the field to signify that an inputWidth is in use so we can size the components.
+	.wc_inputwidth > & {
+		> .wc_input_wrapper {
+			width: 100%;
+
+			> input {
+				@include border-box;
+				width: 100%;
+			}
+
+			//&.wc-datefield > input[type="date"] { // native date iput
+				// max-width: calc(100% - 2rem);
+				// width: initial;
+			//}
+
+			&[role='combobox'] > input[type] { // fake date input
+				max-width: calc(100% - 2rem);
+				// width: initial;
 			}
 		}
 
-		> .wc-input {
-			max-width: $input-width;
-			width: $input-width;
-		}
-	}
-
-	// Stacked is pretty easy, just need to put in a vertical spacer between the label and the controls. This should
-	// probably be smaller than the gap between fields.
-	.stacked > & {
-		display: block;
-
-		> .wc-label + .wc-input {
-			margin-top: $vgap-small;
-		}
-	}
-}
-
-$wc-label-width-slug: wc_fld_lblwth;
-$wc-input-width-slug: wc_fld_inpw;
-
-@mixin wc-fld-layout($lwdth) {
-	$lw: $lwdth * 1%;
-	$iw: 100% - $lw;
-
-	.#{$wc-label-width-slug}_#{$lwdth} {
-		&.flat > .wc-field > :first-child {
-			width: $lw;
-		}
-
-		&.stacked > .wc-field > .wc-input {
-			margin-left: $lw;
-		}
-
-		> .wc-field > .wc-input {
-			max-width: $iw;
-			width: $iw;
-		}
-	}
-
-	.#{$wc-input-width-slug}_#{$lwdth} > .wc-input {
-		width: $lw;
-	}
-}
-
-// @for $i from 1 through 100 {
-// 	$wc-fld-lblw: $i * 1%;
-@for $i from 1 through 20 {
-	$j: $i * 5;
-	@include wc-fld-layout($j);
-}
-
-$wc-fld-list: 33, 67;
-@each $w in $wc-fld-list {
-	@include wc-fld-layout($w);
-}
-
-// special case for 66: it _should_ be 67
-.#{$wc-label-width-slug}_66 {
-	&.flat > .wc-field > :first-child {
-		width: 67%;
-	}
-
-	&.stacked > .wc-field > .wc-input {
-		margin-left: 67%;
-	}
-
-	> .wc-field > .wc-input {
-		max-width: 33%;
-		width: 33%;
-	}
-}
-
-.#{$wc-input-width-slug}_66 .wc-input {
-	width: 67%;
-}
-
-// InputWidth class is added to the field to signify that an inputWidth is in use so we can size the components.
-.wc_inputwidth > .wc-input {
-	> .wc_input_wrapper {
-		width: 100%;
-
-		> input {
+		> textarea,
+		> select,
+		> fieldset {
 			@include border-box;
 			width: 100%;
 		}
-
-		//&.wc-datefield > input[type="date"] { // native date iput
-			// max-width: calc(100% - 2rem);
-			// width: initial;
-		//}
-
-		&[role='combobox'] > input[type] { // fake date input
-			max-width: calc(100% - 2rem);
-			// width: initial;
-		}
-	}
-
-	> textarea,
-	> select,
-	> fieldset {
-		@include border-box;
-		width: 100%;
 	}
 }
 
-@include respond(small) {
-	.wc-field {
-		// Important to override all the above gubbins without another thousand rules.
-		// scss-lint:disable ImportantRule
-		> :first-child,
-		> .wc-input {
-			display: block;
-			margin-left: 0 !important;
-			max-width: 100% !important;
-			width: 100% !important;
-		}
-
-		> .wc_fld_pl { //this is the placeholder for a null or moved label (moved for checkbox or radio). Remove on narrow viewports.
-			display: none !important;
-		}
-
-		> .wc-label + .wc-input {
-			margin-top: $vgap-small;
-		}
-	}
+@include respond($size: 'not-small') {
+	@include wc-fld-layout-flat;
 }

--- a/wcomponents-theme/src/main/xslt/wc.ui.field.input.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.field.input.xsl
@@ -5,14 +5,6 @@
 		The input part of WField is a wrapper for other components. FieldIndicators
 		should be output after the functional content of the input.
 
-		param parentLayout (length 1)
-		Used to determine if the WField has a parent WFieldLayout (which may not be true
-		if the WField is in an AJAX response. We have to calculate this in ui:field so we may as well pass it in.
-
-		param labelWidth
-		The labelWidth property of the parent WFieldLayout (if known). We have to
-		calculate this in ui:field so we may as well pass it in.
-
 		param isCheckRadio (1/0)
 		Indicates whether the WField is a container for a WCheckBox, WRadioButton
 		or a WSelectToggle (renderAs not control) as the primary input control,
@@ -20,59 +12,9 @@
 		calculate this in ui:field so we may as well pass it in.
 	-->
 	<xsl:template match="ui:input">
-		<xsl:param name="parentLayout"/>
-		<xsl:param name="labelWidth"/>
 		<xsl:param name="isCheckRadio"/>
-		<xsl:variable name="inputWidth" select="../@inputWidth"/>
 		<div>
-			<xsl:call-template name="makeCommonClass">
-				<xsl:with-param name="additional">
-					<xsl:if test="$inputWidth">
-						<xsl:text> wc_inputwidth</xsl:text>
-					</xsl:if>
-				</xsl:with-param>
-			</xsl:call-template>
-			<!--
-				If we are part of an ajaxResponse with REPLACE_CONTENT and we don't have a parent ui:field we
-				need to add a transient attribute to act as a flag for the ajax subscriber
-			-->
-			<xsl:variable name="inputContainerWidth">
-				<xsl:if test="$labelWidth!=''">
-					<xsl:value-of select="100 - format-number($labelWidth,'#')"/>
-				</xsl:if>
-			</xsl:variable>
-			<xsl:variable name="inputStyle">
-				<xsl:if test="$parentLayout and $labelWidth!=''">
-					<xsl:choose>
-						<xsl:when test="not($inputWidth)">
-							<xsl:value-of select="concat('width:',$inputContainerWidth,'%;')"/>
-							<xsl:value-of select="concat('max-width:',$inputContainerWidth,'%;')"/>
-						</xsl:when>
-						<xsl:otherwise>
-							<xsl:value-of select="concat('max-width:',$inputContainerWidth,'%;')"/>
-						</xsl:otherwise>
-					</xsl:choose>
-					<!-- MARGIN-LEFT:
-						if labelWidth is 100: none
-						otherwise:
-							STACKED: always (since we are only here if labelWidth is set)
-							FLAT: only if the label is hidden
-					-->
-					<xsl:if test="not($labelWidth='100') and ($parentLayout='stacked' or preceding-sibling::ui:label/@hidden)">
-						<xsl:text>margin-left:</xsl:text>
-						<xsl:value-of select="format-number($labelWidth,'#')"/>
-						<xsl:text>%;</xsl:text>
-					</xsl:if>
-				</xsl:if>
-				<xsl:if test="$inputWidth">
-					<xsl:value-of select="concat('width:',$inputWidth,'%;')"/>
-				</xsl:if>
-			</xsl:variable>
-			<xsl:if test="$inputStyle!=''">
-				<xsl:attribute name="style">
-					<xsl:value-of select="$inputStyle"/>
-				</xsl:attribute>
-			</xsl:if>
+			<xsl:call-template name="makeCommonClass"/>
 			<xsl:choose>
 				<xsl:when test="$isCheckRadio!=1">
 					<xsl:apply-templates select="node()[not(self::ui:fieldindicator)]"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.field.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.field.xsl
@@ -47,10 +47,13 @@
 				<xsl:call-template name="fieldIsCheckRadio" />
 			</xsl:variable>
 			<li id="{@id}">
-				<xsl:attribute name="id">
-					<xsl:value-of select="@id" />
-				</xsl:attribute>
-				<xsl:call-template name="makeCommonClass"/>
+				<xsl:call-template name="makeCommonClass">
+					<xsl:with-param name="additional">
+						<xsl:if test="@inputWidth">
+							<xsl:value-of select="concat('wc_inputwidth wc_fld_inpw_', @inputWidth)"/>
+						</xsl:if>
+					</xsl:with-param>
+				</xsl:call-template>
 				<!--
 					If we are part of an ajaxResponse and we don't have a parent ui:fieldlayout we
 					need to add a transient attribute to act as a flag for the ajax subscriber
@@ -62,28 +65,15 @@
 				</xsl:if>
 				<xsl:call-template name="hideElementIfHiddenSet" />
 				<xsl:call-template name="ajaxTarget" />
-				<xsl:if test=" not($layout = 'stacked') and ($isCheckRadio=1 or not(ui:label))">
+				<xsl:if test=" not($layout = 'stacked') and ($isCheckRadio=1 or not(ui:label) or ui:label/@hidden)">
 					<span class="wc_fld_pl">
-						<xsl:if test="$labelWidth!=''">
-							<xsl:attribute name="style">
-								<xsl:value-of select="concat('width:',$labelWidth,'%;')"/>
-							</xsl:attribute>
-						</xsl:if>
 						<xsl:text>&#x00a0;</xsl:text>
 					</span>
 				</xsl:if>
 				<xsl:if test="$isCheckRadio!=1">
-					<xsl:apply-templates select="ui:label">
-						<xsl:with-param name="style">
-							<xsl:if test="$labelWidth!='' and not($layout = 'stacked')">
-								<xsl:value-of select="concat('width:',$labelWidth,'%;')"/>
-							</xsl:if>
-						</xsl:with-param>
-					</xsl:apply-templates>
+					<xsl:apply-templates select="ui:label"/>
 				</xsl:if>
 				<xsl:apply-templates select="ui:input">
-					<xsl:with-param name="labelWidth" select="$labelWidth" />
-					<xsl:with-param name="parentLayout" select="$layout" />
 					<xsl:with-param name="isCheckRadio" select="$isCheckRadio" />
 				</xsl:apply-templates>
 			</li>

--- a/wcomponents-theme/src/main/xslt/wc.ui.fieldLayout.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.fieldLayout.xsl
@@ -26,16 +26,16 @@
 		<xsl:element name="{$element}">
 			<xsl:call-template name="commonAttributes">
 				<xsl:with-param name="isWrapper" select="1"/>
-				<xsl:with-param name="class" select="@layout"/>
+				<xsl:with-param name="class">
+					<xsl:value-of select="@layout"/>
+					<xsl:if test="@labelWidth">
+						<xsl:value-of select="concat(' wc_fld_lblwth_',@labelWidth)"/>
+					</xsl:if>
+				</xsl:with-param>
 			</xsl:call-template>
 			<xsl:if test="@ordered and @ordered &gt; 1">
 				<xsl:attribute name="start">
 					<xsl:value-of select="@ordered"/>
-				</xsl:attribute>
-			</xsl:if>
-			<xsl:if test="@labelWidth">
-				<xsl:attribute name="data-wc-labelwidth">
-					<xsl:value-of select="@labelWidth"/>
 				</xsl:attribute>
 			</xsl:if>
 			<xsl:apply-templates select="ui:margin"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.label.n.labelCommonAttributes.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.label.n.labelCommonAttributes.xsl
@@ -1,6 +1,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
 	<xsl:import href="wc.common.ajax.xsl"/>
 	<xsl:import href="wc.common.title.xsl"/>
+	<xsl:import href="wc.common.hide.xsl"/>
 	
 	<!--
 		Helper for common attributes for each common type of transform of 
@@ -19,17 +20,11 @@
 		<xsl:attribute name="id">
 			<xsl:value-of select="@id"/>
 		</xsl:attribute>
-		
 		<xsl:call-template name="title"/>
-		
-		<xsl:if test="$element">
-			<xsl:if test="$element/@hidden">
-				<xsl:call-template name="hiddenElement"/>
-			</xsl:if>
+		<xsl:if test="$element and $element/@hidden">
+			<xsl:call-template name="hiddenElement"/>
 		</xsl:if>
-		
 		<xsl:call-template name="ajaxTarget"/>
-		
 		<xsl:if test="$style != ''">
 			<xsl:attribute name="style">
 				<xsl:value-of select="$style"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.label.n.makeFauxLabel.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.label.n.makeFauxLabel.xsl
@@ -17,7 +17,6 @@
 	-->
 	<xsl:template name="makeFauxLabel">
 		<xsl:param name="forElement"/>
-		<xsl:param name="style"/>
 
 		<xsl:variable name="readOnly">
 			<xsl:if test="$forElement/@readOnly">
@@ -32,7 +31,6 @@
 		<span tabindex="-1" aria-hidden="true">
 			<xsl:call-template name="labelCommonAttributes">
 				<xsl:with-param name="element" select="$forElement"/>
-				<xsl:with-param name="style" select="$style"/>
 			</xsl:call-template>
 
 			<xsl:choose>

--- a/wcomponents-theme/src/main/xslt/wc.ui.label.n.makeLabel.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.label.n.makeLabel.xsl
@@ -4,6 +4,7 @@
 	<xsl:import href="wc.ui.label.n.labelClassHelper.xsl"/>
 	<xsl:import href="wc.ui.label.n.labelCommonAttributes.xsl"/>
 	<xsl:import href="wc.ui.label.n.labelHintHelper.xsl"/>
+	<xsl:import href="wc.common.offscreenSpan.xsl"/>
 
 	<!--
 		Basic helper template to make a label for a labelable element.
@@ -29,7 +30,6 @@
 	-->
 	<xsl:template name="makeLabel">
 		<xsl:param name="labelableElement"/>
-		<xsl:param name="style"/>
 
 		<xsl:variable name="readOnly">
 			<xsl:if test="$labelableElement/@readOnly">
@@ -51,7 +51,6 @@
 		<xsl:element name="{$elementType}">
 			<xsl:call-template name="labelCommonAttributes">
 				<xsl:with-param name="element" select="$labelableElement"/>
-				<xsl:with-param name="style" select="$style"/>
 			</xsl:call-template>
 
 			<xsl:choose>

--- a/wcomponents-theme/src/main/xslt/wc.ui.label.n.makeLabelForNothing.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.label.n.makeLabelForNothing.xsl
@@ -22,15 +22,11 @@
 		wc.ui.field.xsl.
 	-->
 	<xsl:template name="makeLabelForNothing">
-		<xsl:param name="style"/>
 		<xsl:element name="span">
 			<xsl:call-template name="labelCommonAttributes">
 				<xsl:with-param name="element" select="false()"/>
-				<xsl:with-param name="style" select="$style"/>
 			</xsl:call-template>
-			
 			<xsl:call-template name="labelClassHelper"/>
-			
 			<xsl:call-template name="hideElementIfHiddenSet"/>
 			<xsl:apply-templates/>
 			<xsl:call-template name="WLabelHint"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.label.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.label.xsl
@@ -20,7 +20,6 @@
 		param style: passed in ultimately from the transform for ui:field. See wc.ui.field.xsl.
 	-->
 	<xsl:template match="ui:label">
-		<xsl:param name="style"/>
 		<xsl:variable name="for" select="@for"/>
 
 		<xsl:choose>
@@ -33,7 +32,6 @@
 						<xsl:if test="not(local-name($labelableElement)='checkbox' or local-name($labelableElement)='radiobutton' or local-name($labelableElement)='selecttoggle')">
 							<xsl:call-template name="makeLabel">
 								<xsl:with-param name="labelableElement" select="$labelableElement"/>
-								<xsl:with-param name="style" select="$style"/>
 							</xsl:call-template>
 						</xsl:if>
 					</xsl:when>
@@ -47,13 +45,10 @@
 							<xsl:when test="$forElement">
 								<xsl:call-template name="makeFauxLabel">
 									<xsl:with-param name="forElement" select="$forElement"/>
-									<xsl:with-param name="style" select="$style"/>
 								</xsl:call-template>
 							</xsl:when>
 							<xsl:otherwise>
-								<xsl:call-template name="makeLabelForNothing">
-									<xsl:with-param name="style" select="$style"/>
-								</xsl:call-template>
+								<xsl:call-template name="makeLabelForNothing"/>
 							</xsl:otherwise>
 						</xsl:choose>
 					</xsl:otherwise>
@@ -71,13 +66,10 @@
 					<xsl:when test="count($labelableDescendant)=1">
 						<xsl:call-template name="makeLabel">
 							<xsl:with-param name="labelableElement" select="$labelableDescendant[1]"/>
-							<xsl:with-param name="style" select="$style"/>
 						</xsl:call-template>
 					</xsl:when>
 					<xsl:otherwise>
-						<xsl:call-template name="makeLabelForNothing">
-							<xsl:with-param name="style" select="$style"/>
-						</xsl:call-template>
+						<xsl:call-template name="makeLabelForNothing"/>
 					</xsl:otherwise>
 				</xsl:choose>
 			</xsl:when>
@@ -88,9 +80,8 @@
 					the WLabel is for. In either case this is indicative of a WComponent Java error. We should never
 					get here and it could be deleted in which case anything falling through will not be transformed.
 				-->
-				<xsl:call-template name="makeLabelForNothing">
-					<xsl:with-param name="style" select="$style"/>
-				</xsl:call-template>
+				<xsl:call-template name="makeLabelForNothing"/>
+				
 			</xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>


### PR DESCRIPTION
* Removed inline styles from WFieldLayout/WField. LabelWidth and inputWidth are no longer dependant on ancestor lookups. 
* Removed JavaScript which was needed to fix the ancestor lookups when a WField was updated via AJAX. 
* Significant simplification of XSLT.
* Fixed a flaw in determining component size when inputWidth was set.