### PR TITLE
Sections, lists consolidation.

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/menu/bar.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/bar.js
@@ -15,10 +15,11 @@
  * @requires module:wc/dom/uid
  * @requires module:wc/i18n/i18n
  * @requires module:wc/ui/menu/menuItem
+ * @requires module:wc/has
  */
-define(["wc/ui/menu/core", "wc/dom/keyWalker", "wc/dom/shed", "wc/dom/Widget", "wc/dom/initialise", "wc/dom/uid", "wc/i18n/i18n", "wc/ui/menu/menuItem"],
-	/** @param abstractMenu wc/ui/menu/core @param keyWalker wc/dom/keyWalker @param shed wc/dom/shed @param Widget wc/dom/Widget @param initialise wc/dom/initialise @param uid wc/dom/uid @param i18n @ignore */
-	function(abstractMenu, keyWalker, shed, Widget, initialise, uid, i18n) {
+define(["wc/ui/menu/core", "wc/dom/keyWalker", "wc/dom/shed", "wc/dom/Widget", "wc/dom/initialise", "wc/dom/uid", "wc/i18n/i18n", "wc/has", "wc/ui/menu/menuItem"],
+	/** @param abstractMenu @param keyWalker @param shed @param Widget @param initialise @param uid @param i18n @param has @ignore */
+	function(abstractMenu, keyWalker, shed, Widget, initialise, uid, i18n, has) {
 		"use strict";
 
 		/* Unused dependencies:
@@ -303,7 +304,7 @@ define(["wc/ui/menu/core", "wc/dom/keyWalker", "wc/dom/shed", "wc/dom/Widget", "
 			 */
 			this.updateMenusForMobile = function (element) {
 				var candidates;
-				if (!this.isMobile) {
+				if (!this.isMobile || has("ipad")) {
 					return;
 				}
 				if (this.isSubMenu(element)) {

--- a/wcomponents-theme/src/main/sass/wc.common.sectionSpacing.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.sectionSpacing.scss
@@ -37,55 +37,28 @@ section {
 	}
 
 	// now the content
-	// All
-	> .wc-content {
+	// WSection is easy: its content is a wpanel.
+	> .wc-panel {
+		margin: $section-content-spacing;
+		padding: 0;
+	}
+
+	// WPanel content and layouts.
+	> div, // the WPanel child of WSection is a div but the rule above overrides this.
+	> .wc-listlayout {
 		padding: $section-content-spacing;
 	}
 
-	// WPanel layouts
-	> .wc-listlayout { // we need to fix the list layout default margin
-		&,
-		&.none,
-		&.flat,
-		&.bar { // need to make these a bit more specific to override the double class in wc.ui.listLayout.scss
-			margin: $section-content-spacing;
-		}
-
-		&.dot { // dotted lists need some more left margin
-			margin-left: $list-layout-dot-spacing + $section-content-spacing;
-
-			&.flat { //except when they are flat
-				margin-left: $section-content-spacing;
-			}
+	// Docking a Bar menu
+	// If you have a WPanel of type CHROME or ACTION or a WSection containing a plain WPanel
+	// and the WPanel does not have a layout then add a WMenu Type BAR to the content of the
+	// WPanel then we can 'dock' the menu to the panel/section header.
+	&,
+	> .wc-panel {
+		> .wc-content > .bar:first-child {
+			// the negative margin must be 0 - the padding of WSection content.
+			$neg-margin: -$section-content-spacing;
+			margin: $neg-margin $neg-margin $section-content-spacing;
 		}
 	}
-
-	// We need to reset the margin-left if the list is ordered so we need element qualifier for ordered lists only
-	// scss-lint:disable QualifyingElement
-	> ol.wc-listlayout {
-		margin-left: $list-layout-ordered-spacing + $section-content-spacing;
-
-		&.flat { //except when they are flat
-			margin-left: $section-content-spacing;
-		}
-	}
-	//scss-lint:enable QualifyingElement
-}
-
-// the negative margin must be 0 - the padding of WSection content.
-$neg-margin: -$section-content-spacing;
-
-// Docking a Bar menu
-// If you have a WPanel of type CHROME or ACTION or a WSection containing a plain WPanel and the WPanel does not have a
-// layout then add a WMenu Type BAR to the content of the WPanel then we can 'dock' the menu to the panel/section
-// header.
-.wc-section > .wc-content > .wc-panel, //we use the WSection class here so we do not end up with weird multi-depth happenings.
-.chrome,
-.action {
-	// need these deep selectors unfortunately
-	// scss-lint:disable SelectorDepth
-	> .wc-content > .bar:first-child {
-		margin: $neg-margin $neg-margin $section-content-spacing;
-	}
-	// scss-lint:enable SelectorDepth
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.listLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.listLayout.scss
@@ -78,6 +78,10 @@
 ol.wc-listlayout {
 	margin-left: $list-layout-ordered-spacing;
 
+	&.none {
+		margin-left: 0;
+	}
+
 	&.flat { // flat ordered lists use a pseudo-element with a counter
 		counter-reset: li;
 		margin-left: 0;

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.action.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.action.color.scss
@@ -10,7 +10,7 @@
 // its title as the H1 of the section.
 @import 'panel_vars';
 
-.action {
+.wc_pnl_action {
 	background-color: $wc-ui-color-panel-action-background;
 	border-color: $wc-ui-color-panel-action-border;
 

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.block.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.block.scss
@@ -6,6 +6,6 @@
 
 @import 'panel_vars';
 
-.block {
+.wc_pnl_block {
 	padding: $hgap-normal;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.box.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.box.scss
@@ -3,6 +3,6 @@
 // 'A box panel has a border.' therefore has a pad to remove the content from the border.
 @import 'mixins-common';
 
-.box {
+.wc_pnl_box {
 	@include padded-box;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.chrome.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.chrome.color.scss
@@ -4,7 +4,7 @@
 
 @import 'panel_vars';
 
-.chrome > h1 {
+.wc_pnl_chrome > h1 {
 	background-color: $wc-ui-color-section-heading-bg;
 	color: $wc-ui-color-section-heading-fg;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.feature.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.feature.color.scss
@@ -3,6 +3,6 @@
 // 'The feature panel is highlighted by a background colour and border.'
 @import 'panel_vars';
 
-.feature {
+.wc_pnl_feature {
 	@include padded-box($bg-color: $wc-ui-color-panel-feature-background, $color: $wc-ui-color-panel-feature-foreground);
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.footer.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.footer.color.scss
@@ -3,8 +3,6 @@
 // This CSS for the page footer
 @import 'panel_vars';
 
-// Only apply footer styles to WPanel type footer.
-// scss-lint:disable QualifyingElement
-footer.wc-panel {
+.wc_pnl_footer {
 	@include padded-box($bg-color: $wc-ui-color-panel-footer-background, $color: $wc-ui-color-panel-footer-foreground);
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.header.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.header.scss
@@ -10,22 +10,8 @@
 	padding: $vgap-normal $hgap-normal;
 }
 
-@include respond (mobile) {
-	[role='banner'] {
-		> .wc-content {
-			@include flex($direction: row-reverse, $wrap: wrap, $justify: space-between, $align-items: center, $align-content: flex-start);
-			padding: $hgap-small;
-
-			> * {
-				@include flex-grow(0);
-				@include flex-shrink(1);
-			}
-		}
-
-		h1 {
-			@include tight-box;
-			font-size: 1.25rem;
-			font-weight: bold;
-		}
+@include respond(phonelike) {
+	[role='banner'] > :first-child {
+		@include flex($direction: row-reverse, $wrap: wrap, $justify: space-between, $align-items: center);
 	}
 }

--- a/wcomponents-theme/src/main/xslt/wc.ui.content.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.content.xsl
@@ -1,4 +1,5 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
+	<xsl:import href="wc.common.n.className.xsl"/>
 	<!--
 		ui:content is a child node of a number of components in its most basic form it
 		merely passes through. Some components have their own content implementation:
@@ -16,12 +17,6 @@
 					<xsl:value-of select="@id"/>
 				</xsl:attribute>
 			</xsl:if>
-			<xsl:attribute name="class">
-				<xsl:text>wc-content</xsl:text>
-				<xsl:if test="$class != ''">
-					<xsl:value-of select="concat(' ', $class)"/>
-				</xsl:if>
-			</xsl:attribute>
 			<xsl:if test="$ajaxId != ''">
 				<xsl:attribute name="data-wc-ajaxalias">
 					<xsl:value-of select="$ajaxId"/>
@@ -32,6 +27,9 @@
 					<xsl:value-of select="$labelId"/>
 				</xsl:attribute>
 			</xsl:if>
+			<xsl:call-template name="makeCommonClass">
+				<xsl:with-param name="additional" select="$class"/>
+			</xsl:call-template>
 			<xsl:apply-templates/>
 		</div>
 	</xsl:template>

--- a/wcomponents-theme/src/main/xslt/wc.ui.panel.n.WPanelClass.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.panel.n.WPanelClass.xsl
@@ -3,10 +3,11 @@
 	<xsl:import href="wc.common.n.className.xsl" />
 
 	<xsl:template name="WPanelClass">
+		<xsl:param name="type" />
 		<xsl:call-template name="commonClassHelper">
 			<xsl:with-param name="additional">
-				<xsl:if test="@type">
-					<xsl:value-of select="concat(' ',@type)" />
+				<xsl:if test="$type and $type != ''">
+					<xsl:value-of select="concat(' wc_pnl_', $type)" />
 				</xsl:if>
 				<xsl:choose>
 					<xsl:when test="(@mode='lazy' and @hidden)"><xsl:text> wc_magic</xsl:text></xsl:when>

--- a/wcomponents-theme/src/main/xslt/wc.ui.panel.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.panel.xsl
@@ -19,6 +19,7 @@
 			* ui:listlayout
 	-->
 	<xsl:template match="ui:panel">
+		<xsl:param name="type" select="@type"/>
 		<xsl:variable name="id" select="@id"/>
 		
 		<xsl:variable name="containerElement">
@@ -29,14 +30,16 @@
 				<xsl:value-of select="$id"/>
 			</xsl:attribute>
 			<xsl:attribute name="class">
-				<xsl:call-template name="WPanelClass"/>
+				<xsl:call-template name="WPanelClass">
+					<xsl:with-param name="type" select="$type"/>
+				</xsl:call-template>
 			</xsl:attribute>
 			<xsl:if test="@buttonId">
 				<xsl:attribute name="${wc.common.attribute.button}">
 					<xsl:value-of select="@buttonId"/>
 				</xsl:attribute>
 			</xsl:if>
-			<xsl:if test="@type='header'">
+			<xsl:if test="$type='header'">
 				<xsl:attribute name="role">
 					<xsl:text>banner</xsl:text>
 				</xsl:attribute>

--- a/wcomponents-theme/src/main/xslt/wc.ui.section.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.section.xsl
@@ -24,12 +24,9 @@
 			<xsl:call-template name="hideElementIfHiddenSet"/>
 			<xsl:if test="*[not(self::ui:margin)] or not($mode='eager')">
 				<xsl:apply-templates select="ui:decoratedlabel" mode="section"/>
-				<xsl:element name="div">
-					<xsl:attribute name="class">
-						<xsl:text>wc-content</xsl:text>
-					</xsl:attribute>
-					<xsl:apply-templates select="ui:panel"/>
-				</xsl:element>
+				<xsl:apply-templates select="ui:panel">
+					<xsl:with-param name="type" select="''"/>
+				</xsl:apply-templates>
 			</xsl:if>
 		</xsl:element>
 	</xsl:template>


### PR DESCRIPTION
* Re-jigged the structure of WSection to simplify it;
* added a prefix to the WPanel type classNames to remove some ambiguity;
* simplified the CSS for spacing section elements (WSection and WPanel
types CHROME and ACTION);
* removed iPads from the header menu munger;
* fixed a rendering flaw with WList/ListLayout when ordered and with
Separator.NONE.