### PR TITLE
Undeprecate accessible text

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWComponent.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWComponent.java
@@ -1636,8 +1636,6 @@ public abstract class AbstractWComponent implements WComponent {
 
 	/**
 	 * {@inheritDoc}
-	 *
-	 * @deprecated use setToolTip
 	 */
 	@Override
 	public void setAccessibleText(final String text, final Serializable... args) {
@@ -1647,8 +1645,6 @@ public abstract class AbstractWComponent implements WComponent {
 
 	/**
 	 * {@inheritDoc}
-	 *
-	 * @deprecated use getToolTip
 	 */
 	@Override
 	public String getAccessibleText() {

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/ComponentModel.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/ComponentModel.java
@@ -174,8 +174,6 @@ public class ComponentModel implements WebModel, Externalizable {
 
 	/**
 	 * Adds extra textual information to describe a component. This is intended for screen-readers only.
-	 *
-	 * @deprecated use toolTip
 	 */
 	private Serializable accessibleText;
 
@@ -523,7 +521,6 @@ public class ComponentModel implements WebModel, Externalizable {
 
 	/**
 	 * @return Returns the accessible text.
-	 * @deprecated use getToolTip
 	 */
 	protected Serializable getAccessibleText() {
 		return accessibleText;
@@ -532,7 +529,6 @@ public class ComponentModel implements WebModel, Externalizable {
 	/**
 	 * @param text The accessible text to set.
 	 * @param args optional message format arguments.
-	 * @deprecated use setToolTip
 	 */
 	protected void setAccessibleText(final String text, final Serializable... args) {
 		this.accessibleText = I18nUtilities.asMessage(text, args);

--- a/wcomponents-theme/src/main/xslt/wc.common.aria.label.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.aria.label.xsl
@@ -1,22 +1,6 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
 	<!--
-		This helper template sets attribute aria-live on many components
-		and must never be excluded.
-
-		This is an WAI-ARIA property which indicates the verbose announcement level of
-		updates to the content if it is updated via AJAX or a subordinate control.
-
-		See:
-			wc.ui.collapsible.xsl
-			wc.ui.table.xsl
-			wc.ui.dialog.xsl
-			wc.ui.multiFormComponent.xsl
-			wc.ui.panel.xsl
-			wc.ui.tab.xsl
-
-		param live default "polite"
-		The verbosity level to set. See http://www.w3.org/TR/wai-aria/states_and_properties
-		aria-live guidelines for potential values.
+		This helper template sets attribute aria-label on many components and must never be excluded.
 	-->
 	<xsl:template name="ariaLabel">
 		<xsl:if test="@accessibleText">

--- a/wcomponents-theme/src/main/xslt/wc.common.makeLegend.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.makeLegend.xsl
@@ -10,23 +10,12 @@
 		WMultiTextField
 		WRadioButtonSelect
 
-	Creates a legend element. If the component has a WLabel associated with it then
-	the legend is created by the transform for that WLabel using the explicit param.
+	Creates a legend element. If the component has a WLabel associated with it then the legend is created by the 
+	transform for that WLabel using the explicit param. If the component does not have a WLabel then its legend is
+	populated using a text equivalent fallback @accessibleText or @toolTip.
 
-	Otherwise a legend element is created and populated as follows:
-
-		1 if the element has its accessibleText property set then the legend uses
-		this text as its content and is moved out of viewport; otherwise
-
-		2 the legend has the default label text as its content and is left on
-		screen as this is an error state for WComponents as it contravenes our
-		attempts to implement accessibility guidelines. Whilst a fieldset is not a
-		labellable element it does require a legend (in HTML5) and the most
-		appropriate means to create a legend is by using a WLabel.
-
-	param myLabel: the WLabel "for" the calling component, if any. This will have already
-	been determined before calling this template so we do not have to re-interrogate the
-	label key.
+	param myLabel: the WLabel "for" the calling component, if any. This will have already been determined before calling
+	this template so we do not have to re-interrogate the label key.
 -->
 	<xsl:template name="makeLegend">
 		<xsl:param name="myLabel"/>
@@ -36,17 +25,17 @@
 					<xsl:with-param name="labelableElement" select="."/>
 				</xsl:apply-templates>
 			</xsl:when>
-			<xsl:when test="@toolTip">
-				<xsl:call-template name="makeTextLegend">
-					<xsl:with-param name="content">
-						<xsl:value-of select="normalize-space(@toolTip)"/>
-					</xsl:with-param>
-				</xsl:call-template>
-			</xsl:when>
 			<xsl:when test="@accessibleText">
 				<xsl:call-template name="makeTextLegend">
 					<xsl:with-param name="content">
 						<xsl:value-of select="normalize-space(@accessibleText)"/>
+					</xsl:with-param>
+				</xsl:call-template>
+			</xsl:when>
+			<xsl:when test="@toolTip">
+				<xsl:call-template name="makeTextLegend">
+					<xsl:with-param name="content">
+						<xsl:value-of select="normalize-space(@toolTip)"/>
 					</xsl:with-param>
 				</xsl:call-template>
 			</xsl:when>

--- a/wcomponents-theme/src/main/xslt/wc.common.missingLabel.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.missingLabel.xsl
@@ -3,13 +3,7 @@
 		A labelable component must be associated with one of:
 			WLabel
 			toolTip
-			accessibleText (deprecated in favour of toolTip)
-
-		If the component does not have a label or toolTip and is not part of
-		an ajaxResponse then we test for the presence of the accessibleText
-		attribute If this attribute is set we use it to create a label for the
-		component. If the accessibleText attribute is not set then a placeholder
-		warning label will be created if the component.
+			accessibleText
 
 		param id:
 		The component id, defaults to @id


### PR DESCRIPTION
Remove deprecation tag on accessibleText. This should have been removed when #374 was closed as invalid.