### PR TITLE
Add automation helper module

### DIFF
--- a/wcomponents-theme/src/main/js/wc/a8n.js
+++ b/wcomponents-theme/src/main/js/wc/a8n.js
@@ -1,0 +1,112 @@
+/**
+ * This module provides affordances for automated testing tools.
+ */
+define(["wc/dom/initialise", "wc/ajax/ajax", "wc/ajax/Trigger", "wc/timers", "wc/Observer"],
+	function(initialise, ajax, Trigger, timers, Observer) {
+		var observer,
+			instance = {
+				preInit: preInit,
+				postInit: postInit,
+				subscribe: subscribe
+			},
+			flags = {
+				AJAX: 1,
+				TIMERS: 2,
+				AJAX_TRIGGER: 4,
+				DOM_READY: 8
+			},
+			globalPending = 0;
+
+		timers._subscribe(pendingTimers);
+		ajax.subscribe(pendingAjax);
+		Trigger.subscribe(pendingAjaxTrigger);
+		Trigger.subscribe(pendingAjaxTrigger, -1);
+
+		/*
+		 * Subscriber for pending AJAX requests.
+		 */
+		function pendingAjax(pending) {
+			var element = document.body;
+			if (element) {
+				// TODO remove this attribute - it is not needed any more now we have data-wc-domready
+				element.setAttribute("data-wc-ajaxp", pending);
+			}
+			pendingUpdated(pending, flags.AJAX);
+		}
+
+		/*
+		 * Subscriber for pending AJAX requests that will update the DOM.
+		 */
+		function pendingAjaxTrigger(trigger, pending) {
+			pendingUpdated(pending, flags.AJAX_TRIGGER);
+		}
+
+		/*
+		 * Subscriber for pending timeouts.
+		 */
+		function pendingTimers(pending) {
+			var element = document.body;
+			if (element) {
+				// TODO remove this attribute - it is not needed any more now we have data-wc-domready
+				element.setAttribute("data-wc-timers", pending);
+			}
+			pendingUpdated(pending, flags.TIMERS);
+		}
+
+		/*
+		 * Called by subscribers when they are notified of a possible change in state.
+		 */
+		function pendingUpdated(pending, flag) {
+			var attr = "data-wc-domready",
+				currentState, isReady,
+				element = document.body;
+			if (pending) {
+				globalPending |= flag;
+			}
+			else {
+				globalPending &= ~flag;
+			}
+			if (element) {
+				isReady = !globalPending;
+				currentState = (element.getAttribute(attr) === "true");
+				if (isReady !== currentState) {
+					element.setAttribute(attr, isReady);
+					if (observer) {
+						observer.notify(isReady);
+					}
+				}
+			}
+		}
+
+		/*
+		 * Called before initialisation rotuines run.
+		 */
+		function preInit() {
+			pendingUpdated(true, flags.DOM_READY);
+		}
+
+		/*
+		 * Called after initialisation rotuines run.
+		 */
+		function postInit() {
+			pendingUpdated(false, flags.DOM_READY);
+		}
+
+		/**
+		 * Subscribers will be called any time the global ready state changes.
+		 * They will be passed a boolean, true means ready, false means not ready.
+		 * @param {Function} subscriber
+		 */
+		function subscribe(subscriber) {
+			if (!subscriber) {
+				return;
+			}
+			if (!observer) {
+				observer = new Observer();
+			}
+			return observer.subscribe(subscriber);
+		}
+
+		initialise.register(instance);
+		return instance;
+	});

--- a/wcomponents-theme/src/main/js/wc/a8n.js
+++ b/wcomponents-theme/src/main/js/wc/a8n.js
@@ -1,9 +1,10 @@
 /**
  * This module provides affordances for automated testing tools.
  */
-define(["wc/dom/initialise", "wc/ajax/ajax", "wc/ajax/Trigger", "wc/timers", "wc/Observer"],
-	function(initialise, ajax, Trigger, timers, Observer) {
+define(["wc/dom/initialise", "wc/ajax/ajax", "wc/ajax/Trigger", "wc/timers", "wc/Observer", "wc/dom/storage"],
+	function(initialise, ajax, Trigger, timers, Observer, storage) {
 		var observer,
+			timer,
 			instance = {
 				preInit: preInit,
 				postInit: postInit,
@@ -27,6 +28,7 @@ define(["wc/dom/initialise", "wc/ajax/ajax", "wc/ajax/Trigger", "wc/timers", "wc
 		 */
 		function pendingAjax(pending) {
 			var element = document.body;
+			// console.log("AJAX ", pending);
 			if (element) {
 				// TODO remove this attribute - it is not needed any more now we have data-wc-domready
 				element.setAttribute("data-wc-ajaxp", pending);
@@ -38,6 +40,7 @@ define(["wc/dom/initialise", "wc/ajax/ajax", "wc/ajax/Trigger", "wc/timers", "wc
 		 * Subscriber for pending AJAX requests that will update the DOM.
 		 */
 		function pendingAjaxTrigger(trigger, pending) {
+			// console.log("TRIGGER ", pending);
 			pendingUpdated(pending, flags.AJAX_TRIGGER);
 		}
 
@@ -45,6 +48,7 @@ define(["wc/dom/initialise", "wc/ajax/ajax", "wc/ajax/Trigger", "wc/timers", "wc
 		 * Subscriber for pending timeouts.
 		 */
 		function pendingTimers(pending) {
+			// console.log("TIMER ", pending);
 			var element = document.body;
 			if (element) {
 				// TODO remove this attribute - it is not needed any more now we have data-wc-domready
@@ -57,25 +61,54 @@ define(["wc/dom/initialise", "wc/ajax/ajax", "wc/ajax/Trigger", "wc/timers", "wc
 		 * Called by subscribers when they are notified of a possible change in state.
 		 */
 		function pendingUpdated(pending, flag) {
+			if (timer) {
+				window.clearTimeout(timer);
+			}
+			if (flag !== null) {
+				if (pending) {
+					globalPending |= flag;
+				}
+				else {
+					globalPending &= ~flag;
+				}
+			}
+			checkNotify();
+		}
+
+		function checkNotify() {
 			var attr = "data-wc-domready",
-				currentState, isReady,
+				delay, notify, currentState, isReady,
 				element = document.body;
-			if (pending) {
-				globalPending |= flag;
-			}
-			else {
-				globalPending &= ~flag;
-			}
 			if (element) {
 				isReady = !globalPending;
 				currentState = (element.getAttribute(attr) === "true");
 				if (isReady !== currentState) {
-					element.setAttribute(attr, isReady);
-					if (observer) {
-						observer.notify(isReady);
+					if (timer) {
+						window.clearTimeout(timer);
+					}
+					notify = stateChangeFactory(element, attr);
+					if (!isReady) {  // If the DOM is busy we want to notify ASAP
+						notify();
+					}
+					else {  // If the DOM is ready notify "soon" in case another action is about to start
+						delay = storage.get("wc.a8n.delay") || 501;  // String should be ok without casting...
+						timer = window.setTimeout(notify, delay);
 					}
 				}
 			}
+		}
+
+		/*
+		 * Handle a change of state from ready to busy and vice versa.
+		 */
+		function stateChangeFactory(element, attr) {
+			return function() {
+				var isReady = !globalPending;
+				element.setAttribute(attr, isReady);
+				if (observer) {
+					observer.notify(isReady);
+				}
+			};
 		}
 
 		/*

--- a/wcomponents-theme/src/main/js/wc/ajax/Trigger.js
+++ b/wcomponents-theme/src/main/js/wc/ajax/Trigger.js
@@ -275,15 +275,44 @@ define(["lib/sprintf",
 		/**
 		 * Subscribe to profile information.
 		 * This is for use by testing / monitoring tools and does not form a core part of the functionality of this module.
-		 * The subscriber will be notified when
+		 * The subscriber will be notified when after the response is received.
+		 * The first argument to the subscriber will be information about the trigger. The second will be a boolean, true if there are pending triggers, false if there are none.
 		 * @param {Function} subscriber
+		 * @param {number} [phase] If a negative number is provided the subscriber will be called when a trigger is fired.
 		 */
-		Trigger.subscribe = function (subscriber) {
+		Trigger.subscribe = function (subscriber, phase) {
+			var group = null;
+			if (phase && phase < 0) {
+				group = { group: "before" };
+			}
 			if (!observer) {
 				observer = new Observer();
 			}
-			return observer.subscribe(subscriber);
+			return observer.subscribe(subscriber, group);
 		};
+
+		/**
+		 * Related to the subscribe method above.
+		 * @param {Trigger} trigger The trigger that is firing.
+		 * @param {string} [groupName] The group to notify.
+		 */
+		function notify(trigger, groupName) {
+			var pending;
+			trigger.profile.received = Date.now();
+			if (observer) {
+				pending = !!pendingList.length;
+				if (groupName) {
+					observer.setFilter(groupName);
+				}
+				observer.notify({
+					profile: trigger.profile,
+					id: trigger.id,
+					alias: trigger.alias,
+					loads: trigger.loads,
+					url: trigger.url  // this will probably be null
+				}, pending);
+			}
+		}
 
 		/**
 		 * Find the url this trigger should use when sending ajax requests. This will remove the HASH for browsers with
@@ -722,6 +751,7 @@ define(["lib/sprintf",
 		function handleResponse($self, response, trigger, isError) {
 			var idx, cbresult, done = function() {
 					setLoading($self, true);
+					notify(trigger);
 				};
 			console.log("Got response for trigger", trigger.id);
 			if (!unloading) {
@@ -748,20 +778,10 @@ define(["lib/sprintf",
 						}
 						// Remove "aria-busy" AFTER the new content is loaded to avoid collapsing to zero pixels
 						// The Promise.resolve call allows us to "wait" for callbacks that return a promise.
-						Promise.resolve(cbresult).then(done);
+						Promise.resolve(cbresult).then(done, done);
 					}
 					catch (ex) {
 						console.error(ex);
-					}
-					trigger.profile.received = Date.now();
-					if (observer) {
-						observer.notify({
-							profile: trigger.profile,
-							id: trigger.id,
-							alias: trigger.alias,
-							loads: trigger.loads,
-							url: trigger.url  // this will probably be null
-						});
 					}
 				}
 				finally {
@@ -798,10 +818,12 @@ define(["lib/sprintf",
 						}
 						pendingList.push(this);  // we must do this before sending cos we can't guarantee what AJAX will do (could be forced into synchronous mode)
 						trigger.profile.sent = Date.now();
+						notify(trigger, "before");
 						ajax.simpleRequest(this);
 					}
 					catch (ex) {
 						pendingList.pop();  // error so assume the request is not pending - pop it off the queue
+						notify(trigger);
 						console.error(ex);
 					}
 				}

--- a/wcomponents-theme/src/main/js/wc/ajax/Trigger.js
+++ b/wcomponents-theme/src/main/js/wc/ajax/Trigger.js
@@ -517,6 +517,7 @@ define(["lib/sprintf",
 				request;
 
 			if (trigger.oneShot) {  // will be a negative number if it is not oneshot, therefore will equate to true
+				notify(trigger, "before");
 				promise = new Promise(function(resolve, reject) {
 					trigger.callback = function() {
 						var scope = this, cbresult;
@@ -529,6 +530,7 @@ define(["lib/sprintf",
 						});
 					};
 					trigger.onerror = function() {
+						notify(trigger);
 						if (trigger._onerror) {
 							trigger._onerror.apply(this, arguments);
 						}
@@ -818,7 +820,6 @@ define(["lib/sprintf",
 						}
 						pendingList.push(this);  // we must do this before sending cos we can't guarantee what AJAX will do (could be forced into synchronous mode)
 						trigger.profile.sent = Date.now();
-						notify(trigger, "before");
 						ajax.simpleRequest(this);
 					}
 					catch (ex) {

--- a/wcomponents-theme/src/main/js/wc/ajax/ajax.js
+++ b/wcomponents-theme/src/main/js/wc/ajax/ajax.js
@@ -3,15 +3,15 @@
  *
  * @module
  *
+ * @requires module:wc/Observer
  * @requires module:wc/xml/xmlString
  * @requires module:wc/timers
  * @requires module:wc/has
  *
  * @todo Document private members
  */
-define(["wc/xml/xmlString", "wc/timers", "wc/has", "wc/dom/uid", "require"],
-/** @param xmlString wc/xml/xmlString @param timers wc/timers @param has wc/has @param uid wc/dom/uid @param require require @ignore */
-function(xmlString, timers, has, uid, require) {
+define(["wc/Observer", "wc/xml/xmlString", "wc/timers", "wc/has", "wc/dom/uid", "require"],
+function(Observer, xmlString, timers, has, uid, require) {
 	"use strict";
 	var global = window;
 
@@ -21,7 +21,15 @@ function(xmlString, timers, has, uid, require) {
 	 * @private
 	 */
 	function Ajax() {
-		var xBrowserRequest;
+		var observer, xBrowserRequest;
+
+		this.subscribe = function(subscriber) {
+			if (!observer) {
+				observer = new Observer();
+			}
+			return observer.subscribe(subscriber);
+		};
+
 		/**
 		 * Increments or decrements the pending count. Nothing else should write to the pending variable.
 		 *
@@ -33,7 +41,6 @@ function(xmlString, timers, has, uid, require) {
 		 * @param {boolean} [decrement] If true decrement the count, otherwise will be incremented.
 		 */
 		function updatePending(decrement) {
-			var element = document.body;
 			if (decrement) {
 				if (pending) {
 					pending--;
@@ -45,8 +52,8 @@ function(xmlString, timers, has, uid, require) {
 			else {
 				pending++;
 			}
-			if (element) {
-				element.setAttribute(PENDING_AJAX_FLAG, !!pending);
+			if (observer) {
+				observer.notify(!!pending);
 			}
 		}
 
@@ -498,13 +505,6 @@ function(xmlString, timers, has, uid, require) {
 		};
 	}
 	var getActiveX,
-		/**
-		 * This constant names an attribute which only exists to make life easier for performance testers.
-		 * @constant {String}
-		 * @private
-		 * @ignore
-		 */
-		PENDING_AJAX_FLAG = "data-wc-ajaxp",
 		W3C_IFACE = "XMLHttpRequest",
 		ieXmlHttpEngine,
 		/**

--- a/wcomponents-theme/src/main/xslt/wc.ui.root.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.root.xsl
@@ -60,11 +60,11 @@
 				<xsl:variable name="styleLoaderId" select="concat($scriptId,'-styleloader')"/>
 				<script type="text/javascript" id="{$styleLoaderId}">
 					<xsl:text>require(["wc/compat/compat!"], function() {</xsl:text>
-					<xsl:text>require(["wc/loader/style", "wc/dom/removeElement"</xsl:text>
+					<xsl:text>require(["wc/a8n", "wc/loader/style", "wc/dom/removeElement"</xsl:text>
 					<xsl:if test="$isDebug=1">
 						<xsl:text>,"wc/debug/consoleColor", "wc/debug/indicator"</xsl:text><!-- , "wc/debug/a11y" #533 -->
 					</xsl:if>
-					<xsl:text>], function(s, r){try{s.load();}finally{r("</xsl:text>
+					<xsl:text>], function(a, s, r){try{s.load();}finally{r("</xsl:text>
 					<xsl:value-of select="$styleLoaderId"/>
 					<xsl:text>", 250);}});</xsl:text>
 					<xsl:text>});</xsl:text>
@@ -82,6 +82,9 @@
 				<xsl:call-template name="wcBodyClass"/>
 			</xsl:variable>
 			<body>
+				<xsl:attribute name="data-wc-domready">
+					<xsl:text>false</xsl:text><!-- JS will set this to true - this is for automation testing tools -->
+				</xsl:attribute>
 				<xsl:if test="$bodyClass!=''">
 					<xsl:attribute name="class">
 						<xsl:value-of select="normalize-space($bodyClass)"/>


### PR DESCRIPTION
Simplify "dom ready" checks for automation testing tools and scripts.

Provides both a javascript and pure DOM "hook" to determine if a potential update is pending (i.e. AJAX or timeout pending).

**DOM**
The `body` element has an attribute `data-wc-domready` which will be `false` if the DOM is pending a potential update and `true` when there are no pending updates.

**JS**
The automation module provides a `subscribe` method which can be used to register a function that will be called with a boolean, `true` if the DOM is "ready" or `false` if the DOM is pending a potential update.

Example:

```
require(["wc/a8n"], function(a8n) {
    a8n.subscribe(function(isReady) {
        console.log("isReady:", isReady);
    });
});
```