### PR TITLE
Reinstate disabled media support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## API Changes
 * WAudio and WVideo Controls.ALL, and Controls.DEFAULT have been **deprecated** as they no have no impact on the
-  controls;
+  controls (#503);
 * WAudio and WVideo Controls.NONE have been **deprecated** as they are not compatible with WCAG requirements that media
   be able to be turned off. These were always incompatible with autoplay to prevent a11y failure. This means that any
-  media component with Controls.NONE has never been able to work and **will never** be able to work.
+  media component with Controls.NONE has never been able to work and **will never** be able to work (#503).
 
 ## Enhancements
+* Re-instated client side support for disabled state in WAudio and WVideo but this only applies when Controls.PLAY_PAUSE
+  is used as there is no native disabled support in audio or video elements. The play/pause button **will not** be
+  disabled if autoplay is set as this causes an a11y failure.
 
 ## Major Bug fixes
 * Worked around an issue which prevented Sass from compiling on Linux with glibc below v13 and a related issue which

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WAudioExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WAudioExample.java
@@ -48,6 +48,11 @@ public class WAudioExample extends WContainer {
 	private final WCheckBox cbControls = new WCheckBox();
 
 	/**
+	 * Used to set the disabled option on audio.
+	 */
+	private final WCheckBox cbDisable = new WCheckBox();
+
+	/**
 	 * A button used to apply new settings to the audio component.
 	 */
 	private final WButton btnApply = new WButton("Apply settings");
@@ -88,8 +93,19 @@ public class WAudioExample extends WContainer {
 		add(layout);
 		layout.addField("Autoplay", cbAutoPlay);
 		layout.addField("Loop", cbLoop);
+		layout.addField("Disable", cbDisable);
 		layout.addField("Show only play/pause", cbControls);
 		layout.addField((WLabel) null, btnApply);
+
+		// enable disable option only when control PLAY_PAUSE is used.
+		WSubordinateControl control = new WSubordinateControl();
+		add(control);
+		Rule rule = new Rule();
+		rule.setCondition(new Equal(cbControls, Boolean.TRUE.toString()));
+		rule.addActionOnTrue(new Enable(cbDisable));
+		rule.addActionOnFalse(new Disable(cbDisable));
+		control.addRule(rule);
+
 		// allow config to change without reloading the whole page.
 		add(new WAjaxControl(btnApply, audio));
 
@@ -117,5 +133,6 @@ public class WAudioExample extends WContainer {
 		audio.setAutoplay(cbAutoPlay.isSelected());
 		audio.setLoop(!cbLoop.isDisabled() && cbLoop.isSelected());
 		audio.setControls(cbControls.isSelected() ? WAudio.Controls.PLAY_PAUSE : WAudio.Controls.NATIVE);
+		audio.setDisabled(cbControls.isSelected() && cbDisable.isSelected());
 	}
 }

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WVideoExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WVideoExample.java
@@ -10,9 +10,9 @@ import com.github.bordertech.wcomponents.VideoResource;
 import com.github.bordertech.wcomponents.WAjaxControl;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WCheckBox;
+import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WFieldLayout;
 import com.github.bordertech.wcomponents.WLabel;
-import com.github.bordertech.wcomponents.WPanel;
 import com.github.bordertech.wcomponents.WVideo;
 import com.github.bordertech.wcomponents.subordinate.Disable;
 import com.github.bordertech.wcomponents.subordinate.Enable;
@@ -26,7 +26,7 @@ import com.github.bordertech.wcomponents.subordinate.WSubordinateControl;
  * @author Yiannis Paschalidis
  * @since 1.0.0
  */
-public class WVideoExample extends WPanel {
+public class WVideoExample extends WContainer {
 
 	/**
 	 * The WVideo used in this example.
@@ -53,6 +53,11 @@ public class WVideoExample extends WPanel {
 	 * Used to set the controls option on video to PLAY_PAUSE.
 	 */
 	private final WCheckBox cbControls = new WCheckBox();
+
+	/**
+	 * Used to set the disabled option on video.
+	 */
+	private final WCheckBox cbDisable = new WCheckBox();
 
 	/**
 	 * A button used to apply new settings to the audio component.
@@ -98,19 +103,22 @@ public class WVideoExample extends WPanel {
 		layout.addField("Autoplay", cbAutoPlay);
 		layout.addField("Loop", cbLoop);
 		layout.addField("Mute", cbMute);
+		layout.addField("Disable", cbDisable);
 		layout.addField("Show separate play/pause", cbControls);
 		layout.addField((WLabel) null, btnApply);
 
 		// add the video to the UI
 		add(video);
 
-		// disable mute if PLAY_PAUSE is used
+		// disable mute and enable disable if PLAY_PAUSE is used
 		WSubordinateControl control = new WSubordinateControl();
 		add(control);
 		Rule rule = new Rule();
 		rule.setCondition(new Equal(cbControls, Boolean.TRUE.toString()));
 		rule.addActionOnTrue(new Disable(cbMute));
+		rule.addActionOnTrue(new Enable(cbDisable));
 		rule.addActionOnFalse(new Enable(cbMute));
+		rule.addActionOnFalse(new Disable(cbDisable));
 		control.addRule(rule);
 		// Allow the config to be updated without reloading the whole UI.
 		add(new WAjaxControl(btnApply, video));
@@ -139,5 +147,6 @@ public class WVideoExample extends WPanel {
 		video.setLoop(cbLoop.isSelected());
 		video.setMuted(!cbMute.isDisabled() && cbMute.isSelected());
 		video.setControls(cbControls.isSelected() ? WVideo.Controls.PLAY_PAUSE : WVideo.Controls.NATIVE);
+		video.setDisabled(cbControls.isSelected() && cbDisable.isSelected());
 	}
 }

--- a/wcomponents-theme/src/main/xslt/wc.common.media.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.media.xsl
@@ -3,6 +3,7 @@
 	<xsl:import href="wc.common.hide.xsl"/>
 	<xsl:import href="wc.common.media.n.mediaUnsupportedContent.xsl"/>
 	<xsl:import href="wc.common.n.className.xsl"/>
+	<xsl:import href="wc.common.disabledElement.xsl"/>
 	<!--
 		Transforms for ui:audio from WAudio and ui:video from WVideo and their children.
 		
@@ -35,7 +36,7 @@
 			<xsl:call-template name="hideElementIfHiddenSet"/>
 			<xsl:call-template name="ajaxTarget"/>
 			<xsl:variable name="mediaId" select="concat(@id, '-media')"/>
-			
+
 			<xsl:element name="{$elementType}">
 				<xsl:attribute name="id">
 					<xsl:value-of select="$mediaId"/>
@@ -108,6 +109,12 @@
 			</xsl:element>
 			<xsl:if test="@controls='play'">
 				<button type="button" class="wc_btn_icon wc_av_play" aria-pressed="false" aria-controls="{$mediaId}">
+					<xsl:if test="not(@autoplay)">
+						<!-- do not allow the button to be disabled if autoplay is on - the user MUST be able to stop/pause playback. -->
+						<xsl:call-template name="disabledElement">
+							<xsl:with-param name="isControl" select="1"/>
+						</xsl:call-template>
+					</xsl:if>
 					<span class="wc_off">
 						<xsl:value-of select="$$${wc.ui.media.i18n.play}"/>
 					</span>


### PR DESCRIPTION
Re-instated support for media to be disabled on load if controls is PLAY_PAUSE. The play/pause button **will not** be disabled if autoplay
is set as this causes an a11y failure.

Fixes #506