### PR TITLE
WField null labels

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WFieldLayout.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WFieldLayout.java
@@ -180,6 +180,9 @@ public class WFieldLayout extends AbstractNamingContextContainer implements Ajax
 	 * @return the field which was added to the layout.
 	 */
 	public WField addField(final String label, final WComponent field) {
+		if (null == label) {
+			return addField((WLabel) null, field);
+		}
 		return addField(new WLabel(label), field);
 	}
 


### PR DESCRIPTION
Ensured that a null label in WFieldLayout.addField will result in the same output whether the null is cast to String or WLabel. Fixes #512