### PR TITLE
wclock alpha

### DIFF
--- a/wcomponents-theme-parent/pom.xml
+++ b/wcomponents-theme-parent/pom.xml
@@ -24,7 +24,7 @@
 		<npm.download.root>http://registry.npmjs.org/npm/-/</npm.download.root>
 		<!--<node.sass.download.root>https://github.com/sass/node-sass/releases/download</node.sass.download.root>-->
 		<phantomjs.download.root>https://repo1.maven.org/maven2/com/github/klieber/phantomjs/2.0.0</phantomjs.download.root>
-
+		<timezonedata.download.url>ftp://ftp.iana.org/tz/tzdata-latest.tar.gz</timezonedata.download.url>
 		<theme.dir>${basedir}</theme.dir>
 		<theme.default.name>wcomponents-theme</theme.default.name>
 		<theme.unpacked.name>theme_unpacked</theme.unpacked.name>
@@ -169,6 +169,7 @@
 								<property name="build.rootdir" location="${theme.target.dir}" />
 								<property name="theme.skip.tests" value="true" />
 								<property name="maven.plugin.classpath" refid="maven.plugin.classpath" />
+								<property name="timezonedata.download.url" value="${timezonedata.download.url}"/>
 								<ant antfile="${theme.core.dir}/build.xml">
 									<target name="build" />
 								</ant>
@@ -195,6 +196,7 @@
 								<property name="theme.skip.tests" value="${skipOptionalTests}" />
 								<property name="maven.plugin.classpath" refid="maven.plugin.classpath" />
 								<!--<property name="theme.skip.tests" value="${skipOptionalTests}" />-->
+								<property name="timezonedata.download.url" value="${timezonedata.download.url}"/>
 								<ant antfile="${theme.core.dir}/build.xml">
 									<target name="test" />
 								</ant>

--- a/wcomponents-theme/build-js.xml
+++ b/wcomponents-theme/build-js.xml
@@ -57,6 +57,7 @@
 			</fileset>
 		</copy>
 		<copy file="${basedir}/node_modules/sprintf-js/src/sprintf.js" tofile="${lib.tmp.src.dir}/sprintf.js"/>
+		<copy file="${basedir}/node_modules/timezone-js/src/date.js" tofile="${lib.tmp.src.dir}/date.js"/>
 		<copy todir="${lib.tmp.src.dir}/dojo" overwrite="true">
 			<fileset dir="${basedir}/node_modules/dojo">
 				<include name="domReady.js"/>

--- a/wcomponents-theme/build-resource.xml
+++ b/wcomponents-theme/build-resource.xml
@@ -16,7 +16,7 @@
 		The copy of resources is done in two steps so that we can run a filter chain on text-like files and
 		not on binary-like files.
 	-->
-	<target name="build" depends="init" description="Builds resources">
+	<target name="build" depends="init, getTimezoneData" description="Builds resources">
 		<copy todir="${resource.build.target.dir}" overwrite="true" flatten="true">
 			<fileset dir="${resource.rootdir}" includes="*.xml, *.rdf, *.html, *.txt, *.svg" excludesfile="${excludesfile}" />
 			<fileset dir="${impl.resource.rootdir}" includes="*.xml, *.rdf, *.html, *.txt, *.svg" erroronmissingdir="false"/>
@@ -28,6 +28,7 @@
 				<striplinebreaks />
 			</filterchain>
 		</copy>
+
 		<copy todir="${resource.build.target.dir}" overwrite="true" flatten="true">
 			<fileset dir="${resource.rootdir}">
 				<include name="*" />
@@ -43,6 +44,27 @@
 			</fileset>
 		</copy>
 		<echo message="Done building xml" />
+	</target>
+	
+	<target name="getTimezoneData">
+		<mkdir dir="${resource.build.target.dir}/timezone"/>
+		<get src="${timezonedata.download.url}" dest="${tmp.dir}" tryGzipEncoding="true" skipexisting="true"/>
+		<gunzip src="${tmp.dir}/tzdata-latest.tar.gz" dest="${tmp.dir}"/>
+		<untar src="${tmp.dir}/tzdata-latest.tar" dest="${tmp.dir}/timezone/">
+			<!-- Add .txt because of this: https://github.com/BorderTech/wcomponents/issues/540 -->
+			<regexpmapper from="^([^\.]+)$" to="\1.txt"/>
+		</untar>
+		<copy todir="${resource.build.target.dir}/timezone" overwrite="true">
+			<fileset dir="${tmp.dir}/timezone" includes="*"/>
+			<filterchain>
+				<striplinecomments>
+					<comment value="#"/>
+				</striplinecomments>
+				<tokenfilter>
+					<ignoreblank/> 
+				</tokenfilter>
+			</filterchain>
+		</copy>
 	</target>
 
 	<target name="clean" description="Cleans up all artifacts produced by this build">

--- a/wcomponents-theme/build.xml
+++ b/wcomponents-theme/build.xml
@@ -448,6 +448,7 @@ chromedriver_cdnurl=${mirror.root}/chromedriver
 				<property name="npmjs.dir" location="${npmjs.dir}"/>
 				<property name="npm.registry.url" value="${npm.registry.url}"/>
 				<property name="phantomjs.binary" value="${phantomjs.binary}"/>
+				<property name="timezonedata.download.url" value="${timezonedata.download.url}"/>
 			</ant>
 			<stopwatch name="@{antFile}" action="total"/>
 		</sequential>

--- a/wcomponents-theme/src/main/js/wc/date/Format.js
+++ b/wcomponents-theme/src/main/js/wc/date/Format.js
@@ -7,7 +7,7 @@ define(["wc/date/interchange", "wc/date/monthName"],
 	/** @param interchange wc/date/interchange @param monthName wc/date/monthName @ignore */
 	function(interchange, monthName) {
 		"use strict";
-		var FORMAT_RE = /y{2,4}|d+|MON|M{2,4}/g,
+		var FORMAT_RE = /y{2,4}|d+|MON|M{2,4}|H+|m+|h+|a+/g,
 			NORMALIZE_WHITESPACE_RE = /\s{2,}/g;
 
 		/**
@@ -92,7 +92,23 @@ define(["wc/date/interchange", "wc/date/monthName"],
 					case "yy":
 						result = date.year ? date.year.substr(2) : null;
 						break;
-					case "yyyy": result = date.year;
+					case "yyyy":
+						result = date.year;
+						break;
+					case "HH":
+						result = getHour(date, false, false);
+						break;
+					case "h":
+						result = getHour(date, true, false);
+						break;
+					case "hh":
+						result = getHour(date, true, true);
+						break;
+					case "mm":
+						result = date.minute;
+						break;
+					case "a":
+						result = (date.hour || date.hour === 0) ? (date.hour < 12 ? "AM" : "PM") : "";
 						break;
 					default:
 						failFlag = true;
@@ -109,6 +125,27 @@ define(["wc/date/interchange", "wc/date/monthName"],
 			}
 			return result;
 		};
+
+		function getHour(date, twelve, pad) {
+			var result = date.hour;
+			if (result && (twelve || pad)) {
+				result *= 1;
+				if (result || result === 0) {
+					if (twelve) {
+						if (result > 12) {
+							result -= 12;
+						}
+						else if (result === 0) {
+							result = 12;
+						}
+					}
+					if (pad && result < 10) {
+						result = "0" + result;
+					}
+				}
+			}
+			return result;
+		}
 
 		return Format;
 	});

--- a/wcomponents-theme/src/main/js/wc/loader/resource.js
+++ b/wcomponents-theme/src/main/js/wc/loader/resource.js
@@ -55,7 +55,7 @@ define(["wc/ajax/ajax", "wc/loader/prefetch", "wc/config", "module"],
 			 * @returns {string} The URL to the resource.
 			 */
 			this.getResourceUrl = function(fileName) {
-				var path, idx, cachebuster, config = getConfig();
+				var url, path, idx, cachebuster, config = getConfig();
 				if (config) {
 					path = config.resourceBaseUrl;
 					cachebuster = config.cachebuster;
@@ -67,7 +67,12 @@ define(["wc/ajax/ajax", "wc/loader/prefetch", "wc/config", "module"],
 				}
 
 				baseUrl = baseUrl || path || "";  // ${resource.target.dir.name}/";
-				var url = baseUrl + fileName + "?" + cachebuster;
+				if (fileName) {
+					url = baseUrl + fileName + "?" + cachebuster;
+				}
+				else {
+					url = baseUrl;
+				}
 				return url;
 			};
 

--- a/wcomponents-theme/src/main/js/wc/ui/clock.js
+++ b/wcomponents-theme/src/main/js/wc/ui/clock.js
@@ -1,0 +1,92 @@
+/**
+ * Experimental clock widget
+ */
+define(["lib/date", "wc/ajax/ajax", "wc/loader/resource", "wc/dom/textContent", "wc/timers", "wc/config",
+	"wc/date/Format", "wc/date/interchange"],
+	function(date, ajax, resource, textContent, timers, wcconfig, Format, interchange) {
+		var defaultFormat = new Format("dd MMM yyyy, hh:mm a"),
+			instance = new Clock(),
+			config = wcconfig.get("wc/ui/clock");
+
+		date.timezone.zoneFileBasePath = resource.getResourceUrl() + "timezone";
+		if (config && config.defaultZone) {
+			date.timezone.defaultZoneFile = config.defaultZone;
+		}
+		else {
+			date.timezone.defaultZoneFile = ["australasia"];
+		}
+
+		date.timezone.transport = function(request) {
+			var url = request.url;
+			if (/\/[^\.]+$/.test(url)) {
+				request.url += ".txt";
+			}
+			request.cache = true;
+			request.responseType = ajax.responseType.TEXT;
+			request.onError = request.error;
+			request.callback = request.success;
+			ajax.simpleRequest(request);
+		};
+
+		function startTicking(config) {
+			var formatter = config.format || format,
+				start = config.start || Date.now(),
+				result = {
+					date: new date.Date(start, config.timezone),
+					timer: null
+				};
+			tick();
+			function tick() {
+				var nextTick, dateString, element = document.getElementById(config.id);
+				if (element) {
+					dateString = formatter(result.date);
+					textContent.set(element, dateString);
+				}
+				nextTick = 60 - result.date.getSeconds();
+				nextTick *= 1000;
+				result.date.setTime(result.date.getTime() + nextTick);
+				result.timer = timers.setTimeout(tick, nextTick);
+			}
+			return result;
+		}
+
+		function processClocks(clocks) {
+			var i, next, len = clocks.length;
+			for (i = 0; i < len; i++) {
+				next = clocks[i];
+				startTicking(next);
+			}
+		}
+
+		/**
+		 * Formats the date object into a human readable string.
+		 * @param {Date} date The date to format.
+		 * @returns {string} The formatted date.
+		 */
+		function format(date) {
+			var parsed = interchange.fromDate(date, true),
+				result = defaultFormat.format(parsed);
+			return result;
+		}
+
+		/**
+		 *
+		 * @constructor
+		 */
+		function Clock() {
+			var inited = false;
+
+			this.register = function(clocks) {
+				if (!inited) {
+					date.timezone.init({ callback: function() {
+						inited = true;
+						processClocks(clocks);
+					}});
+				}
+				else {
+					processClocks(clocks);
+				}
+			};
+		}
+		return instance;
+	});

--- a/wcomponents-theme/src/test/intern/wc.date.Format.test.js
+++ b/wcomponents-theme/src/test/intern/wc.date.Format.test.js
@@ -73,6 +73,62 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils!"],
 					expected = "9",
 					actual = formatter.format(date);
 				assert.strictEqual(expected, actual);
+			},
+			testFormatTime: function () {
+				var mask = "dd/MM/yyyy HH:mm",
+					formatter = new Format(mask),
+					date = "2000-02-03T00:02",
+					expected = "03/02/2000 00:02",
+					actual = formatter.format(date);
+				assert.strictEqual(expected, actual);
+			},
+			testFormatTime12HrAM: function () {
+				var mask = "dd/MM/yyyy hh:mm",
+					formatter = new Format(mask),
+					date = "2000-02-03T00:02",
+					expected = "03/02/2000 12:02",
+					actual = formatter.format(date);
+				assert.strictEqual(expected, actual);
+			},
+			testFormatTime12HrPM: function () {
+				var mask = "dd/MM/yyyy hh:mm",
+					formatter = new Format(mask),
+					date = "2000-02-03T23:59",
+					expected = "03/02/2000 11:59",
+					actual = formatter.format(date);
+				assert.strictEqual(expected, actual);
+			},
+			testFormatTime12HrShort: function () {
+				var mask = "dd/MM/yyyy h:mm",
+					formatter = new Format(mask),
+					date = "2000-02-03T01:02",
+					expected = "03/02/2000 1:02",
+					actual = formatter.format(date);
+				assert.strictEqual(expected, actual);
+			},
+			testFormatTime12HrLong: function () {
+				var mask = "dd/MM/yyyy hh:mm",
+					formatter = new Format(mask),
+					date = "2000-02-03T01:02",
+					expected = "03/02/2000 01:02",
+					actual = formatter.format(date);
+				assert.strictEqual(expected, actual);
+			},
+			testFormatTime12HrAAAM: function () {
+				var mask = "dd/MM/yyyy hh:mm a",
+					formatter = new Format(mask),
+					date = "2000-02-03T00:02",
+					expected = "03/02/2000 12:02 AM",
+					actual = formatter.format(date);
+				assert.strictEqual(expected, actual);
+			},
+			testFormatTime12HrAAPM: function () {
+				var mask = "dd/MM/yyyy hh:mm a",
+					formatter = new Format(mask),
+					date = "2000-02-03T12:00",
+					expected = "03/02/2000 12:00 PM",
+					actual = formatter.format(date);
+				assert.strictEqual(expected, actual);
 			}
 		});
 	}

--- a/wcomponents-theme/unbuilt.package.json
+++ b/wcomponents-theme/unbuilt.package.json
@@ -21,6 +21,7 @@
 		"requirejs": "~2.2.0",
 		"sprintf-js": "~1.0.3",
 		"systemjs": "~0.19.22",
+		"timezone-js": "~0.4.13",
 		"tinymce": "~4.2.5",
 		"tracking": "~1.1.2"
 	}


### PR DESCRIPTION
Experimental `WClock` client side only (and therefore never used) for now.

For in-house builds (behind firewall) requires two new cloud dependencies:

1. `timezonedata.download.url` should point to a URI where the archive (ftp://ftp.iana.org/tz/tzdata-latest.tar.gz) is located.
2. Add [timezone-js](https://www.npmjs.com/package/timezone-js) to on-prem NPM repository.

Able to display world clocks:
* taking into account daylight savings dates
* independent of client system time.
