### PR TITLE
minor javadoc issue and intellij gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,53 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries
+.idea/vcs.xml
+.idea/jsLibraryMappings.xml
+
+# Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+
+# Gradle:
+.idea/gradle.xml
+.idea/libraries
+
+# Mongo Explorer plugin:
+.idea/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+*.iml
+.idea/
 
 ### Emacs - created by https://www.gitignore.io/api/emacs ###
 # -*- mode: gitignore; -*-

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/layout/BorderLayout.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/layout/BorderLayout.java
@@ -6,7 +6,7 @@ package com.github.bordertech.wcomponents.layout;
  * @author Yiannis Paschalidis
  * @since 1.0.0
  * @deprecated WComponents 1.1.4. Use {@link com.github.bordertech.wcomponents.WRow} and
- * {@link com.github.bordertech.wcomponents.WColumn} or {@linl com.github.bordertech.wcomponents.ColumnLayout} instead.
+ * {@link com.github.bordertech.wcomponents.WColumn} or {@link com.github.bordertech.wcomponents.ColumnLayout} instead.
  * It is preferred that an application use {@link com.github.bordertech.wcomponents.WTemplate} for layout as this
  * provides for lighter payloads and more responsive UIs.
  */


### PR DESCRIPTION
While the IDE specific gitignore should be in each user's global gitignore I think it makes sense to add usual suspects to the project specific file. IntelliJ is definitely picking up in our circles, so worth adding.

The Javadoc fix helps when doclint is on.
