### PR TITLE
WLink and WButton get text equivalent off image

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WButtonRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WButtonRenderer.java
@@ -5,6 +5,7 @@ import com.github.bordertech.wcomponents.Renderer;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WButton.ImagePosition;
 import com.github.bordertech.wcomponents.WComponent;
+import com.github.bordertech.wcomponents.WImage;
 import com.github.bordertech.wcomponents.XmlStringBuilder;
 import com.github.bordertech.wcomponents.servlet.WebXmlRenderContext;
 import com.github.bordertech.wcomponents.util.SystemException;
@@ -71,6 +72,14 @@ class WButtonRenderer extends AbstractWebXmlRenderer {
 						break;
 					default:
 						throw new SystemException("Unknown image position: " + imagePosition);
+				}
+			}
+
+			if (Util.empty(text) && Util.empty(button.getToolTip()) && Util.empty(button.getAccessibleText())) {
+				// If the button has an umageUrl but no text equivalent get the text equivalent off of the image
+				WImage imgHolder = button.getImageHolder();
+				if (null != imgHolder) {
+					xml.appendOptionalAttribute("toolTip", imgHolder.getAlternativeText());
 				}
 			}
 		}

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WLinkRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WLinkRenderer.java
@@ -3,6 +3,7 @@ package com.github.bordertech.wcomponents.render.webxml;
 import com.github.bordertech.wcomponents.AjaxTarget;
 import com.github.bordertech.wcomponents.Renderer;
 import com.github.bordertech.wcomponents.WComponent;
+import com.github.bordertech.wcomponents.WImage;
 import com.github.bordertech.wcomponents.WLink;
 import com.github.bordertech.wcomponents.WLink.ImagePosition;
 import com.github.bordertech.wcomponents.XmlStringBuilder;
@@ -65,6 +66,14 @@ final class WLinkRenderer extends AbstractWebXmlRenderer {
 						break;
 					default:
 						throw new SystemException("Unknown image position: " + imagePosition);
+				}
+			}
+			// we have an image. We must have a text equivalent
+			if (Util.empty(text) && Util.empty(link.getToolTip()) && Util.empty(link.getAccessibleText())) {
+				// If the link has an umageUrl but no text equivalent get the text equivalent off of the image
+				WImage linkImage = link.getImageHolder();
+				if (null != linkImage) {
+					xml.appendOptionalAttribute("toolTip", linkImage.getAlternativeText());
 				}
 			}
 		}

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WButtonRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WButtonRenderer_Test.java
@@ -5,6 +5,7 @@ import com.github.bordertech.wcomponents.ComponentModel;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WButton.ImagePosition;
 import com.github.bordertech.wcomponents.WContainer;
+import com.github.bordertech.wcomponents.WImage;
 import com.github.bordertech.wcomponents.WPanel;
 import com.github.bordertech.wcomponents.WTextField;
 import com.github.bordertech.wcomponents.util.SystemException;
@@ -19,7 +20,7 @@ import org.xml.sax.SAXException;
 /**
  * Junit test case for {@link WButtonRenderer}.
  *
- * @author Jonathan Austin
+ * @author Jonathan Austin, Mark Reeves
  * @since 1.0.0
  */
 public class WButtonRenderer_Test extends AbstractWebXmlRendererTestCase {
@@ -123,5 +124,14 @@ public class WButtonRenderer_Test extends AbstractWebXmlRendererTestCase {
 
 		button.setAccessibleText(getMaliciousAttribute("ui:button"));
 		assertSafeContent(button);
+	}
+
+	@Test
+	public void testButtonImageToolTipRender() throws IOException, SAXException, XpathException {
+		WButton button = new WButton();
+		String expected = "alt text";
+		WImage buttonImage = new WImage("http://localhost/image.png", expected);
+		button.setImage(buttonImage.getImage());
+		assertXpathEvaluatesTo(expected, "//ui:button/@toolTip", button);
 	}
 }

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WLinkRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WLinkRenderer_Test.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.render.webxml;
 
 import com.github.bordertech.wcomponents.TestAction;
 import com.github.bordertech.wcomponents.WContainer;
+import com.github.bordertech.wcomponents.WImage;
 import com.github.bordertech.wcomponents.WLink;
 import com.github.bordertech.wcomponents.WPanel;
 import java.io.IOException;
@@ -201,6 +202,17 @@ public class WLinkRenderer_Test extends AbstractWebXmlRendererTestCase {
 				root);
 		assertXpathEvaluatesTo(target2.getId(), "//ui:ajaxtrigger/ui:ajaxtargetid[2]/@targetId",
 				root);
+	}
+
+
+
+	@Test
+	public void testButtonImageToolTipRender() throws IOException, SAXException, XpathException {
+		WLink link = new WLink();
+		String expected = "alt text";
+		WImage buttonImage = new WImage("http://localhost/image.png", expected);
+		link.setImage(buttonImage.getImage());
+		assertXpathEvaluatesTo(expected, "//ui:link/@toolTip", link);
 	}
 
 }

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/LinkOptionsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/LinkOptionsExample.java
@@ -9,6 +9,7 @@ import com.github.bordertech.wcomponents.WDropdown;
 import com.github.bordertech.wcomponents.WFieldLayout;
 import com.github.bordertech.wcomponents.WFieldSet;
 import com.github.bordertech.wcomponents.WHorizontalRule;
+import com.github.bordertech.wcomponents.WImage;
 import com.github.bordertech.wcomponents.WLink;
 import com.github.bordertech.wcomponents.WLink.ImagePosition;
 import com.github.bordertech.wcomponents.WPanel;
@@ -176,7 +177,8 @@ public class LinkOptionsExample extends WPanel {
 		exampleLink.setText(tfLinkLabel.getText());
 
 		if (cbSetImage.isSelected()) {
-			exampleLink.setImage("/image/attachment.png");
+			WImage linkImage = new WImage("/image/attachment.png", "Add attachment");
+			exampleLink.setImage(linkImage.getImage());
 			exampleLink.setImagePosition((ImagePosition) ddImagePosition.getSelected());
 		}
 

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WButtonExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WButtonExample.java
@@ -11,6 +11,7 @@ import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WFieldLayout;
 import com.github.bordertech.wcomponents.WHeading;
 import com.github.bordertech.wcomponents.WHorizontalRule;
+import com.github.bordertech.wcomponents.WImage;
 import com.github.bordertech.wcomponents.WMessageBox;
 import com.github.bordertech.wcomponents.WMessages;
 import com.github.bordertech.wcomponents.WPanel;
@@ -123,6 +124,12 @@ public class WButtonExample extends WPanel implements MessageContainer {
 				+ "If you are creating a button containing only an image you should be careful as it may not be obvious to the application user that the 'image' is actually a 'button'."
 				+ "The button must still have text content to adequately explain the button's purpose."));
 		add(makeImageButton("Save", true));
+
+		add(new ExplanatoryText("Button using a WImage description as the text equivalent."));
+		WButton button = new WButton();
+		WImage buttonImage = new WImage("/image/tick.png", "Mark as OK");
+		button.setImage(buttonImage.getImage());
+		add(button);
 
 		add(new WHeading(HeadingLevel.H3, "Image and text"));
 		add(new ExplanatoryText(
@@ -312,7 +319,7 @@ public class WButtonExample extends WPanel implements MessageContainer {
 		add(new ExplanatoryText("A button without a text label is very bad"));
 
 		add(new WHeading(HeadingLevel.H3, "WButton with a WImage but without a good label"));
-		WButton button = new WButton("\u00a0");
+		WButton button = new WButton("");
 		button.setImage("/image/help.png");
 		add(button);
 		add(new ExplanatoryText(


### PR DESCRIPTION
WLink and WButton with an image will attempt to get the text equivalent
off of the image if the button/link has none of:

* text content;
* toolTip; or
* accessibleText.

This will still allow applications to create buttons and links with
poor accessibility but removes one more problem where a button/link did
not have a fighting chance of getting a text alternative to the image.
Fixes #650