### PR TITLE
Mandatory field indicators

### DIFF
--- a/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.scss
@@ -9,22 +9,19 @@ ul.wc-fieldlayout {
 }
 //scss-lint:enable QualifyingElement
 
-.wc-field {
-	// > .wc-label {
-	// 	@include fit-content; // allows for better position of mandatory indicator.
-	// }
-
-	.wc_fld_pl { //this is the placeholder for a null or moved label (moved for checkbox or radio). Remove on narrow viewports.
-		display: none;
-	}
-
-	+ .wc-field {
-		margin-top: $vgap-normal;
-	}
+// This is the placeholder for a null or moved label (moved for checkbox or radio). Not shown on narrow viewports.
+.wc_fld_pl {
+	display: none;
 }
 
+// Verticl space between fields in a WFieldLayout.
+.wc-field  + .wc-field {
+	margin-top: $vgap-normal;
+}
+
+// The input container div.
 .wc-input {
-	margin-top: $vgap-small;
+	margin-top: $vgap-small; // push off of the label.
 
 	// InputWidth class is added to the field to signify that an inputWidth is in use so we can size the components.
 	.wc_inputwidth > & {
@@ -62,18 +59,15 @@ ul.wc-fieldlayout {
 			display: inline-block;
 			vertical-align: text-top;
 
-			&:first-child { //the first child is the label or stand-in or merely an empty placeholder/spacer
+			&:first-child { //The first child is the label or stand-in or merely an empty placeholder/spacer.
 				width: $label-width;
 			}
 		}
 
 		> .wc-input {
+			margin-top: 0; // Remove stacked margin.
 			max-width: $input-width;
 			width: $input-width;
-		}
-
-		.wc-input { // reset
-			margin-top: 0;
 		}
 	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fieldLayout.scss
@@ -10,10 +10,9 @@ ul.wc-fieldlayout {
 //scss-lint:enable QualifyingElement
 
 .wc-field {
-	> label,
-	> span {
-		display: block;
-	}
+	// > .wc-label {
+	// 	@include fit-content; // allows for better position of mandatory indicator.
+	// }
 
 	.wc_fld_pl { //this is the placeholder for a null or moved label (moved for checkbox or radio). Remove on narrow viewports.
 		display: none;

--- a/wcomponents-theme/src/main/sass/wc.ui.label.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.label.scss
@@ -6,12 +6,6 @@
 	@include label-hint;
 }
 
-// use inline-block on a label-dummy to prevent a required marker flying off the end
-//scss-lint:disable QualifyingElement
-span.wc-label {
-	display: inline-block;
-}
-
 // space between a checkable and its label
 [type='radio'] + label,
 [type='checkbox'] + label,
@@ -19,36 +13,36 @@ span.wc-label {
 	margin-left: $hgap-small;
 }
 
-// required markers
-.wc_req {
-	[type='radio'] + &:before,
-	[type='checkbox'] + &:before {
-		margin-right: $hgap-small;
-	}
-
-	[type='radio'] + &:after,
-	[type='checkbox'] + &:after {
-		display: none;
-	}
-}
-
-label.wc_req:after,
-.label.wc_req:after,
-input[type='radio'] +.wc_req:before,
-input[type='checkbox'] + .wc_req:before {
-	@include mandatory-indicator;
-}
-
+// use inline-block to prevent a required marker flying off the end
 .wc-label {
+	display: inline-block;
+
 	&.wc_req {
 		@include border-box;
+		@include fit-content; // allows for better position of mandatory indicator.
 		padding-right: 1em;
 		position: relative;
+
+		&:after,
+		input[type='checkbox'] + &:before,
+		input[type='radio'] + &:before {
+			@include mandatory-indicator;
+		}
 
 		&:after {
 			position: absolute;
 			right: $hgap-small;
 			top: 0;
+		}
+
+		[type='radio'] + &:before,
+		[type='checkbox'] + &:before {
+			margin-right: $hgap-small;
+		}
+
+		[type='radio'] + &:after,
+		[type='checkbox'] + &:after {
+			display: none;
 		}
 	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.legend.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.legend.scss
@@ -13,9 +13,6 @@ legend {
 	.wc_req > &:before {
 		@include mandatory-indicator;
 		float: right;
-	}
-
-	.wc_req.wc_notext > &:before {
-		content: '';
+		width: 0; // allow for wrapping legends.
 	}
 }


### PR DESCRIPTION
Re-instated mandatory field indicators on label-stand-in spans used in WFieldLayout for compound controls.

Fixes #549