### PR TITLE
Textarea subordinate

### DIFF
--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/subordinate/SubordinateControlOptionsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/subordinate/SubordinateControlOptionsExample.java
@@ -746,6 +746,7 @@ public class SubordinateControlOptionsExample extends WContainer {
 
 			case TextArea:
 				trigger = new WTextArea();
+				((WTextArea) trigger).setMaxLength(1000);
 				break;
 
 			case TextField:

--- a/wcomponents-theme/src/main/js/wc/ui/subordinate.js
+++ b/wcomponents-theme/src/main/js/wc/ui/subordinate.js
@@ -208,7 +208,9 @@ define(["wc/dom/tag",
 					element = getElement(id),
 					selectedItems;
 				if (element && !shed.isDisabled(element)) {
-					selectedItems = getSelectedOptions(element);
+					if (shed.isSelectable(element)) {
+						selectedItems = getSelectedOptions(element);
+					}
 					if (selectedItems) {
 						if (selectedItems.length > 0) {
 							result = testElementValue(selectedItems, testValue, operator);


### PR DESCRIPTION
Subordinate controls should only get group if they are selectable.
Fixes #590.