### PR TITLE
Responsive tables, bug fixes

### DIFF
--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/table/ExampleDataUtil.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/table/ExampleDataUtil.java
@@ -34,18 +34,18 @@ public final class ExampleDataUtil {
 		data.add(new PersonBean("ID1", "Joe", "Bloggs", DateUtilities.createDate(1, 2, 1973)));
 		data.add(new PersonBean("ID2", "Richard", "Starkey", DateUtilities.createDate(4, 8, 1976)));
 		data.add(new PersonBean("ID3", "Peter", "Sellers", DateUtilities.createDate(21, 12, 1999)));
-		data.add(new PersonBean("ID4", "Tom", "Smith", DateUtilities.createDate(16, 9, 1963)));
+		data.add(new PersonBean("ID4", "Tom", "Smith", DateUtilities.createDate(16, 9, 1963), false));
 		data.add(new PersonBean("ID5", "Mary", "Jane", DateUtilities.createDate(2, 4, 1972)));
 		data.add(new PersonBean("ID6", "John", "Bonham", DateUtilities.createDate(5, 3, 1952)));
 		data.add(new PersonBean("ID7", "Nick", "Mason", DateUtilities.createDate(3, 5, 1946)));
-		data.add(new PersonBean("ID8", "James", "Osterberg", DateUtilities.createDate(4, 6, 1974)));
+		data.add(new PersonBean("ID8", "James", "Osterberg", DateUtilities.createDate(4, 6, 1974), false));
 		data.add(new PersonBean("ID9", "Kate", "Pierson", DateUtilities.createDate(7, 11, 1965)));
 		data.add(new PersonBean("ID10", "Saul", "Hudson", DateUtilities.createDate(5, 3, 1978)));
 		data.add(new PersonBean("ID11", "Kim", "Sung", DateUtilities.createDate(1, 10, 1945)));
 		data.add(new PersonBean("ID12", "Ahmed", "McCarthur", DateUtilities.createDate(15, 7, 1985)));
 		data.add(new PersonBean("ID13", "Nicholai", "Smith", DateUtilities.createDate(29, 4, 1996)));
 		data.add(new PersonBean("ID14", "Polly", "Vinyl", DateUtilities.createDate(15, 8, 1978)));
-		data.add(new PersonBean("ID15", "Ron", "Donald", DateUtilities.createDate(1, 1, 1923)));
+		data.add(new PersonBean("ID15", "Ron", "Donald", DateUtilities.createDate(1, 1, 1923), false));
 		data.add(new PersonBean("ID16", "Tom", "Smith", DateUtilities.createDate(5, 8, 1932)));
 
 		// Add documents

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/table/PersonBean.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/table/PersonBean.java
@@ -44,7 +44,12 @@ public final class PersonBean implements Serializable {
 	private List<TravelDoc> documents;
 
 	/**
-	 * Creates a PersonBean.
+	 * Is this item selectable when selection is on?
+	 */
+	private boolean selectable;
+
+	/**
+	 * Creates a selectable PersonBean.
 	 *
 	 * @param personId the person's unique id
 	 * @param firstName the person's first name.
@@ -53,10 +58,25 @@ public final class PersonBean implements Serializable {
 	 */
 	public PersonBean(final String personId, final String firstName, final String lastName,
 			final Date dateOfBirth) {
+		this(personId, firstName, lastName, dateOfBirth, true);
+	}
+
+	/**
+	 * Creates a PersonBean.
+	 *
+	 * @param personId the person's unique id
+	 * @param firstName the person's first name.
+	 * @param lastName the person's last name.
+	 * @param dateOfBirth the person's date of birth.
+	 * @param selectable the person is selectable.
+	 */
+	public PersonBean(final String personId, final String firstName, final String lastName,
+			final Date dateOfBirth, final boolean selectable) {
 		this.personId = personId;
 		this.firstName = firstName;
 		this.lastName = lastName;
 		this.dateOfBirth = dateOfBirth;
+		this.selectable = selectable;
 	}
 
 	/**
@@ -106,6 +126,20 @@ public final class PersonBean implements Serializable {
 	 */
 	public void setDateOfBirth(final Date dateOfBirth) {
 		this.dateOfBirth = dateOfBirth;
+	}
+
+	/**
+	 * @return true if the person is selectable.
+	 */
+	public boolean isSelectable() {
+		return selectable;
+	}
+
+	/**
+	 * @param selectable Indicates if this person may be selected.
+	 */
+	public void setSelectable(final boolean selectable) {
+		this.selectable = selectable;
 	}
 
 	/**

--- a/wcomponents-theme/src/main/js/wc/ui/menu/menuItem.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/menuItem.js
@@ -7,15 +7,13 @@
  * @requires module:wc/dom/initialise
  * @requires module:wc/dom/Widget"
  * @requires module:wc/dom/isAcceptableTarget
- * @requires module:wc/dom/shed
  */
 define(["wc/dom/ariaAnalog",
 		"wc/dom/initialise",
 		"wc/dom/Widget",
-		"wc/dom/isAcceptableTarget",
-		"wc/dom/shed"],
-	/** @param ariaAnalog wc/dom/ariaAnalog @param initialise wc/dom/initialise @param Widget wc/dom/Widget @param isAcceptableEventTarget wc/dom/isAcceptableTarget @param shed wc/dom/shed @ignore */
-	function(ariaAnalog, initialise, Widget, isAcceptableEventTarget, shed) {
+		"wc/dom/isAcceptableTarget"],
+	/** @param ariaAnalog @param initialise @param Widget @param isAcceptableEventTarget @ignore */
+	function(ariaAnalog, initialise, Widget, isAcceptableEventTarget) {
 		"use strict";
 
 		var opener;
@@ -35,7 +33,7 @@ define(["wc/dom/ariaAnalog",
 			 */
 			function clickEventHelper($event, instance) {
 				var target = $event.target, element;
-				if (!$event.defaultPrevented && (element = instance.getActivableFromTarget(target)) && !shed.isDisabled(element)) {
+				if (!$event.defaultPrevented && (element = instance.getActivableFromTarget(target))) {
 					opener = opener || new Widget("button", "wc-submenu-o");
 					/* a menu item (checkbox|radio) can be toggled if it is itself an acceptable element OR
 					 * if the click event is on a branch opener button, which would normally render the menu

--- a/wcomponents-theme/src/main/js/wc/ui/menu/treeItem.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/treeItem.js
@@ -200,7 +200,7 @@ define(["wc/dom/ariaAnalog",
 			 */
 			this.clickEvent = function($event) {
 				var target = $event.target, element;
-				if (!$event.defaultPrevented && (element = this.getActivableFromTarget(target)) && !shed.isDisabled(element)) {
+				if (!$event.defaultPrevented && (element = this.getActivableFromTarget(target))) {
 					if (isAcceptable(element, target)) {
 						this.activate(element, $event.shiftKey, ($event.ctrlKey || $event.metaKey));
 					}

--- a/wcomponents-theme/src/main/sass/_colors.scss
+++ b/wcomponents-theme/src/main/sass/_colors.scss
@@ -34,6 +34,10 @@ $wc-ui-color-invite-fg: $std-color-invite-fg !default;
 // where translucent invites are acceptable (eg table rows)
 $wc-ui-color-invite-bg-rgba: $std-color-invite-bg-rgba !default;
 
+// Generic selected
+$wc-ui-color-selected-bg: $std-color-selected-bg !default;
+$wc-ui-color-selected-fg: $std-color-selected-fg !default;
+
 // links and headings
 $wc-ui-color-link: $std-color-primary !default;
 $wc-ui-color-link-visited: $std-color-secondary !default;

--- a/wcomponents-theme/src/main/sass/_colorscheme.scss
+++ b/wcomponents-theme/src/main/sass/_colorscheme.scss
@@ -17,7 +17,7 @@ $std-color-tertiary: #f3f3f3 !default;
 // Main colour accents are used as background/foreground combo (or vice versa) and must meet 4.5:1 contrast ratio with
 // the main colour definitions above
 $std-color-primary-accent: $std-color-white !default;
-$std-color-secondary-accent:$std-color-white !default;
+$std-color-secondary-accent: $std-color-white !default;
 $std-color-tertiary-accent: $std-color-primary !default;
 
 // Transient and specific purpose accents
@@ -27,6 +27,10 @@ $std-color-invite-bg: #bbd6ff !default;
 $std-color-invite-fg: $std-color-black !default;
 // Table row focus must be translucent with alpha no greater than 0.5.
 $std-color-invite-bg-rgba: rgba(204, 229, 255, 0.5) !default;
+
+// Selected containers and aria analogs
+$std-color-selected-bg: #6a6a6a !default;
+$std-color-selected-fg: #fafafa !default;
 //
 // Background highlighting accents (not focus/hover) such as zebra striping.
 $std-color-highlight-bg: #f2f2f2 !default;

--- a/wcomponents-theme/src/main/sass/_table_vars.scss
+++ b/wcomponents-theme/src/main/sass/_table_vars.scss
@@ -13,4 +13,5 @@ $table-cell-padding-left-right: $wc-gap-small !default;
 $table-cell-padding: $table-cell-padding-top-bottom !default;
 
 // the amount of the indent for hierarchic tables
-$table-hierarchic-indent: 1rem !default;
+$table-hierarchic-indent: $wc-gap-large !default;
+$table-hierarchic-indent-small: $wc-gap-normal !default;

--- a/wcomponents-theme/src/main/sass/wc.common.page.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.page.scss
@@ -50,7 +50,6 @@ pre {
 	zoom: 1;
 }
 
-
 @include respond-med-device {
 	body {
 		font-size: $dt-font-size;

--- a/wcomponents-theme/src/main/sass/wc.common.rowColumn.ie10.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.rowColumn.ie10.scss
@@ -2,5 +2,6 @@
 @import 'mixins-common';
 
 .wc-column {
+	display: inline-block; // with implied width auto
 	vertical-align: top;
 }

--- a/wcomponents-theme/src/main/sass/wc.common.rowColumn.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.rowColumn.scss
@@ -4,15 +4,10 @@
 
 .wc-row {
 	@include flex;
-
-	.wc_chkgrp & {
-		@include flex-justify-content(space-between);
-	}
 }
 
 .wc-column {
 	@include border-box;
-	// display: inline-block; // with implied width auto I think this is needed for IE 11 but cannot be loaded later
 }
 
 @for $i from 2 through 100 {

--- a/wcomponents-theme/src/main/sass/wc.ui.label.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.label.scss
@@ -10,6 +10,7 @@
 [type='radio'] + label,
 [type='checkbox'] + label,
 .wc_ro + .wc-label {
+	display: inline; // .wc-label's inline-block can cause the label to fall under the input when there is not enough room for the label
 	margin-left: $wc-gap-small;
 }
 

--- a/wcomponents-theme/src/main/sass/wc.ui.table.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.color.scss
@@ -33,3 +33,21 @@ tr.wc_invite {
 		background-color: $wc-ui-color-disabled-bg;
 	}
 }
+
+@include respond-phone {
+	.wc-table.wc-respond {
+		tr[aria-selected='true'] {
+			&,
+			&.wc_invite:hover,
+			&.wc_invite:focus {
+				background-color: $wc-ui-color-selected-bg;
+			}
+
+			> th,
+			> td {
+				color: $wc-ui-color-selected-fg;
+				// WARNING: you _may_ want to add overrides for coloured elements eg, headings.
+			}
+		}
+	}
+}

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansion.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansion.scss
@@ -7,28 +7,11 @@
 }
 
 // The next lot does indentation of "child" rows when the table type is 'heirarchic'
-.wc_table_rowexp_container {
-	+ td,
-	+ th {
-		.wc_tbl_hierarchic > tr[aria-level='2'] > & {
-			padding-left: $table-cell-padding-left-right + $table-hierarchic-indent;
+@for $i from 2 to 6 {
+	.wc_tbl_hierarchic > [aria-level='#{$i}'] > .wc_table_rowexp_container {
+		+ td,
+		+ th {
+			padding-left: ($i - 1) * $table-hierarchic-indent;
 		}
-
-		.wc_tbl_hierarchic > tr[aria-level='3'] > & {
-			padding-left: $table-cell-padding-left-right + (2 * $table-hierarchic-indent);
-		}
-
-		.wc_tbl_hierarchic > tr[aria-level='4'] > & {
-			padding-left: $table-cell-padding-left-right + (3 * $table-hierarchic-indent);
-		}
-
-		.wc_tbl_hierarchic > tr[aria-level='5'] > & {
-			padding-left: $table-cell-padding-left-right + (4 * $table-hierarchic-indent);
-		}
-
-		.wc_tbl_hierarchic > tr[aria-level='6'] > & {
-			padding-left: $table-cell-padding-left-right + (5 * $table-hierarchic-indent);
-		}
-		// Want more? add 'em yourself!
 	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.table.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.scss
@@ -2,7 +2,6 @@
 // This is the core of the table CSS. The other CSS files are used for functional images and other items which are less
 // likely to be implementation specific
 @import 'table_vars';
-@import 'mixins-common';
 
 table {
 	@include border;
@@ -38,4 +37,67 @@ th.wc_table_sel_wrapper { // reset the vertical alignment of th with these class
 
 .wc_table_colauto {
 	width: 0.5rem; // actually anything small but more than zero.
+}
+
+@include respond-phone {
+	.wc-respond > table {
+		&,
+		caption,
+		thead,
+		tfoot,
+		tbody,
+		tr,
+		th,
+		td {
+			@include border-box;
+			display: block;
+			width: 100%;
+		}
+
+		caption {
+			padding: $wc-gap-small 0;
+		}
+
+		tr {
+			+ tr[aria-level='1'],
+			+ tr:not([aria-level]) {
+				margin-top: $wc-gap-small;
+			}
+		}
+
+		th,
+		td {
+			padding: $wc-gap-small;
+		}
+
+		.wc_table_sel_wrapper,
+		.wc_table_rowexp_container {
+			display: none;
+		}
+
+		.wc_table_rowexp_container[role='button'] {
+			display: inline-block;
+			padding: $wc-gap-small 0;
+			width: auto;
+
+			+ .wc-th,
+			+ .wc-td {
+				display: inline-block;
+				padding-left: 0;
+				width: calc(100% - 1rem);
+			}
+		}
+
+		@for $i from 2 to 6 {
+			.wc_tbl_hierarchic > [aria-level='#{$i}'] {
+				padding-left: $i * $table-hierarchic-indent-small;
+
+
+				> th,
+				> td {
+					padding-left: 0; // override all the guff in the main CSS
+				}
+			}
+		}
+	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.table.topControls.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.topControls.scss
@@ -23,22 +23,19 @@
 	}
 }
 
-@include respond-phonelike {
-	.wc_table_top_controls {
-		display: block;
+@include respond-phone {
+	.wc-respond {
+		> .wc_table_top_controls {
+			@include flex-direction(column);
 
-		> div {
-			display: block;
-			text-align: left;
-			width: 100%;
+			> div {
+				@include flex-shrink(1);
 
-			+ div {
-				margin-top: $wc-gap-small;
+				&:last-child {
+					@include flex-justify-content(flex-start);
+					text-align: left;
+				}
 			}
-		}
-
-		> .wc_table_exp_cont {
-			text-align: left;
 		}
 	}
 }

--- a/wcomponents-theme/src/main/xslt/wc.common.checkableSelect.n.checkableSelectOption.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.checkableSelect.n.checkableSelectOption.xsl
@@ -4,6 +4,7 @@
 	<xsl:import href="wc.common.disabledElement.xsl"/>
 	<xsl:import href="wc.common.required.xsl"/>
 	<xsl:import href="wc.common.checkableSelect.n.checkableSelectOptionLabel.xsl"/>
+	<xsl:import href="wc.common.n.className.xsl"/>
 
 	<!--
 		This template transforms the content of an option to a list item and the
@@ -54,6 +55,7 @@
 			</xsl:choose>
 		</xsl:variable>
 		<xsl:element name="{$elementName}">
+			<xsl:call-template name="makeCommonClass"/>
 			<xsl:choose>
 				<xsl:when test="$readOnly=1">
 					<xsl:call-template name="checkableSelectOptionLabel"/>

--- a/wcomponents-theme/src/main/xslt/wc.common.checkableSelect.option.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.checkableSelect.option.xsl
@@ -58,16 +58,20 @@
 				</xsl:otherwise>
 			</xsl:choose>
 		</xsl:variable>
+		<xsl:variable name="class">
+			<xsl:if test="$layout = 'column'">
+				<xsl:text>wc-column</xsl:text>
+			</xsl:if>
+			<xsl:if test="$elementName='ul'">
+				<xsl:text> wc_list_nb</xsl:text>
+			</xsl:if>
+		</xsl:variable>
 		<xsl:element name="{$elementName}">
-			<xsl:attribute name="class">
-				<xsl:value-of select="$layout"/>
-				<xsl:if test="$layout = 'column'">
-					<xsl:text> wc-column</xsl:text>
-				</xsl:if>
-				<xsl:if test="$elementName='ul'">
-					<xsl:text> wc_list_nb</xsl:text>
-				</xsl:if>
-			</xsl:attribute>
+			<xsl:if test="$class != ''">
+				<xsl:attribute name="class">
+					<xsl:value-of select="normalize-space($class)"/>
+				</xsl:attribute>
+			</xsl:if>
 			<xsl:call-template name="checkableSelectOption">
 				<xsl:with-param name="optionName" select="$inputName"/>
 				<xsl:with-param name="optionType" select="$type"/>

--- a/wcomponents-theme/src/main/xslt/wc.common.selectToggle.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.selectToggle.xsl
@@ -206,6 +206,22 @@
 				</span>
 			</xsl:when>
 			<xsl:otherwise>
+				<xsl:variable name="textEquivalent">
+					<xsl:choose>
+						<xsl:when test="$label!=''">
+							<xsl:value-of select="$label"/>
+						</xsl:when>
+						<xsl:when test="self::ui:rowselection">
+							<xsl:value-of select="$$${wc.common.toggles.i18n.selectAll.a11y}"/>
+						</xsl:when>
+						<xsl:when test="$myLabel">
+							<xsl:apply-templates select="$myLabel" mode="selectToggle"/>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:value-of select="$$${wc.common.toggles.i18n.selectAll.a11y}"/>
+						</xsl:otherwise>
+					</xsl:choose>
+				</xsl:variable>
 				<button id="{$toggleId}" role="checkbox" aria-controls="{$targetList}">
 					<xsl:attribute name="type">
 						<xsl:choose>
@@ -250,22 +266,11 @@
 							<xsl:text>wc_seltog wc_btn_nada</xsl:text>
 						</xsl:with-param>
 					</xsl:call-template>
-					<xsl:attribute name="title">
-						<xsl:choose>
-							<xsl:when test="$label!=''">
-								<xsl:value-of select="$label"/>
-							</xsl:when>
-							<xsl:when test="self::ui:rowselection">
-								<xsl:value-of select="$$${wc.common.toggles.i18n.selectAll.a11y}"/>
-							</xsl:when>
-							<xsl:when test="$myLabel">
-								<xsl:apply-templates select="$myLabel" mode="selectToggle"/>
-							</xsl:when>
-							<xsl:otherwise>
-								<xsl:value-of select="$$${wc.common.toggles.i18n.selectAll.a11y}"/>
-							</xsl:otherwise>
-						</xsl:choose>
-					</xsl:attribute>
+					<xsl:if test="self::ui:selecttoggle">
+						<xsl:attribute name="title">
+							<xsl:value-of select="$textEquivalent"/>
+						</xsl:attribute>
+					</xsl:if>
 					<xsl:choose>
 						<xsl:when test="self::ui:selecttoggle">
 							<xsl:call-template name="disabledElement">
@@ -283,6 +288,12 @@
 						<xsl:attribute name="data-wc-cbgroup">
 							<xsl:value-of select="$thisGroupName"/>
 						</xsl:attribute>
+					</xsl:if>
+					<!-- ADDING TEXT CONTENT - NO MORE ATTRIBUTES AFTER THIS COMMENT -->
+					<xsl:if test="self::ui:rowselection">
+						<span>
+							<xsl:value-of select="$textEquivalent"/>
+						</span>
 					</xsl:if>
 				</button>
 			</xsl:otherwise>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.n.topControls.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.n.topControls.xsl
@@ -19,7 +19,7 @@
 		
 		<xsl:variable name="hasRowSelection">
 			<xsl:choose>
-				<xsl:when test="ui:rowselection[@selectAll='text'] and ..//ui:tr[not(@unselectable=$t) and ancestor::ui:table[1]/@id=$id]">
+				<xsl:when test="ui:rowselection[@selectAll] and ..//ui:tr[not(@unselectable=$t) and ancestor::ui:table[1]/@id=$id]">
 					<xsl:number value="1"/>
 				</xsl:when>
 				<xsl:otherwise>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.subTr.content.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.subTr.content.xsl
@@ -34,7 +34,7 @@
 				selection.
 			-->
 			<xsl:if test="$myTable/ui:rowselection">
-				<td role="gridcell">
+				<td class="wc_table_sel_wrapper" role="gridcell">
 					<xsl:text>&#x2002;</xsl:text>
 				</td>
 			</xsl:if>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.tbody.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.tbody.xsl
@@ -1,4 +1,6 @@
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" 
+	xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
 	<xsl:import href="wc.constants.xsl"/>
 	<xsl:import href="wc.common.n.className.xsl"/>
 

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.thead.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.thead.xsl
@@ -15,21 +15,8 @@
 					</xsl:attribute>
 				</xsl:if>
 				<xsl:if test="../ui:rowselection">
-					<th class="wc_table_sel_wrapper" scope="col">
-						<xsl:if test="$hasRole &gt; 0">
-							<xsl:attribute name="role">
-								<xsl:text>columnheader</xsl:text>
-							</xsl:attribute>
-						</xsl:if>
-						<xsl:choose>
-							<xsl:when test="../ui:rowselection/@selectAll = 'control'">
-								<xsl:apply-templates select="../ui:rowselection"/>
-							</xsl:when>
-							<xsl:otherwise>
-								<xsl:attribute name="aria-hidden">true</xsl:attribute>
-								<xsl:text>&#xa0;</xsl:text>
-							</xsl:otherwise>
-						</xsl:choose>
+					<th class="wc_table_sel_wrapper" scope="col" aria-hidden="true">
+						<xsl:text>&#xa0;</xsl:text>
 					</th>
 				</xsl:if>
 				<xsl:if test="../ui:rowexpansion">


### PR DESCRIPTION
* Added Sass to provide initial implementation of responsive tables. I have chosen to key this off of a custom class applied to WTable rather than to all tables by default. The class is `wc-respond`. Fixes #671.
* Fixed errors in list of ignored roles in ariaAnalog which could result in false negatives in determining the nearest active ARIA widget. Fixes #670.
* Updated CSS which could cause some labels to fall under their control on narrow views such that a WLabel for a WCheckBox or WRadioButton will now. Fixes #672
* Removed unused unconventional class attribute value from WCheckBoxSelect/WRadioButtonSelect option lists as part of #651.