### PR TITLE
PhantomJS support and some build script tweaks.

### DIFF
--- a/wcomponents-theme-parent/pom.xml
+++ b/wcomponents-theme-parent/pom.xml
@@ -24,7 +24,6 @@
 		<npm.download.root>http://registry.npmjs.org/npm/-/</npm.download.root>
 		<!--<node.sass.download.root>https://github.com/sass/node-sass/releases/download</node.sass.download.root>-->
 		<phantomjs.download.root>https://repo1.maven.org/maven2/com/github/klieber/phantomjs/2.0.0</phantomjs.download.root>
-		<timezonedata.download.url>ftp://ftp.iana.org/tz/tzdata-latest.tar.gz</timezonedata.download.url>
 		<theme.dir>${basedir}</theme.dir>
 		<theme.default.name>wcomponents-theme</theme.default.name>
 		<theme.unpacked.name>theme_unpacked</theme.unpacked.name>
@@ -42,6 +41,8 @@
 		<wc.project.version>${project.version}</wc.project.version><!-- Child projects should override this to the version of WComponents they use -->
 		<xsltjson.download.url>https://github.com/bramstein/xsltjson/archive/master.zip</xsltjson.download.url>
 		<xsltjson.dir>${project.build.directory}/xsltjson</xsltjson.dir><!-- Convert XML to JSON at build time -->
+		<timezonedata.download.url>http://www.iana.org/time-zones/repository/tzdata-latest.tar.gz</timezonedata.download.url>
+		<timezone.dir>${project.build.directory}/timezone</timezone.dir><!-- Fetch Timezone Database -->
 	</properties>
 
 	<build>
@@ -142,10 +143,23 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<skip>${mobile.skip.executions}</skip>
+							<skip>${theme.skip.antrun}</skip>
 							<url>${xsltjson.download.url}</url>
 							<unpack>false</unpack>
 							<outputDirectory>${xsltjson.dir}</outputDirectory>
+						</configuration>
+					</execution>
+					<execution>
+						<id>fetch-timezonedb</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>wget</goal>
+						</goals>
+						<configuration>
+							<skip>${theme.skip.antrun}</skip>
+							<url>${timezonedata.download.url}</url>
+							<unpack>true</unpack>
+							<outputDirectory>${timezone.dir}</outputDirectory>
 						</configuration>
 					</execution>
 				</executions>
@@ -169,7 +183,6 @@
 								<property name="build.rootdir" location="${theme.target.dir}" />
 								<property name="theme.skip.tests" value="true" />
 								<property name="maven.plugin.classpath" refid="maven.plugin.classpath" />
-								<property name="timezonedata.download.url" value="${timezonedata.download.url}" />
 								<ant antfile="${theme.core.dir}/build.xml">
 									<target name="build" />
 								</ant>
@@ -196,7 +209,6 @@
 								<property name="theme.skip.tests" value="${skipOptionalTests}" />
 								<property name="maven.plugin.classpath" refid="maven.plugin.classpath" />
 								<!--<property name="theme.skip.tests" value="${skipOptionalTests}" />-->
-								<property name="timezonedata.download.url" value="${timezonedata.download.url}" />
 								<ant antfile="${theme.core.dir}/build.xml">
 									<target name="test" />
 								</ant>

--- a/wcomponents-theme/build-js.xml
+++ b/wcomponents-theme/build-js.xml
@@ -57,7 +57,7 @@
 			</fileset>
 		</copy>
 		<copy file="${basedir}/node_modules/sprintf-js/src/sprintf.js" tofile="${lib.tmp.src.dir}/sprintf.js"/>
-<!--		<copy file="${basedir}/node_modules/timezone-js/src/date.js" tofile="${lib.tmp.src.dir}/date.js"/>-->
+		<copy file="${basedir}/node_modules/timezone-js/src/date.js" tofile="${lib.tmp.src.dir}/date.js"/>
 		<copy todir="${lib.tmp.src.dir}/dojo" overwrite="true">
 			<fileset dir="${basedir}/node_modules/dojo">
 				<include name="domReady.js"/>

--- a/wcomponents-theme/build-resource.xml
+++ b/wcomponents-theme/build-resource.xml
@@ -16,7 +16,7 @@
 		The copy of resources is done in two steps so that we can run a filter chain on text-like files and
 		not on binary-like files.
 	-->
-	<target name="build" depends="init" description="Builds resources">
+	<target name="build" depends="init, getTimezoneData" description="Builds resources">
 		<copy todir="${resource.build.target.dir}" overwrite="true" flatten="true">
 			<fileset dir="${resource.rootdir}" includes="*.xml, *.rdf, *.html, *.txt, *.svg" excludesfile="${excludesfile}" />
 			<fileset dir="${impl.resource.rootdir}" includes="*.xml, *.rdf, *.html, *.txt, *.svg" erroronmissingdir="false"/>
@@ -46,16 +46,24 @@
 		<echo message="Done building xml" />
 	</target>
 
+	<!--
+		This target makes the IANA timezone database available to code which may need it.
+
+		For example this may be used to determine the local time in a particular political
+		region at a specific point in time.
+	-->
 	<target name="getTimezoneData">
+		<property name="timezone.dir" location="${build.rootdir}/timezone"/>
 		<mkdir dir="${resource.build.target.dir}/timezone"/>
-		<get src="${timezonedata.download.url}" dest="${tmp.dir}" tryGzipEncoding="true" skipexisting="true"/>
-		<gunzip src="${tmp.dir}/tzdata-latest.tar.gz" dest="${tmp.dir}"/>
-		<untar src="${tmp.dir}/tzdata-latest.tar" dest="${tmp.dir}/timezone/">
-			<!-- Add .txt because of this: https://github.com/BorderTech/wcomponents/issues/540 -->
+		<!--
+		<gunzip src="${timezone.dir}/tzdata-latest.tar.gz" dest="${timezone.dir}"/>
+		<untar src="${timezone.dir}/tzdata-latest.tar" dest="${timezone.dir}/unzipped/">
+			 Add .txt because of this: https://github.com/BorderTech/wcomponents/issues/540 
 			<regexpmapper from="^([^\.]+)$" to="\1.txt"/>
 		</untar>
+		-->
 		<copy todir="${resource.build.target.dir}/timezone" overwrite="true">
-			<fileset dir="${tmp.dir}/timezone" includes="*"/>
+			<fileset dir="${timezone.dir}" includes="*"/>
 			<filterchain>
 				<striplinecomments>
 					<comment value="#"/>

--- a/wcomponents-theme/build.xml
+++ b/wcomponents-theme/build.xml
@@ -448,7 +448,6 @@ chromedriver_cdnurl=${mirror.root}/chromedriver
 				<property name="npmjs.dir" location="${npmjs.dir}"/>
 				<property name="npm.registry.url" value="${npm.registry.url}"/>
 				<property name="phantomjs.binary" value="${phantomjs.binary}"/>
-				<property name="timezonedata.download.url" value="${timezonedata.download.url}"/>
 			</ant>
 			<stopwatch name="@{antFile}" action="total"/>
 		</sequential>

--- a/wcomponents-theme/src/main/js/wc/ui/clock.js
+++ b/wcomponents-theme/src/main/js/wc/ui/clock.js
@@ -18,9 +18,9 @@ define(["lib/date", "wc/ajax/ajax", "wc/loader/resource", "wc/dom/textContent", 
 
 		date.timezone.transport = function(request) {
 			var url = request.url;
-			if (/\/[^\.]+$/.test(url)) {
-				request.url += ".txt";
-			}
+//			if (/\/[^\.]+$/.test(url)) {
+//				request.url += ".txt";
+//			}
 			request.cache = true;
 			request.responseType = ajax.responseType.TEXT;
 			request.onError = request.error;

--- a/wcomponents-theme/src/main/sass/_mixins-flex.scss
+++ b/wcomponents-theme/src/main/sass/_mixins-flex.scss
@@ -12,6 +12,7 @@
 /// @param {align-items} $align-items [stretch] The item alignment model to apply.
 /// @param {align-content} $align-content [stretch] The item content alignment model to set.
 @mixin flex($direction: row, $wrap: nowrap, $justify: flex-start, $align-items: stretch, $align-content: stretch) {
+	display: block;  // See issue #561
 	display: -webkit-flex;
 	-webkit-flex-direction: $direction;
 	-webkit-flex-wrap: $wrap;

--- a/wcomponents-theme/unbuilt.package.json
+++ b/wcomponents-theme/unbuilt.package.json
@@ -21,6 +21,7 @@
 		"requirejs": "~2.2.0",
 		"sprintf-js": "~1.0.3",
 		"systemjs": "~0.19.22",
+		"timezone-js": "~0.4.13",
 		"tinymce": "~4.2.5",
 		"tracking": "~1.1.2"
 	}


### PR DESCRIPTION
Closes #561.

Reworked the fetching of the IANA timezone DB so it is far more robust - no idea why I previously used the Ant `get` task, weird brain spasm. Now also uses HTTP URL.

Fixes a long standing and largely asymptomatic build issue which caused some resources to be downloaded and placed on the filesystem multiple times (i.e. in the build of theme-parent module).
