### PR TITLE
XSLT CSS Bugs

### DIFF
--- a/wcomponents-theme/src/main/xslt/wc.ui.fieldLayout.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.fieldLayout.xsl
@@ -26,12 +26,23 @@
 					</xsl:if>
 				</xsl:with-param>
 			</xsl:call-template>
-			<xsl:if test="@ordered and @ordered != 1">
-				<xsl:attribute name="style">
-					<xsl:value-of select="concat('counter-reset: wcfld ', @ordered - 1)"/>
-				</xsl:attribute>
-			</xsl:if>
-			<xsl:apply-templates select="ui:margin"/>
+			<xsl:variable name="style">
+				<xsl:if test="@ordered and @ordered != 1">
+					<xsl:value-of select="concat('counter-reset: wcfld ', @ordered - 1, ';')"/>
+				</xsl:if>
+			</xsl:variable>
+			<xsl:choose>
+				<xsl:when test="ui:margin">
+					<xsl:apply-templates select="ui:margin">
+						<xsl:with-param name="style" select="$style"/>
+					</xsl:apply-templates>
+				</xsl:when>
+				<xsl:when test="$style != ''">
+					<xsl:attribute name="style">
+						<xsl:value-of select="$style"/>
+					</xsl:attribute>
+				</xsl:when>
+			</xsl:choose>
 			<xsl:apply-templates select="ui:field"/>
 		</div>
 	</xsl:template>

--- a/wcomponents-theme/src/main/xslt/wc.ui.flowLayout.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.flowLayout.xsl
@@ -27,10 +27,16 @@
 				<xsl:if test="@valign">
 					<xsl:value-of select="concat('  wc_fl_', @valign)"/>
 				</xsl:if>
-				<xsl:call-template name="getHVGapClass"/>
-				<xsl:call-template name="getHVGapClass">
-					<xsl:with-param name="isVGap" select="1"/>
-				</xsl:call-template>
+				<xsl:choose>
+					<xsl:when test="@align='vertical'">
+						<xsl:call-template name="getHVGapClass">
+							<xsl:with-param name="isVGap" select="1"/>
+						</xsl:call-template>
+					</xsl:when>
+					<xsl:otherwise>
+						<xsl:call-template name="getHVGapClass"/>
+					</xsl:otherwise>
+				</xsl:choose>
 			</xsl:attribute>
 			<xsl:apply-templates select="ui:cell[node()]" mode="fl"/>
 		</div>


### PR DESCRIPTION
* Fixed WFieldLayout XSLT to ensure offset is honoured when there is a
Margin. Fixes #634
* Fixed FlowLayout XSLT to output the correct `@hgap`/`@vgap` only when
required by `@align`. Fixes #635