### PR TITLE
Fix direction of sort icons

### DIFF
--- a/wcomponents-theme/src/main/sass/wc.ui.table.sortIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.sortIcons.scss
@@ -8,10 +8,10 @@ th {
 	}
 
 	&[sorted]:after {
-		content: $fa-var-caret-square-o-down;
+		content: $fa-var-caret-square-o-up;
 	}
 
 	&[sorted~='reversed']:after {
-		content: $fa-var-caret-square-o-up;
+		content: $fa-var-caret-square-o-down;
 	}
 }


### PR DESCRIPTION
Arrows indicating direction of sort in WTable were the ‘wrong’ way
around.