### PR TITLE
Fix expanded properties check and try alternate sass compiler

### DIFF
--- a/wcomponents-theme-parent/pom.xml
+++ b/wcomponents-theme-parent/pom.xml
@@ -168,6 +168,7 @@
 								<property name="build.number" value="${project.version}" />
 								<property name="build.rootdir" location="${theme.target.dir}" />
 								<property name="theme.skip.tests" value="true" />
+								<property name="maven.plugin.classpath" refid="maven.plugin.classpath" />
 								<ant antfile="${theme.core.dir}/build.xml">
 									<target name="build" />
 								</ant>
@@ -192,6 +193,7 @@
 								<property name="build.number" value="${project.version}" />
 								<property name="build.rootdir" location="${theme.target.dir}" />
 								<property name="theme.skip.tests" value="${skipOptionalTests}" />
+								<property name="maven.plugin.classpath" refid="maven.plugin.classpath" />
 								<!--<property name="theme.skip.tests" value="${skipOptionalTests}" />-->
 								<ant antfile="${theme.core.dir}/build.xml">
 									<target name="test" />
@@ -216,6 +218,7 @@
 								<property name="build.number" value="${project.version}" />
 								<property name="build.rootdir" location="${theme.target.dir}" />
 								<property name="theme.skip.tests" value="true" />
+								<property name="maven.plugin.classpath" refid="maven.plugin.classpath" />
 								<ant antfile="${theme.core.dir}/build.xml">
 									<target name="document" />
 								</ant>
@@ -227,6 +230,11 @@
 					</execution>
 				</executions>
 				<dependencies>
+					<dependency>
+						<groupId>com.vaadin</groupId>
+						<artifactId>vaadin-sass-compiler</artifactId>
+						<version>0.9.13</version>
+					</dependency>
 					<dependency>
 						<groupId>com.cathive.sass</groupId>
 						<artifactId>sass-java</artifactId>

--- a/wcomponents-theme/build-css.xml
+++ b/wcomponents-theme/build-css.xml
@@ -120,6 +120,37 @@
 	</target>
 
 	<!--
+		Vaadin Sass Compiler is a pure Java Sass compiler.
+		It would be great if it worked but it does not support quite a few syntax features found in native Sass.
+		It would also be nice if we could point at source and dest directories rather than files.
+		A native Ant task would also be preferable.
+		I'm leaving this is place so that we can test newer versions as they come and hopefully switch to it later.
+	-->
+	<target name="compileScssVaadin">
+		<stopwatch name="compileScss" action="start" />
+		<foreach target="compileScssFileVaadin" param="scss.file">
+			<fileset dir="${sass.tmp.src.dir}">
+				<include name="*.scss"/>
+			</fileset>
+		</foreach>
+		<stopwatch name="compileScss" action="total" />
+	</target>
+
+	<!-- Helper for compileScssVaadin -->
+	<target name="compileScssFileVaadin">
+		<var name="scss.file.name" unset="true"/>
+		<basename property="scss.file.name" file="${scss.file}"/>
+		<echo>Compiling ${scss.file.name}</echo>
+		<java classname="com.vaadin.sass.SassCompiler" fork="true" failonerror="true">
+			<classpath>
+				<path refid="project.class.path"/>
+			</classpath>
+			<arg value="${scss.file}"/>
+			<arg value="${style.tmp.src.dir}/${scss.file.name}"/>
+		</java>
+	</target>
+
+	<!--
 		Make CSS out of SCSS.
 		While we'd like to use a true NodeJS module for this none-sass isn't it: it's a wrapper around
 		the native sass binaries which must be downloaded from the web for the build platform. All sorts

--- a/wcomponents-theme/build-import.xml
+++ b/wcomponents-theme/build-import.xml
@@ -174,7 +174,8 @@
 				<include name="**/*.css"/>
 				<include name="**/*.xsl"/>
 				<include name="**/*.xml"/>
-				<contains text="${"/><!-- this would be much better as a regex-->
+				<containsregexp expression="\$\{[^\}]+\}"/>
+				<!--<contains text="${"/> this would be much better as a regex-->
 			</fileset>
 		</path>
 		<property name="unexpanded" refid="unexpanded.properties"/>

--- a/wcomponents-theme/build.xml
+++ b/wcomponents-theme/build.xml
@@ -435,6 +435,7 @@ chromedriver_cdnurl=${mirror.root}/chromedriver
 			<stopwatch name="@{antFile}" action="start"/>
 			<ant antfile="${theme.core.dir}/@{antFile}" inheritAll="false" target="@{target}">
 				<property name="component.rootdir" location="${theme.core.dir}"/>
+				<property name="maven.plugin.classpath" value="${maven.plugin.classpath}"/>
 				<property name="basedir" location="${basedir}"/>
 				<property name="tmp.dir" location="${theme.tmp.dir}"/>
 				<property name="build.number" value="${project.version}"/>


### PR DESCRIPTION
The sass maven plugin we currently use does not work on some versions of RHEL due to glibc version issues.

It also munges unicode characters when run on Windows (causing fontawesome mixin to die).

We'd prefer a native java (or JS) Sass compiler. Here I hook up Vaadin Sass Compiler (to find that it unfortunately is not quite capable).
