### PR TITLE
WTree (htree) selection

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/menu/core.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/core.js
@@ -1762,7 +1762,13 @@ define(["wc/has",
 			return (this.isItem(element) && !this._isBranch(element));
 		};
 
-
+		/**
+		 * Test if an element is a "submenu" node of the current menu/tree type.
+		 * @function
+		 * @public
+		 * @param {Element} element The element to test
+		 * @returns {Boolean} true if element is a submenu and not the root.
+		 */
 		AbstractMenu.prototype.isSubMenu = function(element) {
 			if (!element) {
 				return null;

--- a/wcomponents-theme/src/main/js/wc/ui/menu/treeItem.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/treeItem.js
@@ -52,7 +52,7 @@ define(["wc/dom/ariaAnalog",
 				var root, result = isAcceptableTarget(element, target);
 
 				if (tree && (root = tree.getRoot(target))) {
-					if (tree.isInVOpen(target)) {
+					if (tree.isInVOpen(target) || tree.isSubMenu(target) || tree.isRoot(target)) {
 						return false;
 					}
 
@@ -201,7 +201,6 @@ define(["wc/dom/ariaAnalog",
 			this.clickEvent = function($event) {
 				var target = $event.target, element;
 				if (!$event.defaultPrevented && (element = this.getActivableFromTarget(target)) && !shed.isDisabled(element)) {
-					opener = opener || new Widget("button", "wc_leaf");
 					if (isAcceptable(element, target)) {
 						this.activate(element, $event.shiftKey, ($event.ctrlKey || $event.metaKey));
 					}


### PR DESCRIPTION
Fixed a flaw in wc/ui/menu/treeitem which allowed a treeitem which has
children to receive “selection” if an empty space in the child group
was clicked.