### PR TITLE
ListLayout and column inline styles (#655, #656)

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WList.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WList.java
@@ -52,13 +52,9 @@ public class WList extends WRepeater implements Marginable {
 	}
 
 	/**
-	 * The horizontal gap between the list items, measured in pixels.
+	 * The gap between the components in the list.
 	 */
-	private final int hgap;
-	/**
-	 * The vertical gap between the list items, measured in pixels.
-	 */
-	private final int vgap;
+	private final int gap;
 
 	/**
 	 * Creates a WList of the given type.
@@ -66,20 +62,30 @@ public class WList extends WRepeater implements Marginable {
 	 * @param type the list type.
 	 */
 	public WList(final Type type) {
-		this(type, 0, 0);
+		this(type, 0);
 	}
 
 	/**
 	 * Creates a WList of the given type.
 	 *
 	 * @param type the list type.
-	 * @param hgap the horizontal gap between the list items, measured in pixels.
-	 * @param vgap the vertical gap between the list items, measured in pixels.
+	 * @param hgap the horizontal gap between the list items, used only if type is Type.FLAT
+	 * @param vgap the vertical gap between the list items,  used only if type is not Type.FLAT
+	 * @deprecated use {@link #WList(Type, int)
 	 */
 	public WList(final Type type, final int hgap, final int vgap) {
+		this(type, type == Type.FLAT ? hgap : vgap);
+	}
+
+	/**
+	 * Creates a WList of the given type with the specified gap between items.
+	 *
+	 * @param type the list type.
+	 * @param gap the gap between the list items
+	 */
+	public WList(final Type type, final int gap) {
 		getComponentModel().type = type;
-		this.hgap = hgap;
-		this.vgap = vgap;
+		this.gap = gap;
 	}
 
 	/**
@@ -149,17 +155,32 @@ public class WList extends WRepeater implements Marginable {
 	}
 
 	/**
-	 * @return Returns the horizontal gap between the cells, measured in pixels.
+	 * @return Returns the horizontal gap between the cells.
+	 * @deprecated use {@link getGap()}
 	 */
 	public int getHgap() {
-		return hgap;
+		if (getType() == Type.FLAT) {
+			return gap;
+		}
+		return 0;
 	}
 
 	/**
-	 * @return Returns the vertical gap between the cells, measured in pixels.
+	 * @return Returns the vertical gap between the cells.
+	 * @deprecated use {@link getGap()}
 	 */
 	public int getVgap() {
-		return vgap;
+		if (getType() == Type.FLAT) {
+			return 0;
+		}
+		return gap;
+	}
+
+	/**
+	 * @return the gap between items in the List.
+	 */
+	public int getGap() {
+		return gap;
 	}
 
 	/**
@@ -201,7 +222,7 @@ public class WList extends WRepeater implements Marginable {
 		private boolean renderBorder;
 
 		/**
-		 * The seperator used to separate items in the list.
+		 * The separator used to separate items in the list.
 		 */
 		private Separator separator;
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/layout/ListLayout.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/layout/ListLayout.java
@@ -3,13 +3,14 @@ package com.github.bordertech.wcomponents.layout;
 /**
  * ListLayout renders out its items in a list.
  *
- * @author Yiannis Paschalidis
+ * @author Yiannis Paschalidis, Mark Reeves
  * @since 1.0.0
  */
 public class ListLayout implements LayoutManager {
 
 	/**
-	 * An enumeration of possible values for horizontal alignment of column content.
+	 * An enumeration of possible values for horizontal alignment of the components added to the layout relative to the
+	 * containing WPanel.
 	 */
 	public enum Alignment {
 		/**
@@ -17,7 +18,7 @@ public class ListLayout implements LayoutManager {
 		 */
 		LEFT,
 		/**
-		 * Indicates that content should be horizontally centered in the column.
+		 * Indicates that content should be horizontally centered in the WPanel.
 		 */
 		CENTER,
 		/**
@@ -45,7 +46,8 @@ public class ListLayout implements LayoutManager {
 	}
 
 	/**
-	 * An enumeration of possible values for the item separator.
+	 * An enumeration of possible values for the item separator. When the ListLayout is ordered the separator is the
+	 * default ordering separator unless specifically set to Separator.NONE.
 	 */
 	public enum Separator {
 		/**
@@ -53,11 +55,11 @@ public class ListLayout implements LayoutManager {
 		 */
 		NONE,
 		/**
-		 * Indicates that the separator should be a bar (vertical line).
+		 * Indicates that the separator should be a bar (vertical line). Not used when the ListLayout is ordered.
 		 */
 		BAR,
 		/**
-		 * Indicates that the separator should be a dot.
+		 * Indicates that the separator should be a dot. Not used when the ListLayout is ordered.
 		 */
 		DOT
 	}
@@ -83,26 +85,44 @@ public class ListLayout implements LayoutManager {
 	private final boolean ordered;
 
 	/**
-	 * The horizontal gap between the list items, measured in pixels.
+	 * The gap between the components added to the layout.
 	 */
-	private final int hgap;
+	private final int gap;
 
 	/**
-	 * The vertical gap between the list items, measured in pixels.
+	 * Default constructor creates an unordered, LEFT aligned, DOT separated, STACKED list - i.e. a pretty much default
+	 * HTML list.
 	 */
-	private final int vgap;
+	public ListLayout() {
+		this(Type.STACKED, Alignment.LEFT, Separator.DOT, false, 0);
+	}
 
 	/**
-	 * Creates a ListLayout with the specified attributes.
-	 *
-	 * @param type the list type.
-	 * @param alignment the item alignment.
-	 * @param separator the separator to display between items.
-	 * @param ordered whether the list is an ordered list.
+	 * Creates a ListLayout with a specified type. The ListLayout will be unordered, leftAligned, and DOT separated.
+	 * @param type The type of list to create.
 	 */
-	public ListLayout(final Type type, final Alignment alignment, final Separator separator,
-			final boolean ordered) {
-		this(type, alignment, separator, ordered, 0, 0);
+	public ListLayout(final Type type) {
+		this(type, Alignment.LEFT, Separator.DOT, false, 0);
+	}
+
+	/**
+	 * Creates a stacked ListLayout with a specified ordered setting. The ListLayout will be stacked, left aligned, and
+	 * DOT separated (if not ordered) or numbered (if ordered).
+	 * @param ordered true to create an ordered list.
+	 */
+	public ListLayout(final boolean ordered) {
+		this(Type.STACKED, Alignment.LEFT, Separator.DOT, ordered, 0);
+	}
+
+
+
+	/**
+	 * Creates a ListLayout with a specified type. The ListLayout will be unordered, leftAligned, and DOT separated.
+	 * @param type he type of list to create
+	 * @param alignment the alignment of the list relative to its containing WPanel.
+	 */
+	public ListLayout(final Type type, final Alignment alignment) {
+		this(type, alignment, Separator.DOT, false, 0);
 	}
 
 	/**
@@ -112,17 +132,47 @@ public class ListLayout implements LayoutManager {
 	 * @param alignment the item alignment.
 	 * @param separator the separator to display between items.
 	 * @param ordered whether the list is an ordered list.
-	 * @param hgap the horizontal gap between the list items, measured in pixels.
-	 * @param vgap the vertical gap between the list items, measured in pixels.
+	 */
+	public ListLayout(final Type type, final Alignment alignment, final Separator separator, final boolean ordered) {
+		this(type, alignment, separator, ordered, 0);
+	}
+
+	/**
+	 * Creates a ListLayout with the specified attributes.
+	 *
+	 * @param type the list type.
+	 * @param alignment the item alignment.
+	 * @param separator the separator to display between items.
+	 * @param ordered whether the list is an ordered list.
+	 * @param hgap The horizontal gap between the list items, measured in pixels. Used only when type is Type.FLAT.
+	 * @param vgap The vertical gap between the list items, measured in pixels. Used only when type is not Type.FLAT.
+	 *
+	 * @deprecated use {@link #ListLayout(Type, Alignment, Separator, boolean, int)}
 	 */
 	public ListLayout(final Type type, final Alignment alignment, final Separator separator,
 			final boolean ordered, final int hgap, final int vgap) {
+		this(type, alignment, separator, ordered, type == Type.FLAT ? hgap : vgap);
+	}
+
+	/**
+	 * Creates a ListLayout with the specified attributes.
+	 *
+	 * @param type the list type.
+	 * @param alignment the item alignment.
+	 * @param separator the separator to display between items.
+	 * @param ordered whether the list is an ordered list.
+	 * @param gap the gap between the components added to the layouts.
+	 */
+	public ListLayout(final Type type, final Alignment alignment, final Separator separator, final boolean ordered,
+			final int gap) {
+		if (type == null) {
+			throw new IllegalArgumentException("Type must be provided.");
+		}
 		this.type = type;
 		this.alignment = alignment;
 		this.separator = separator;
 		this.ordered = ordered;
-		this.hgap = hgap;
-		this.vgap = vgap;
+		this.gap = gap;
 	}
 
 	/**
@@ -155,15 +205,30 @@ public class ListLayout implements LayoutManager {
 
 	/**
 	 * @return the horizontal gap between the list items, measured in pixels.
+	 * @deprecated use {@link #getGap()}
 	 */
 	public int getHgap() {
-		return hgap;
+		if (this.type == Type.FLAT) {
+			return gap;
+		}
+		return 0;
 	}
 
 	/**
 	 * @return the vertical gap between the list items, measured in pixels.
+	 * @deprecated use {@link #getGap()}
 	 */
 	public int getVgap() {
-		return vgap;
+		if (this.type == Type.FLAT) {
+			return 0;
+		}
+		return gap;
+	}
+
+	/**
+	 * @return the space between the components added to the layout.
+	 */
+	public int getGap() {
+		return gap;
 	}
 }

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/ListLayoutRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/ListLayoutRenderer.java
@@ -27,8 +27,7 @@ final class ListLayoutRenderer extends AbstractWebXmlRenderer {
 		XmlStringBuilder xml = renderContext.getWriter();
 		ListLayout layout = (ListLayout) panel.getLayout();
 		int childCount = panel.getChildCount();
-		int hgap = layout.getHgap();
-		int vgap = layout.getVgap();
+		int gap = layout.getGap();
 
 		xml.appendTagOpen("ui:listlayout");
 
@@ -85,8 +84,7 @@ final class ListLayoutRenderer extends AbstractWebXmlRenderer {
 
 		xml.appendOptionalAttribute("ordered", layout.isOrdered(), "true");
 
-		xml.appendOptionalAttribute("hgap", hgap > 0, hgap);
-		xml.appendOptionalAttribute("vgap", vgap > 0, vgap);
+		xml.appendOptionalAttribute("gap", gap > 0, gap);
 
 		xml.appendClose();
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WListRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WListRenderer.java
@@ -29,8 +29,7 @@ final class WListRenderer extends AbstractWebXmlRenderer {
 		XmlStringBuilder xml = renderContext.getWriter();
 		WList.Type type = list.getType();
 		WList.Separator separator = list.getSeparator();
-		int hgap = list.getHgap();
-		int vgap = list.getVgap();
+		int gap = list.getGap();
 
 		xml.appendTagOpen("ui:panel");
 		xml.appendAttribute("id", component.getId());
@@ -43,8 +42,7 @@ final class WListRenderer extends AbstractWebXmlRenderer {
 		MarginRendererUtil.renderMargin(list, renderContext);
 
 		xml.appendTagOpen("ui:listlayout");
-		xml.appendOptionalAttribute("hgap", hgap > 0, hgap);
-		xml.appendOptionalAttribute("vgap", vgap > 0, vgap);
+		xml.appendOptionalAttribute("gap", gap > 0, gap);
 
 		if (type != null) {
 			switch (type) {

--- a/wcomponents-core/src/main/resources/schema/ui/v1/panel.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/panel.xsd
@@ -212,7 +212,11 @@
 										"false".</xs:documentation>
 								</xs:annotation>
 							</xs:attribute>
-							<xs:attributeGroup ref="ui:gaps.attributes" />
+							<xs:attribute name="gap" type="xs:positiveInteger">
+								<xs:annotation>
+									<xs:documentation>The space between content components in the layout in pixels. This may be adjusted by the theme and/or user agent.</xs:documentation>
+								</xs:annotation>
+							</xs:attribute>
 						</xs:complexType>
 					</xs:element>
 

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WList_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WList_Test.java
@@ -15,18 +15,22 @@ public class WList_Test extends AbstractWComponentTestCase {
 
 	@Test
 	public void testConstructor1() {
-		WList list = new WList(Type.FLAT);
-		Assert.assertEquals("Constructor - Incorrect type", Type.FLAT, list.getType());
-		Assert.assertEquals("Constructor - Incorrect default hgap", 0, list.getHgap());
-		Assert.assertEquals("Constructor - Incorrect default vgap", 0, list.getVgap());
+		WList list;
+		for (WList.Type t : WList.Type.values()) {
+			list = new WList(t);
+			Assert.assertEquals("Constructor - Incorrect type", t, list.getType());
+			Assert.assertEquals("Constructor - Incorrect default gap", 0, list.getGap());
+		}
 	}
 
 	@Test
 	public void testConstructor2() {
-		WList list = new WList(Type.STACKED, 1, 2);
-		Assert.assertEquals("Constructor - Incorrect type", Type.STACKED, list.getType());
-		Assert.assertEquals("Constructor - Incorrect hgap", 1, list.getHgap());
-		Assert.assertEquals("Constructor - Incorrect vgap", 2, list.getVgap());
+		WList list;
+		for (WList.Type t : WList.Type.values()) {
+			list = new WList(t, 1);
+			Assert.assertEquals("Constructor - Incorrect type", t, list.getType());
+			Assert.assertEquals("Constructor - Incorrect gap", 1, list.getGap());
+		}
 	}
 
 	@Test
@@ -47,6 +51,26 @@ public class WList_Test extends AbstractWComponentTestCase {
 	@Test
 	public void testRenderBorderAccessors() {
 		assertAccessorsCorrect(new WList(Type.FLAT), "renderBorder", false, true, false);
+	}
+
+	// Test of the deprecated constructor.
+	@Test
+	public void testConstructor2Gaps() {
+		WList list;
+		for (WList.Type t : WList.Type.values()) {
+			list = new WList(t, 1, 2);
+			Assert.assertEquals("Constructor - Incorrect type", t, list.getType());
+
+			if (t == WList.Type.FLAT) {
+				Assert.assertEquals("Constructor - Incorrect gap", 1, list.getGap());
+				Assert.assertEquals("Constructor - Incorrect hgap", 1, list.getHgap());
+				Assert.assertEquals("Constructor - Incorrect vgap", 0, list.getVgap());
+			} else {
+				Assert.assertEquals("Constructor - Incorrect gap", 2, list.getGap());
+				Assert.assertEquals("Constructor - Incorrect hgap", 0, list.getHgap());
+				Assert.assertEquals("Constructor - Incorrect vgap", 2, list.getVgap());
+			}
+		}
 	}
 
 }

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/layout/ListLayout_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/layout/ListLayout_Test.java
@@ -1,0 +1,155 @@
+package com.github.bordertech.wcomponents.layout;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * FlowLayout_Test - unit tests for {@link FlowLayout}.
+ *
+ * @author Yiannis Paschalidis, Mark Reeves
+ * @since 1.0.0
+ */
+public class ListLayout_Test {
+
+	/**
+	 * A reusable gap value.
+	 */
+	private static final int GAP = 12;
+
+	/**
+	 * A different reusable gap value. This is used to differentiate the (now deprecated) hgap and vgap properties.
+	 */
+	private static final int BIG_GAP = 18;
+
+
+	@Test
+	public void testDefaultConstructor() {
+		ListLayout list = new ListLayout();
+		Assert.assertEquals("Default type should be STACKED", ListLayout.Type.STACKED, list.getType());
+		Assert.assertEquals("Default alignment should be LEFT", ListLayout.Alignment.LEFT, list.getAlignment());
+		Assert.assertEquals("Default separator should be DOT", ListLayout.Separator.DOT, list.getSeparator());
+		Assert.assertEquals("Default gap should be zero", 0, list.getGap());
+		Assert.assertFalse("Default ordered should be false", list.isOrdered());
+	}
+
+	@Test
+	public void testTypeConstructor() {
+		for (ListLayout.Type t : ListLayout.Type.values()) {
+			ListLayout list = new ListLayout(t);
+			Assert.assertEquals("Incorrect type", t, list.getType());
+			Assert.assertEquals("Default alignment should be LEFT", ListLayout.Alignment.LEFT, list.getAlignment());
+		Assert.assertEquals("Default separator should be DOT", ListLayout.Separator.DOT, list.getSeparator());
+			Assert.assertEquals("Default gap should be zero", 0, list.getGap());
+			Assert.assertFalse("Default ordered should be false", list.isOrdered());
+		}
+	}
+
+	@Test
+	public void testOrderedConstructor() {
+		ListLayout list = new ListLayout(true);
+		Assert.assertTrue("ordered should be true", list.isOrdered());
+		Assert.assertEquals("Default type should be STACKED", ListLayout.Type.STACKED, list.getType());
+		Assert.assertEquals("Default alignment should be LEFT", ListLayout.Alignment.LEFT, list.getAlignment());
+		Assert.assertEquals("Default separator should be DOT", ListLayout.Separator.DOT, list.getSeparator());
+		Assert.assertEquals("Default gap should be zero", 0, list.getGap());
+	}
+
+	@Test
+	public void testTypeAlignmentConstructor() {
+		ListLayout list;
+		for (ListLayout.Type t : ListLayout.Type.values()) {
+			for (ListLayout.Alignment a : ListLayout.Alignment.values()) {
+				list = new ListLayout(t, a);
+				Assert.assertEquals("Incorrect type", t, list.getType());
+				Assert.assertEquals("Incorrect alignment", a, list.getAlignment());
+			}
+		}
+	}
+
+	@Test
+	public void testTypeAlignmentSeparatorOrderedConstructor() {
+		ListLayout list;
+		for (ListLayout.Type t : ListLayout.Type.values()) {
+			for (ListLayout.Alignment a : ListLayout.Alignment.values()) {
+				for (ListLayout.Separator s : ListLayout.Separator.values()) {
+					list = new ListLayout(t, a, s, true);
+					Assert.assertEquals("Incorrect type", t, list.getType());
+					Assert.assertEquals("Incorrect alignment", a, list.getAlignment());
+					Assert.assertEquals("Incorrect separator", s, list.getSeparator());
+					Assert.assertTrue("ordered should be true", list.isOrdered());
+					list = new ListLayout(t, a, s, false);
+					Assert.assertEquals("Incorrect type", t, list.getType());
+					Assert.assertEquals("Incorrect alignment", a, list.getAlignment());
+					Assert.assertEquals("Incorrect separator", s, list.getSeparator());
+					Assert.assertFalse("ordered should be false", list.isOrdered());
+				}
+			}
+		}
+	}
+
+	@Test
+	public void testTypeAlignmentSeparatorOrderedGapConstructor() {
+		ListLayout list;
+		for (ListLayout.Type t : ListLayout.Type.values()) {
+			for (ListLayout.Alignment a : ListLayout.Alignment.values()) {
+				for (ListLayout.Separator s : ListLayout.Separator.values()) {
+					list = new ListLayout(t, a, s, true, GAP);
+					Assert.assertEquals("Incorrect type", t, list.getType());
+					Assert.assertEquals("Incorrect alignment", a, list.getAlignment());
+					Assert.assertEquals("Incorrect separator", s, list.getSeparator());
+					Assert.assertTrue("ordered should be true", list.isOrdered());
+					Assert.assertEquals("Incorrect gap", GAP, list.getGap());
+					list = new ListLayout(t, a, s, false, GAP);
+					Assert.assertEquals("Incorrect type", t, list.getType());
+					Assert.assertEquals("Incorrect alignment", a, list.getAlignment());
+					Assert.assertEquals("Incorrect separator", s, list.getSeparator());
+					Assert.assertFalse("ordered should be false", list.isOrdered());
+					Assert.assertEquals("Incorrect gap", GAP, list.getGap());
+				}
+			}
+		}
+	}
+
+	// Tests of deprecated constructor
+	@Test
+	public void testHgapVgapConstructor() {
+		ListLayout list;
+		boolean isFlat;
+		for (ListLayout.Type t : ListLayout.Type.values()) {
+			for (ListLayout.Alignment a : ListLayout.Alignment.values()) {
+				for (ListLayout.Separator s : ListLayout.Separator.values()) {
+					isFlat = t == ListLayout.Type.FLAT;
+					list = new ListLayout(t, a, s, true, GAP, BIG_GAP);
+					Assert.assertEquals("Incorrect type", t, list.getType());
+					Assert.assertEquals("Incorrect alignment", a, list.getAlignment());
+					Assert.assertEquals("Incorrect separator", s, list.getSeparator());
+					Assert.assertTrue("ordered should be true", list.isOrdered());
+					Assert.assertEquals("Incorrect gap", isFlat ? GAP : BIG_GAP, list.getGap());
+
+					list = new ListLayout(t, a, s, false, GAP, BIG_GAP);
+					Assert.assertEquals("Incorrect type", t, list.getType());
+					Assert.assertEquals("Incorrect alignment", a, list.getAlignment());
+					Assert.assertEquals("Incorrect separator", s, list.getSeparator());
+					Assert.assertFalse("ordered should be false", list.isOrdered());
+					Assert.assertEquals("Incorrect gap", isFlat ? GAP : BIG_GAP, list.getGap());
+				}
+			}
+		}
+	}
+
+	// Test deprecated accessors.
+	// Type.FLAT  should have hgap but 0 vgap.
+	// other types should have vgap but 0 hgap.
+	@Test
+	public void testHGapVGapAccessors() {
+		ListLayout list;
+		boolean isFlat;
+
+		for (ListLayout.Type t : ListLayout.Type.values()) {
+			isFlat = t == ListLayout.Type.FLAT;
+			list = new ListLayout(t, ListLayout.Alignment.LEFT, ListLayout.Separator.NONE, true, GAP, BIG_GAP);
+			Assert.assertEquals("Incorrect horizontal gap", isFlat ? GAP : 0, list.getHgap());
+			Assert.assertEquals("Incorrect vertical gap", isFlat ? 0 : BIG_GAP, list.getVgap());
+		}
+	}
+}

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/ListLayoutRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/ListLayoutRenderer_Test.java
@@ -16,6 +16,10 @@ import org.xml.sax.SAXException;
  */
 public class ListLayoutRenderer_Test extends AbstractWebXmlRendererTestCase {
 
+	private static final int GAP = 8;
+	private static final int BIG_GAP = 16;
+
+
 	@Test
 	public void testDoRenderWhenEmpty() throws IOException, SAXException, XpathException {
 		WPanel panel = new WPanel();
@@ -25,29 +29,35 @@ public class ListLayoutRenderer_Test extends AbstractWebXmlRendererTestCase {
 
 		assertXpathExists("//ui:panel/ui:listlayout", panel);
 		assertXpathNotExists("//ui:panel/ui:listlayout/ui:cell", panel);
-		assertXpathNotExists("//ui:panel/ui:listlayout/@hgap", panel);
-		assertXpathNotExists("//ui:panel/ui:listlayout/@vgap", panel);
+		assertXpathNotExists("//ui:panel/ui:listlayout/@gap", panel);
 		assertXpathNotExists("//ui:panel/ui:listlayout/@align", panel);
 		assertXpathNotExists("//ui:panel/ui:listlayout/@separator", panel);
 		assertXpathNotExists("//ui:panel/ui:listlayout/@ordered", panel);
 		assertXpathEvaluatesTo("flat", "//ui:panel/ui:listlayout/@type", panel);
 
-		panel.setLayout(new ListLayout(ListLayout.Type.STRIPED, ListLayout.Alignment.CENTER,
-				ListLayout.Separator.NONE, false));
+		panel.setLayout(new ListLayout(ListLayout.Type.STRIPED, ListLayout.Alignment.CENTER, ListLayout.Separator.NONE,
+				false));
 		assertXpathEvaluatesTo("striped", "//ui:panel/ui:listlayout/@type", panel);
 		assertXpathEvaluatesTo("center", "//ui:panel/ui:listlayout/@align", panel);
 		assertXpathNotExists("//ui:panel/ui:listlayout/ui:cell", panel);
-		assertXpathNotExists("//ui:panel/ui:listlayout/@hgap", panel);
-		assertXpathNotExists("//ui:panel/ui:listlayout/@vgap", panel);
+		assertXpathNotExists("//ui:panel/ui:listlayout/@gap", panel);
 		assertXpathNotExists("//ui:panel/ui:listlayout/@separator", panel);
 		assertXpathNotExists("//ui:panel/ui:listlayout/@ordered", panel);
 
-		panel.setLayout(new ListLayout(ListLayout.Type.STACKED, ListLayout.Alignment.RIGHT,
-				ListLayout.Separator.NONE, false, 1, 2));
+		panel.setLayout(new ListLayout(ListLayout.Type.STACKED, ListLayout.Alignment.RIGHT, ListLayout.Separator.NONE,
+				false, GAP, BIG_GAP));
 		assertXpathEvaluatesTo("stacked", "//ui:panel/ui:listlayout/@type", panel);
 		assertXpathEvaluatesTo("right", "//ui:panel/ui:listlayout/@align", panel);
-		assertXpathEvaluatesTo("1", "//ui:panel/ui:listlayout/@hgap", panel);
-		assertXpathEvaluatesTo("2", "//ui:panel/ui:listlayout/@vgap", panel);
+		assertXpathEvaluatesTo(String.valueOf(BIG_GAP), "//ui:panel/ui:listlayout/@gap", panel);
+		assertXpathNotExists("//ui:panel/ui:listlayout/ui:cell", panel);
+		assertXpathNotExists("//ui:panel/ui:listlayout/@separator", panel);
+		assertXpathNotExists("//ui:panel/ui:listlayout/@ordered", panel);
+
+		panel.setLayout(new ListLayout(ListLayout.Type.STACKED, ListLayout.Alignment.RIGHT, ListLayout.Separator.NONE,
+				false, GAP));
+		assertXpathEvaluatesTo("stacked", "//ui:panel/ui:listlayout/@type", panel);
+		assertXpathEvaluatesTo("right", "//ui:panel/ui:listlayout/@align", panel);
+		assertXpathEvaluatesTo(String.valueOf(GAP), "//ui:panel/ui:listlayout/@gap", panel);
 		assertXpathNotExists("//ui:panel/ui:listlayout/ui:cell", panel);
 		assertXpathNotExists("//ui:panel/ui:listlayout/@separator", panel);
 		assertXpathNotExists("//ui:panel/ui:listlayout/@ordered", panel);
@@ -60,15 +70,9 @@ public class ListLayoutRenderer_Test extends AbstractWebXmlRendererTestCase {
 
 		WPanel panel = new WPanel();
 		panel.setLayout(new ListLayout(ListLayout.Type.STRIPED, ListLayout.Alignment.LEFT,
-				ListLayout.Separator.DOT, true, 3, 4));
+				ListLayout.Separator.DOT, true, GAP));
 		assertSchemaMatch(panel);
 
-		assertXpathEvaluatesTo("striped", "//ui:panel/ui:listlayout/@type", panel);
-		assertXpathNotExists("//ui:panel/ui:listlayout/@align", panel);
-		assertXpathEvaluatesTo("dot", "//ui:panel/ui:listlayout/@separator", panel);
-		assertXpathEvaluatesTo("3", "//ui:panel/ui:listlayout/@hgap", panel);
-		assertXpathEvaluatesTo("4", "//ui:panel/ui:listlayout/@vgap", panel);
-		assertXpathEvaluatesTo("true", "//ui:panel/ui:listlayout/@ordered", panel);
 		assertXpathNotExists("//ui:panel/ui:listlayout/ui:cell", panel);
 
 		panel.add(new WText(text1));

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WListRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WListRenderer_Test.java
@@ -13,10 +13,20 @@ import org.xml.sax.SAXException;
 /**
  * Junit test case for {@link WListRenderer}.
  *
- * @author Yiannis Paschalidis
+ * @author Yiannis Paschalidis, Mark Reeves
  * @since 1.0.0
  */
 public class WListRenderer_Test extends AbstractWebXmlRendererTestCase {
+
+	/**
+	 * A reusable gap value.
+	 */
+	private static final int GAP = 12;
+
+	/**
+	 * A different reusable gap value. This is used to differentiate the (now deprecated) hgap and vgap properties.
+	 */
+	private static final int BIG_GAP = 18;
 
 	@Test
 	public void testLayoutCorrectlyConfigured() {
@@ -30,35 +40,24 @@ public class WListRenderer_Test extends AbstractWebXmlRendererTestCase {
 		// empty list, no border
 		WList list = new WList(WList.Type.STRIPED);
 		list.setRepeatedComponent(new WText());
-		assertSchemaMatch(list);
-		assertXpathEvaluatesTo("striped", "//ui:listlayout/@type", list);
-		assertXpathNotExists("//ui:listlayout/@separator", list);
-		assertXpathNotExists("//ui:panel/@type", list);
 
-		list.setType(WList.Type.FLAT);
-		assertXpathEvaluatesTo("flat", "//ui:listlayout/@type", list);
-		assertXpathNotExists("//ui:listlayout/@separator", list);
-		assertXpathNotExists("//ui:panel/@type", list);
+		for (WList.Type t : WList.Type.values()) {
+			list.setType(t);
+			assertSchemaMatch(list);
+			assertXpathEvaluatesTo(t.toString().toLowerCase(), "//ui:listlayout/@type", list);
+			assertXpathNotExists("//ui:listlayout/@separator", list);
+			assertXpathNotExists("//ui:panel/@type", list);
+		}
 
-		list.setType(WList.Type.STACKED);
-		assertXpathEvaluatesTo("stacked", "//ui:listlayout/@type", list);
-		assertXpathNotExists("//ui:listlayout/@separator", list);
-		assertXpathNotExists("//ui:panel/@type", list);
-
-		list.setSeparator(WList.Separator.NONE);
-		assertXpathEvaluatesTo("stacked", "//ui:listlayout/@type", list);
-		assertXpathNotExists("//ui:listlayout/@separator", list);
-		assertXpathNotExists("//ui:panel/@type", list);
-
-		list.setSeparator(WList.Separator.BAR);
-		assertXpathEvaluatesTo("stacked", "//ui:listlayout/@type", list);
-		assertXpathEvaluatesTo("bar", "//ui:listlayout/@separator", list);
-		assertXpathNotExists("//ui:panel/@type", list);
-
-		list.setSeparator(WList.Separator.DOT);
-		assertXpathEvaluatesTo("stacked", "//ui:listlayout/@type", list);
-		assertXpathEvaluatesTo("dot", "//ui:listlayout/@separator", list);
-		assertXpathNotExists("//ui:listlayout[@type='box']", list);
+		for (WList.Separator s : WList.Separator.values()) {
+			list.setSeparator(s);
+			assertSchemaMatch(list);
+			if (s == WList.Separator.NONE) {
+				assertXpathNotExists("//ui:listlayout/@separator", list);
+			} else {
+				assertXpathEvaluatesTo(s.toString().toLowerCase(), "//ui:listlayout/@separator", list);
+			}
+		}
 	}
 
 	@Test
@@ -97,24 +96,24 @@ public class WListRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertSchemaMatch(list);
 	}
 
+
 	@Test
-	public void testRenderedFormatHgapVgap() throws IOException, SAXException, XpathException {
+	public void testRenderedFormaGap() throws IOException, SAXException, XpathException {
 		// No hgap, vgap
 		WList list = new WList(WList.Type.STRIPED);
 		list.setRepeatedComponent(new WText());
 		list.setData(Arrays.asList(new String[]{"row1", "row2", "row3"}));
 		assertSchemaMatch(list);
-		assertXpathNotExists("//ui:panel/ui:listlayout/@hgap", list);
-		assertXpathNotExists("//ui:panel/ui:listlayout/@vgap", list);
+		assertXpathNotExists("//ui:panel/ui:listlayout/@gap", list);
 
-		// With hgap, vgap
-		list = new WList(WList.Type.STRIPED, 1, 2);
+		// With gap
+		list = new WList(WList.Type.STRIPED, GAP);
 		list.setRepeatedComponent(new WText());
 		list.setData(Arrays.asList(new String[]{"row1", "row2", "row3"}));
 		assertSchemaMatch(list);
-		assertXpathEvaluatesTo("1", "//ui:panel/ui:listlayout/@hgap", list);
-		assertXpathEvaluatesTo("2", "//ui:panel/ui:listlayout/@vgap", list);
+		assertXpathEvaluatesTo(String.valueOf(GAP), "//ui:panel/ui:listlayout/@gap", list);
 	}
+
 
 	@Test
 	public void testRenderedWithMargins() throws IOException, SAXException, XpathException {
@@ -126,10 +125,10 @@ public class WListRenderer_Test extends AbstractWebXmlRendererTestCase {
 		list.setMargin(margin);
 		assertXpathNotExists("//ui:panel/ui:margin", list);
 
-		margin = new Margin(1);
+		margin = new Margin(GAP);
 		list.setMargin(margin);
 		assertSchemaMatch(list);
-		assertXpathEvaluatesTo("1", "//ui:panel/ui:margin/@all", list);
+		assertXpathEvaluatesTo(String.valueOf(GAP), "//ui:panel/ui:margin/@all", list);
 		assertXpathEvaluatesTo("", "//ui:panel/ui:margin/@north", list);
 		assertXpathEvaluatesTo("", "//ui:panel/ui:margin/@east", list);
 		assertXpathEvaluatesTo("", "//ui:panel/ui:margin/@south", list);
@@ -143,6 +142,27 @@ public class WListRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertXpathEvaluatesTo("2", "//ui:panel/ui:margin/@east", list);
 		assertXpathEvaluatesTo("3", "//ui:panel/ui:margin/@south", list);
 		assertXpathEvaluatesTo("4", "//ui:panel/ui:margin/@west", list);
+	}
+
+
+
+	// deprecated hgap vgap constructor render
+	@Test
+	public void testRenderedFormatHgapVgap() throws IOException, SAXException, XpathException {
+		WList list;
+
+		for (WList.Type t : WList.Type.values()) {
+			list = new WList(t, GAP, BIG_GAP);
+			list.setRepeatedComponent(new WText());
+			list.setData(Arrays.asList(new String[]{"row1", "row2", "row3"}));
+			assertSchemaMatch(list);
+
+			if (t == WList.Type.FLAT) {
+				assertXpathEvaluatesTo(String.valueOf(GAP), "//ui:panel/ui:listlayout/@gap", list);
+			} else {
+				assertXpathEvaluatesTo(String.valueOf(BIG_GAP), "//ui:panel/ui:listlayout/@gap", list);
+			}
+		}
 	}
 
 }

--- a/wcomponents-theme/src/main/sass/_mixins-flex.scss
+++ b/wcomponents-theme/src/main/sass/_mixins-flex.scss
@@ -69,6 +69,13 @@
 	flex-direction: $direction;
 }
 
+/// Apply  _only_the flex display rule to an element.
+@mixin flex-display {
+	display: block; // See issue #561
+	display: -webkit-flex;
+	display: flex;
+}
+
 /// Apply a flex-wrap rule. This assumes a flex display is already set.
 /// @param {flex-wrap} $wrap [nowrap] The wrap type to set.
 @mixin flex-wrap($wrap: nowrap) {

--- a/wcomponents-theme/src/main/sass/wc.common.rowColumn.ie10.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.rowColumn.ie10.scss
@@ -2,6 +2,5 @@
 @import 'mixins-common';
 
 .wc-column {
-	@include border-box;
 	vertical-align: top;
 }

--- a/wcomponents-theme/src/main/sass/wc.common.rowColumn.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.rowColumn.scss
@@ -1,6 +1,7 @@
 /* wc.ui.row.scss */
 @import 'mixins-common';
 
+
 .wc-row {
 	@include flex;
 
@@ -11,8 +12,32 @@
 
 .wc-column {
 	@include border-box;
-	display: inline-block; // with implied width auto
+	// display: inline-block; // with implied width auto I think this is needed for IE 11 but cannot be loaded later
 }
+
+@for $i from 2 through 100 {
+	.wc_col_#{$i} {
+		width: percentage($i / 100);
+	}
+}
+
+// Alternative for less CSS if we only want to support some column widths.
+// $supported-column-widths:  16, 33, 34, 66, 67, 83 !default;
+//
+// @for $i from 1 through 20 {
+// 	$w: $i * 5;
+//
+// 	.wc_col_#{$w} {
+// 		width: percentage($w / 100);
+// 	}
+// }
+//
+// @each $w in $supported-column-widths {
+// 	.wc_col_#{$w} {
+// 		width: percentage($w / 100);
+// 	}
+// }
+
 
 @include respond-phonelike {
 	.wc-row {
@@ -24,7 +49,7 @@
 		// width is set inline for WColumn and ColumnLayout. Important to override this inline css.
 		// TODO: Fix this at least for common widths as per WFieldLayout.
 		// scss-lint:disable ImportantRule
-		width: 100% !important;
+		width: 100%;
 
 		+ .wc-column {
 			margin-top: $wc-gap-small;

--- a/wcomponents-theme/src/main/xslt/wc.common.column.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.column.xsl
@@ -24,13 +24,11 @@
 					<xsl:if test="not(self::ui:column)">
 						<xsl:text> wc-column</xsl:text>
 					</xsl:if>
+					<xsl:if test="$width and $width != 0">
+						<xsl:value-of select="concat(' wc_col_',$width)"/>
+					</xsl:if>
 				</xsl:with-param>
 			</xsl:call-template>
-			<xsl:if test="$width and $width != 0">
-				<xsl:attribute name="style">
-					<xsl:value-of select="concat('width:',$width,'%;')"/>
-				</xsl:attribute>
-			</xsl:if>
 			<xsl:apply-templates/>
 		</div>
 	</xsl:template>


### PR DESCRIPTION
* Updated ListLayout and WList to use a single GAP to replace hgap and
vgap. This was done to remove API ambiguity which lead to rendering
errors. Fixes #655
* Removed inline style from columns. Fixes #656