### PR TITLE
Safari bug workaround

### DIFF
--- a/wcomponents-theme/src/main/sass/_colorscheme.scss
+++ b/wcomponents-theme/src/main/sass/_colorscheme.scss
@@ -47,7 +47,7 @@ $std-color-success-fg: #060;
 // High priority and error indicator/foreground/header/box
 $std-color-error-fg: #af0000;
 // Secondary colour used for background of inputs in an error state.
-$std-color-error-bg: #ffbfbf;
+$std-color-error-bg: #ffdfdf;
 // Warnings and medium priority
 $std-color-warning-fg: $std-color-accent;
 //

--- a/wcomponents-theme/src/main/sass/_mixins-common.scss
+++ b/wcomponents-theme/src/main/sass/_mixins-common.scss
@@ -175,6 +175,7 @@
 	left: -9999px !important;
 	overflow: hidden !important;
 	position: absolute !important;
+	width: 0 !important;
 }
 
 /// Set an outline on an element. Outlines may be better than borders for transient effects.

--- a/wcomponents-theme/src/main/sass/wc.common.page.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.page.dt.scss
@@ -1,8 +1,10 @@
 /* wc.common.page.dt.scss */
 @import 'mixins-common';
 
-body {
-	font-size: $dt-font-size;
+@media only screen and (min-device-width: 1025px) {
+	body {
+		font-size: $dt-font-size;
+	}
 }
 
 @media only screen and (min-device-width: 1921px) {

--- a/wcomponents-theme/src/main/sass/wc.ui.backToTop.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.backToTop.dt.scss
@@ -1,6 +1,9 @@
 /* wc.ui.backToTop.dt.scss */
 @import 'mixins-common';
+
 /// The back to top of page link.
-.wc_btt:before {
-	font-size: 4rem;
+@include respond-not-small {
+	.wc_btt:before {
+		font-size: 4rem;
+	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.dt.scss
@@ -1,57 +1,37 @@
 /* wc.ui.fieldLayout.dt.scss */
 @import 'fieldLayout-mixins';
 
-// Flat is the most common use, but shouldn't be (due to a11y concerns which are not covered by WCAG 2.0)
-.flat > .wc-field {
-	> label,
-	> span,
-	> div {
-		display: inline-block;
-		vertical-align: text-top;
+$wc-fld-list: 33, 67;
 
-		&:first-child { //the first child is the label or stand-in or merely an empty placeholder/spacer
-			width: $label-width;
+@include respond-not-small {
+	// @for $i from 1 through 100 {
+	// 	$wc-fld-lblw: $i * 1%;
+	@for $i from 1 through 20 {
+		$j: $i * 5;
+		@include wc-fld-layout($j);
+	}
+
+	@each $w in $wc-fld-list {
+		@include wc-fld-layout($w);
+	}
+
+	// special case for 66: it _should_ be 67
+	.#{$wc-label-width-slug}_66 {
+		&.flat > .wc-field  > :first-child {
+			width: 67%;
+		}
+
+		&.stacked > .wc-field > .wc-input {
+			margin-left: 67%;
+		}
+
+		> .wc-field > .wc-input {
+			max-width: 33%;
+			width: 33%;
 		}
 	}
 
-	> .wc-input {
-		max-width: $input-width;
-		width: $input-width;
-	}
-
-	.wc-input { // reset
-		margin-top: 0;
-	}
-}
-
-// @for $i from 1 through 100 {
-// 	$wc-fld-lblw: $i * 1%;
-@for $i from 1 through 20 {
-	$j: $i * 5;
-	@include wc-fld-layout($j);
-}
-
-$wc-fld-list: 33, 67;
-@each $w in $wc-fld-list {
-	@include wc-fld-layout($w);
-}
-
-// special case for 66: it _should_ be 67
-.#{$wc-label-width-slug}_66 {
-	&.flat > .wc-field > :first-child {
+	.#{$wc-input-width-slug}_66 .wc-input {
 		width: 67%;
 	}
-
-	&.stacked > .wc-field > .wc-input {
-		margin-left: 67%;
-	}
-
-	> .wc-field > .wc-input {
-		max-width: 33%;
-		width: 33%;
-	}
-}
-
-.#{$wc-input-width-slug}_66 .wc-input {
-	width: 67%;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.scss
@@ -37,23 +37,44 @@ ul.wc-fieldlayout {
 				width: 100%;
 			}
 
-			//&.wc-datefield > input[type="date"] { // native date iput
-				// max-width: calc(100% - 2rem);
-				// width: initial;
-			//}
-
 			&[role='combobox'] > input[type] { // fake date input
 				max-width: calc(100% - 2rem);
-				// width: initial;
 			}
 		}
 
 		> [type='password'],
+		> [type='number'],
 		> textarea,
 		> select,
 		> fieldset {
 			@include border-box;
 			width: 100%;
+		}
+	}
+}
+
+@include respond-not-small {
+	// This block should be in fieldLayout.dt.css but is here to work around a Safari bug.
+	// Flat is the most common use, but shouldn't be (due to a11y concerns which are not adequately covered by WCAG 2.0)
+	.flat > .wc-field {
+		> label,
+		> span,
+		> div {
+			display: inline-block;
+			vertical-align: text-top;
+
+			&:first-child { //the first child is the label or stand-in or merely an empty placeholder/spacer
+				width: $label-width;
+			}
+		}
+
+		> .wc-input {
+			max-width: $input-width;
+			width: $input-width;
+		}
+
+		.wc-input { // reset
+			margin-top: 0;
 		}
 	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.fileUpload.dt.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fileUpload.dt.scss
@@ -1,6 +1,8 @@
 /* wc.ui.fileUpload.scss */
 @import 'mixins-common';
 
-.wc-fileupload .wc_btn_camera {
-	display: inline-block;  // This should only be available on desktop browsers
+@include respond-not-small {
+	.wc-fileupload .wc_btn_camera {
+		display: inline-block;  // This should only be available on desktop browsers
+	}
 }

--- a/wcomponents-theme/src/main/xslt/wc.ui.field.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.field.xsl
@@ -65,7 +65,7 @@
 				</xsl:if>
 				<xsl:call-template name="hideElementIfHiddenSet" />
 				<xsl:call-template name="ajaxTarget" />
-				<xsl:if test=" not($layout = 'stacked') and ($isCheckRadio=1 or not(ui:label) or ui:label/@hidden)">
+				<xsl:if test="not($layout = 'stacked') and ($isCheckRadio=1 or not(ui:label) or ui:label/@hidden)">
 					<span class="wc_fld_pl">
 						<xsl:text>&#x00a0;</xsl:text>
 					</span>


### PR DESCRIPTION
Provided a work around to a Safari bug which broke some implementations
of WFieldLayout.

Added media queries to exclude some former dt CSS from smaller views.