### PR TITLE
Latest requirejs AND excluded a11y checks (for now)

### DIFF
--- a/wcomponents-theme/src/main/xslt/wc.ui.root.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.root.xsl
@@ -62,7 +62,7 @@
 					<xsl:text>require(["wc/compat/compat!"], function() {</xsl:text>
 					<xsl:text>require(["wc/loader/style", "wc/dom/removeElement"</xsl:text>
 					<xsl:if test="$isDebug=1">
-						<xsl:text>,"wc/debug/consoleColor", "wc/debug/a11y", "wc/debug/indicator"</xsl:text>
+						<xsl:text>,"wc/debug/consoleColor", "wc/debug/indicator"</xsl:text><!-- , "wc/debug/a11y" #533 -->
 					</xsl:if>
 					<xsl:text>], function(s, r){try{s.load();}finally{r("</xsl:text>
 					<xsl:value-of select="$styleLoaderId"/>

--- a/wcomponents-theme/unbuilt.package.json
+++ b/wcomponents-theme/unbuilt.package.json
@@ -18,7 +18,7 @@
 		"jsdoc": "~3.3.2",
 		"mustache": "~2.2.1",
 		"promise-polyfill": "~2.1.0",
-		"requirejs": "~2.1.20",
+		"requirejs": "~2.2.0",
 		"sprintf-js": "~1.0.3",
 		"systemjs": "~0.19.22",
 		"tinymce": "~4.2.5",


### PR DESCRIPTION
accessibility developer tools is likely behind the error we are seeing on iOS - "MISMATCHED ANONYMOUS DEFINE".

Given other priorities I am simply excluding the entire a11y check module for now.
We can add it back later and either patch the issue or switch to axe core.

I also picked up the latest version of requirejs - just because.
