### PR TITLE
Tab accessibility fix #692

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,11 @@
   * Added constructor `WList(final Type type, final int gap)` and deprecated constructor `WList(final Type type,
     final int hgap, final int vgap)` in favour of the new constructor.
   * Deprecated `getHGap()` and `getVGap()` in favour of `getGap()`.
+* WTab updated setMode(TabMode) to set TabMode.DYNAMIC if the mode being set is TabMode.SERVER. This is required for
+  fixing a11y problems in TabMode.SERVER as per #692.
 
 ## Bug Fixes
+* Fixed accessibility problems in tabsets #692.
 * Fixed a bug which prevented themes overriding font sizes and gaps in any unit other than rems #685.
 * Ensure missing label warning is in viewport #681.
 * Various table bugs fixed #666, #667, #670.

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTab.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTab.java
@@ -111,10 +111,11 @@ public class WTab extends AbstractNamingContextContainer implements Disableable,
 	}
 
 	/**
+	 * @see https://github.com/BorderTech/wcomponents/issues/692
 	 * @param mode the tab mode.
 	 */
 	public void setMode(final TabMode mode) {
-		getOrCreateComponentModel().mode = mode;
+		getOrCreateComponentModel().mode = mode == TabMode.SERVER ? TabMode.DYNAMIC : mode;
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
@@ -62,7 +62,8 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 		 */
 		ACCORDION,
 		/**
-		 * A styled version of the Left TabSet, where tabs do not contain any content.
+		 * An undefined tabset determined per theme.
+		 * @deprecated 1.2.0
 		 */
 		APPLICATION
 	};
@@ -74,7 +75,7 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 */
 	public enum TabMode {
 		/**
-		 * Indicates that a round-trip should be made whenever the tab is selected.
+		 * Synonym for DYNAMIC.
 		 *
 		 * @deprecated Use TabMode DYNAMIC instead as a like-for-like replacement or any other mode if it is more
 		 * appropriate to the individual use case.
@@ -115,12 +116,13 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 */
 	public static final TabSetType TYPE_ACCORDION = TabSetType.ACCORDION;
 	/**
-	 * An "application" type tab-set, that supports having multiple open tabs.
+	 * An "application" type tab-set, defined only in a theme.
+	 * @deprecated 1.2.0
 	 */
 	public static final TabSetType TYPE_APPLICATION = TabSetType.APPLICATION;
 
 	/**
-	 * A tab mode where invoking the tab will always perform a round-trip to the server.
+	 * A synonym for TabMode.TAB_MODE_DYNAMIC.
 	 *
 	 * @deprecated Use TAB_MODE_DYNAMIC instead as a like-for-like replacement or any other mode if it is more
 	 * appropriate to the individual use case.

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WTabSet_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WTabSet_Test.java
@@ -34,13 +34,13 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 		WComponent tab2 = new WLabel();
 		WComponent tab3 = new WLabel();
 
-		tabset.addTab(tab1, "tab1", WTabSet.TAB_MODE_SERVER);
-		tabset.addTab(tab2, "tab2", WTabSet.TAB_MODE_SERVER);
+		tabset.addTab(tab1, "tab1", WTabSet.TAB_MODE_DYNAMIC);
+		tabset.addTab(tab2, "tab2", WTabSet.TAB_MODE_DYNAMIC);
 
 		// dynamically add tab3
 		tabset.setLocked(true);
 		setActiveContext(createUIContext());
-		tabset.addTab(tab3, "tab3", WTabSet.TAB_MODE_SERVER);
+		tabset.addTab(tab3, "tab3", WTabSet.TAB_MODE_DYNAMIC);
 
 		Assert.assertEquals("Incorrect number of tabs", 3, tabset.getTotalTabs());
 		Assert.assertEquals("Incorrect static tab index for 1st tab", 0, tabset.getTabIndex(tab1));
@@ -62,18 +62,18 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 		WComponent tab4 = new WLabel();
 		WComponent tab5 = new WLabel();
 
-		tabset.addTab(tab1, "tab1", WTabSet.TAB_MODE_SERVER);
-		tabset.addTab(tab2, "tab2", WTabSet.TAB_MODE_SERVER);
+		tabset.addTab(tab1, "tab1", WTabSet.TAB_MODE_DYNAMIC);
+		tabset.addTab(tab2, "tab2", WTabSet.TAB_MODE_DYNAMIC);
 
 		WTabGroup group = new WTabGroup("Group");
-		group.addTab(tab3, "tab3", WTabSet.TAB_MODE_SERVER);
-		group.addTab(tab4, "tab4", WTabSet.TAB_MODE_SERVER);
+		group.addTab(tab3, "tab3", WTabSet.TAB_MODE_DYNAMIC);
+		group.addTab(tab4, "tab4", WTabSet.TAB_MODE_DYNAMIC);
 		tabset.add(group);
 
 		// Dynamically add tab5
 		tabset.setLocked(true);
 		setActiveContext(createUIContext());
-		tabset.addTab(tab5, "tab5", WTabSet.TAB_MODE_SERVER);
+		tabset.addTab(tab5, "tab5", WTabSet.TAB_MODE_DYNAMIC);
 
 		Assert.assertEquals("Incorrect number of tabs", 5, tabset.getTotalTabs());
 		Assert.assertEquals("Incorrect tab index for 1st tab", 0, tabset.getTabIndex(tab1));
@@ -91,13 +91,13 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 	public void testGetTabByIndex() {
 		WTabSet tabset = new WTabSet();
 
-		WTab tab1 = tabset.addTab(new WLabel(), "tab1", WTabSet.TAB_MODE_SERVER);
-		WTab tab2 = tabset.addTab(new WLabel(), "tab2", WTabSet.TAB_MODE_SERVER);
+		WTab tab1 = tabset.addTab(new WLabel(), "tab1", WTabSet.TAB_MODE_DYNAMIC);
+		WTab tab2 = tabset.addTab(new WLabel(), "tab2", WTabSet.TAB_MODE_DYNAMIC);
 
 		// Dynamically add tab3
 		tabset.setLocked(true);
 		setActiveContext(createUIContext());
-		WTab tab3 = tabset.addTab(new WLabel(), "tab3", WTabSet.TAB_MODE_SERVER);
+		WTab tab3 = tabset.addTab(new WLabel(), "tab3", WTabSet.TAB_MODE_DYNAMIC);
 
 		Assert.assertEquals("Incorrect number of tabs", 3, tabset.getTotalTabs());
 		Assert.assertEquals("Incorrect 1st tab", tab1, tabset.getTab(0));
@@ -112,11 +112,11 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 	public void testGetTabByIndexWithTabGroup() {
 		WTabSet tabset = new WTabSet();
 
-		WTab tab1 = new WTab(new WLabel(), "tab1", WTabSet.TAB_MODE_SERVER);
-		WTab tab2 = new WTab(new WLabel(), "tab2", WTabSet.TAB_MODE_SERVER);
-		WTab tab3 = new WTab(new WLabel(), "tab3", WTabSet.TAB_MODE_SERVER);
-		WTab tab4 = new WTab(new WLabel(), "tab4", WTabSet.TAB_MODE_SERVER);
-		WTab tab5 = new WTab(new WLabel(), "tab5", WTabSet.TAB_MODE_SERVER);
+		WTab tab1 = new WTab(new WLabel(), "tab1", WTabSet.TAB_MODE_DYNAMIC);
+		WTab tab2 = new WTab(new WLabel(), "tab2", WTabSet.TAB_MODE_DYNAMIC);
+		WTab tab3 = new WTab(new WLabel(), "tab3", WTabSet.TAB_MODE_DYNAMIC);
+		WTab tab4 = new WTab(new WLabel(), "tab4", WTabSet.TAB_MODE_DYNAMIC);
+		WTab tab5 = new WTab(new WLabel(), "tab5", WTabSet.TAB_MODE_DYNAMIC);
 
 		tabset.add(tab1);
 		tabset.add(tab2);
@@ -149,9 +149,9 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 		WComponent tab2 = new WLabel("label2");
 		WComponent tab3 = new WLabel("label3");
 
-		tabset.addTab(tab1, "tab1", WTabSet.TAB_MODE_SERVER);
-		tabset.addTab(tab2, "tab2", WTabSet.TAB_MODE_SERVER);
-		tabset.addTab(tab3, "tab3", WTabSet.TAB_MODE_SERVER);
+		tabset.addTab(tab1, "tab1", WTabSet.TAB_MODE_DYNAMIC);
+		tabset.addTab(tab2, "tab2", WTabSet.TAB_MODE_DYNAMIC);
+		tabset.addTab(tab3, "tab3", WTabSet.TAB_MODE_DYNAMIC);
 
 		tabset.setLocked(true);
 		setActiveContext(createUIContext());
@@ -171,9 +171,9 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 	@Test
 	public void testActiveIndexAccessors() {
 		WTabSet tabset = new WTabSet();
-		tabset.addTab(new WLabel("tab1"), "tab1", WTabSet.TAB_MODE_SERVER);
-		tabset.addTab(new WLabel("tab2"), "tab2", WTabSet.TAB_MODE_SERVER);
-		tabset.addTab(new WLabel("tab3"), "tab3", WTabSet.TAB_MODE_SERVER);
+		tabset.addTab(new WLabel("tab1"), "tab1", WTabSet.TAB_MODE_DYNAMIC);
+		tabset.addTab(new WLabel("tab2"), "tab2", WTabSet.TAB_MODE_DYNAMIC);
+		tabset.addTab(new WLabel("tab3"), "tab3", WTabSet.TAB_MODE_DYNAMIC);
 
 		assertAccessorsCorrect(tabset, "activeIndex", 0, 1, 2);
 	}
@@ -186,8 +186,8 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 	@Test
 	public void testSetTabVisible() {
 		WTabSet tabset = new WTabSet();
-		tabset.addTab(new WLabel("tab1"), "tab1", WTabSet.TAB_MODE_SERVER);
-		tabset.addTab(new WLabel("tab2"), "tab2", WTabSet.TAB_MODE_SERVER);
+		tabset.addTab(new WLabel("tab1"), "tab1", WTabSet.TAB_MODE_DYNAMIC);
+		tabset.addTab(new WLabel("tab2"), "tab2", WTabSet.TAB_MODE_DYNAMIC);
 
 		Assert.assertTrue("Tab should be visible by default", tabset.isTabVisible(0));
 		Assert.assertTrue("Tab should be visible by default", tabset.isTabVisible(1));
@@ -212,8 +212,8 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 	@Test
 	public void testHandleRequest() {
 		WTabSet tabset = new WTabSet();
-		tabset.addTab(new WLabel("tab1"), "tab1", WTabSet.TAB_MODE_SERVER);
-		tabset.addTab(new WLabel("tab2"), "tab2", WTabSet.TAB_MODE_SERVER);
+		tabset.addTab(new WLabel("tab1"), "tab1", WTabSet.TAB_MODE_DYNAMIC);
+		tabset.addTab(new WLabel("tab2"), "tab2", WTabSet.TAB_MODE_DYNAMIC);
 		tabset.addTab(new WLabel("tab3"), "tab3", WTabSet.TAB_MODE_CLIENT);
 
 		tabset.setLocked(true);
@@ -256,15 +256,15 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 
 	@Test
 	public void testHandleRequestWithInvisibleTabAndTabGroup() {
-		WTabSet tabset = new WTabSet(WTabSet.TabSetType.APPLICATION);
-		tabset.addTab(new WLabel("tab1"), "tab1", WTabSet.TAB_MODE_SERVER);
+		WTabSet tabset = new WTabSet(WTabSet.TabSetType.TOP);
+		tabset.addTab(new WLabel("tab1"), "tab1", WTabSet.TAB_MODE_DYNAMIC);
 		WTabGroup group = new WTabGroup("group1");
-		group.addTab(new WLabel("tab2"), "tab2", WTabSet.TAB_MODE_SERVER);
+		group.addTab(new WLabel("tab2"), "tab2", WTabSet.TAB_MODE_DYNAMIC);
 		group.addTab(new WLabel("tab3"), "tab3", WTabSet.TAB_MODE_CLIENT);
 		group.addTab(new WLabel("tab4"), "tab4", WTabSet.TAB_MODE_CLIENT);
 		group.addTab(new WLabel("tab5"), "tab5", WTabSet.TAB_MODE_CLIENT);
 		tabset.add(group);
-		tabset.addTab(new WLabel("tab6"), "tab6", WTabSet.TAB_MODE_SERVER);
+		tabset.addTab(new WLabel("tab6"), "tab6", WTabSet.TAB_MODE_DYNAMIC);
 
 		// Make tab5 not visible
 		tabset.setTabVisible(4, false);
@@ -308,7 +308,7 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 		// Tab1 - Content, String label, mode
 		WComponent content1 = new DefaultWComponent();
 		String label1 = "label1";
-		WTabSet.TabMode mode1 = WTabSet.TabMode.SERVER;
+		WTabSet.TabMode mode1 = WTabSet.TabMode.DYNAMIC;
 		tabset.addTab(content1, label1, mode1);
 
 		Assert.
@@ -322,7 +322,7 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 		// Tab2 - Content, String label, mode, accessKey
 		WComponent content2 = new DefaultWComponent();
 		String label2 = "label2";
-		WTabSet.TabMode mode2 = WTabSet.TabMode.SERVER;
+		WTabSet.TabMode mode2 = WTabSet.TabMode.DYNAMIC;
 		char accessKey2 = 'X';
 		tabset.addTab(content2, label2, mode2, accessKey2);
 
@@ -337,12 +337,10 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 		// Tab3 - Content, label, mode
 		WComponent content3 = new DefaultWComponent();
 		WDecoratedLabel label3 = new WDecoratedLabel("label3");
-		WTabSet.TabMode mode3 = WTabSet.TabMode.SERVER;
+		WTabSet.TabMode mode3 = WTabSet.TabMode.DYNAMIC;
 		tabset.addTab(content3, label3, mode3);
 
-		Assert.
-				assertEquals("third tab has correct content", content3, tabset.getTab(2).
-						getContent());
+		Assert.assertEquals("third tab has correct content", content3, tabset.getTab(2).getContent());
 		Assert.assertEquals("third tab has correct label", label3, tabset.getTab(2).getTabLabel());
 		Assert.assertEquals("third tab has correct mode", mode3, tabset.getTab(2).getMode());
 		Assert.assertEquals("third tab has correct accessKey", 0, tabset.getTab(2).getAccessKey());
@@ -350,16 +348,14 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 		// Tab4 - Content, label, mode, accessKey
 		WComponent content4 = new DefaultWComponent();
 		WDecoratedLabel label4 = new WDecoratedLabel("label4");
-		WTabSet.TabMode mode4 = WTabSet.TabMode.SERVER;
+		WTabSet.TabMode mode4 = WTabSet.TabMode.DYNAMIC;
 		char accessKey4 = 'X';
 		tabset.addTab(content4, label4, mode4, accessKey4);
 
-		Assert.assertEquals("fourth tab has correct content", content4, tabset.getTab(3).
-				getContent());
+		Assert.assertEquals("fourth tab has correct content", content4, tabset.getTab(3).getContent());
 		Assert.assertEquals("fourth tab has correct label", label4, tabset.getTab(3).getTabLabel());
 		Assert.assertEquals("fourth tab has correct mode", mode4, tabset.getTab(3).getMode());
-		Assert.assertEquals("fourth tab has correct accessKey", accessKey4, tabset.getTab(3).
-				getAccessKey());
+		Assert.assertEquals("fourth tab has correct accessKey", accessKey4, tabset.getTab(3).getAccessKey());
 	}
 
 	/**
@@ -370,7 +366,7 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 		WTabSet tabset = new WTabSet();
 		WComponent content = new DefaultWComponent();
 		WDecoratedLabel label = new WDecoratedLabel("label");
-		WTabSet.TabMode mode = WTabSet.TabMode.SERVER;
+		WTabSet.TabMode mode = WTabSet.TabMode.DYNAMIC;
 		tabset.addTab(content, label, mode);
 
 		Assert.
@@ -389,7 +385,7 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 	@Test
 	public void testGetActiveIndex() {
 		WTabSet tabset = new WTabSet();
-		WTabSet.TabMode mode = WTabSet.TabMode.SERVER;
+		WTabSet.TabMode mode = WTabSet.TabMode.DYNAMIC;
 
 		// no tabs in tabset
 		int indexExpected = 0;
@@ -428,7 +424,7 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 	@Test
 	public void testGetActiveIndicesWhenSomeInvisisible() {
 		WTabSet tabset = new WTabSet();
-		WTabSet.TabMode mode = WTabSet.TabMode.SERVER;
+		WTabSet.TabMode mode = WTabSet.TabMode.DYNAMIC;
 
 		WComponent content1 = new DefaultWComponent();
 		WDecoratedLabel label1 = new WDecoratedLabel("label1");
@@ -487,7 +483,7 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 	@Test
 	public void testSetActiveTabWhenNotThere() {
 		WTabSet tabset = new WTabSet();
-		WTabSet.TabMode mode = WTabSet.TabMode.SERVER;
+		WTabSet.TabMode mode = WTabSet.TabMode.DYNAMIC;
 
 		WComponent content0 = new DefaultWComponent();
 		WComponent content1 = new DefaultWComponent();
@@ -520,7 +516,7 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 	@Test
 	public void testSetTabVisibleByContent() {
 		WTabSet tabset = new WTabSet();
-		WTabSet.TabMode mode = WTabSet.TabMode.SERVER;
+		WTabSet.TabMode mode = WTabSet.TabMode.DYNAMIC;
 		WComponent content1 = new DefaultWComponent();
 		WDecoratedLabel label1 = new WDecoratedLabel("label1");
 		tabset.addTab(content1, label1, mode);
@@ -550,7 +546,7 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 	@Test
 	public void testIsActive() {
 		WTabSet tabset = new WTabSet();
-		WTabSet.TabMode mode = WTabSet.TabMode.SERVER;
+		WTabSet.TabMode mode = WTabSet.TabMode.DYNAMIC;
 
 		WComponent content1 = new DefaultWComponent();
 		WDecoratedLabel label1 = new WDecoratedLabel("label1");
@@ -569,7 +565,7 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 	@Test
 	public void testGetTabIndexByContent() {
 		WTabSet tabset = new WTabSet();
-		WTabSet.TabMode mode = WTabSet.TabMode.SERVER;
+		WTabSet.TabMode mode = WTabSet.TabMode.DYNAMIC;
 
 		WComponent content1 = new DefaultWComponent();
 		WDecoratedLabel label1 = new WDecoratedLabel("label1");

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WTab_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WTab_Test.java
@@ -22,7 +22,7 @@ public class WTab_Test extends AbstractWComponentTestCase {
 	public void testConstructor() {
 		WComponent component = new DefaultWComponent();
 		WDecoratedLabel label = new WDecoratedLabel("label");
-		WTab tab = new WTab(component, label, WTabSet.TabMode.SERVER);
+		WTab tab = new WTab(component, label, WTabSet.TabMode.DYNAMIC);
 
 		Assert.assertEquals("label should be added as first tab content", label, tab.getChildAt(0));
 		Assert.assertEquals("label should be added as second tab content", component, tab.
@@ -35,7 +35,7 @@ public class WTab_Test extends AbstractWComponentTestCase {
 		WDecoratedLabel label = null;
 
 		try {
-			WTab tab = new WTab(component, label, WTabSet.TabMode.SERVER);
+			WTab tab = new WTab(component, label, WTabSet.TabMode.DYNAMIC);
 			Assert.fail("should throw IllegalArgumentException - not get tab - " + tab.getId());
 		} catch (Exception e) {
 			Assert.assertEquals("should get message expected", ILLEGAL_LABEL_ERROR, e.getMessage());
@@ -49,7 +49,7 @@ public class WTab_Test extends AbstractWComponentTestCase {
 	public void testSetContentNonNullToNonNull() {
 		WComponent component = new DefaultWComponent();
 		WDecoratedLabel label = new WDecoratedLabel("label");
-		WTab tab = new WTab(component, label, WTabSet.TabMode.SERVER);
+		WTab tab = new WTab(component, label, WTabSet.TabMode.DYNAMIC);
 		Assert.assertEquals("should be content as set in constructor", component, tab.getContent());
 
 		WComponent component2 = new DefaultWComponent();
@@ -64,7 +64,7 @@ public class WTab_Test extends AbstractWComponentTestCase {
 	public void testSetContentNonNullToNull() {
 		WComponent component = new DefaultWComponent();
 		WDecoratedLabel label = new WDecoratedLabel("label");
-		WTab tab = new WTab(component, label, WTabSet.TabMode.SERVER);
+		WTab tab = new WTab(component, label, WTabSet.TabMode.DYNAMIC);
 		Assert.assertEquals("should be content as set in constructor", component, tab.getContent());
 
 		tab.setContent(null);
@@ -81,7 +81,7 @@ public class WTab_Test extends AbstractWComponentTestCase {
 	public void testSetContentNullToNonNull() {
 		WComponent component = new DefaultWComponent();
 		WDecoratedLabel label = new WDecoratedLabel("label");
-		WTab tab = new WTab(component, label, WTabSet.TabMode.SERVER);
+		WTab tab = new WTab(component, label, WTabSet.TabMode.DYNAMIC);
 		Assert.assertEquals("should be content as set in constructor", component, tab.getContent());
 
 		WComponent component2 = null;
@@ -96,7 +96,7 @@ public class WTab_Test extends AbstractWComponentTestCase {
 	public void testSetContentNullToNull() {
 		WComponent component = new DefaultWComponent();
 		WDecoratedLabel label = new WDecoratedLabel("label");
-		WTab tab = new WTab(component, label, WTabSet.TabMode.SERVER);
+		WTab tab = new WTab(component, label, WTabSet.TabMode.DYNAMIC);
 		Assert.assertEquals("should be content as set in constructor", component, tab.getContent());
 
 		tab.setContent(null);
@@ -111,7 +111,7 @@ public class WTab_Test extends AbstractWComponentTestCase {
 	 */
 	@Test
 	public void testSetDisabled() {
-		WTab tab = new WTab(new DefaultWComponent(), "tab", WTabSet.TabMode.SERVER);
+		WTab tab = new WTab(new DefaultWComponent(), "tab", WTabSet.TabMode.DYNAMIC);
 		Assert.assertFalse("Should not be disabled by default", tab.isDisabled());
 
 		tab.setLocked(true);
@@ -236,13 +236,13 @@ public class WTab_Test extends AbstractWComponentTestCase {
 	}
 
 	/**
-	 * Test preparePaintComponent - tabMode SERVER.
+	 * Test preparePaintComponent - tabMode DYNAMIC.
 	 */
 	@Test
 	public void testPreparePaintComponentServer() {
 		// Tab - Server
 		WComponent component = new WText("this is some text");
-		WTab tab = new WTab(component, "label", WTabSet.TabMode.SERVER);
+		WTab tab = new WTab(component, "label", WTabSet.TabMode.DYNAMIC);
 
 		WTabSet tabSet = new WTabSet();
 		tabSet.addTab(new WText(), "test", WTabSet.TAB_MODE_CLIENT);
@@ -326,7 +326,7 @@ public class WTab_Test extends AbstractWComponentTestCase {
 	@Test
 	public void testModeAccessors() {
 		WTab tab = new WTab(new WContainer(), "test", WTabSet.TabMode.CLIENT);
-		assertAccessorsCorrect(tab, "mode", TabMode.CLIENT, TabMode.DYNAMIC, TabMode.SERVER);
+		assertAccessorsCorrect(tab, "mode", TabMode.CLIENT, TabMode.DYNAMIC, TabMode.LAZY);
 	}
 
 	@Test

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WTabRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WTabRenderer_Test.java
@@ -21,7 +21,7 @@ public class WTabRenderer_Test extends AbstractWebXmlRendererTestCase {
 	@Test
 	public void testRendererCorrectlyConfigured() {
 		WTabSet tabSet = new WTabSet();
-		tabSet.addTab(new WText(""), "", TabMode.SERVER);
+		tabSet.addTab(new WText(""), "", TabMode.DYNAMIC);
 		WTab tab = tabSet.getTab(0);
 
 		Assert.assertTrue("Incorrect renderer supplied",
@@ -67,7 +67,7 @@ public class WTabRenderer_Test extends AbstractWebXmlRendererTestCase {
 
 		tabSet.remove(tab);
 		tab = tabSet.addTab(new WText(tabContent), tabName, TabMode.SERVER, 'X');
-		assertXpathEvaluatesTo("server", "//ui:tab/@mode", tabSet);
+		assertXpathEvaluatesTo("dynamic", "//ui:tab/@mode", tabSet);
 		assertXpathEvaluatesTo(String.valueOf(tab.getAccessKey()), "//ui:tab/@accessKey", tabSet);
 
 		tabSet.remove(tab);

--- a/wcomponents-theme/src/main/js/wc/dom/ariaAnalog.js
+++ b/wcomponents-theme/src/main/js/wc/dom/ariaAnalog.js
@@ -248,12 +248,13 @@ define(["wc/has",
 		/**
 		 * Indicates whether navigating with the keyboard selects items.
 		 *
-		 * @var
-		 * @type Boolean
-		 * @default false
+		 * @function
 		 * @protected
+		 * @param {Element} [element] The element being navigated to. Not used by default.
 		 */
-		AriaAnalog.prototype.selectOnNavigate = false;
+		AriaAnalog.prototype.selectOnNavigate = function (element) {
+			return false;
+		};
 
 		/**
 		 * Indicates whether  only one item can be selected at a time. Must be a
@@ -466,7 +467,7 @@ define(["wc/has",
 				if (this.groupNavigation && isDirectionKey(keyCode)) {
 					moveTo = calcMoveTo(this, keyCode);
 					if (moveTo && (target = this.navigate(element, moveTo))) {
-						if (this.selectOnNavigate && !($event.ctrlKey || $event.metaKey)) {
+						if (this.selectOnNavigate(target) && !($event.ctrlKey || $event.metaKey)) {
 							this.activate(target, $event.shiftKey, ($event.ctrlKey || $event.metaKey));
 						}
 						preventDefaultAction = true;

--- a/wcomponents-theme/src/main/js/wc/ui/listboxAnalog.js
+++ b/wcomponents-theme/src/main/js/wc/ui/listboxAnalog.js
@@ -45,12 +45,14 @@ define(["wc/dom/ariaAnalog", "wc/dom/initialise", "wc/dom/Widget"],
 		function ListboxAnalog() {
 			/**
 			 * Select items immediately on navigation.
-			 * @var
+			 * @function
 			 * @protected
-			 * @type Boolean
+			 * @returns {Boolean} always true for this analog.
 			 * @override
 			 */
-			this.selectOnNavigate = true;
+			this.selectOnNavigate = function() {
+				return true;
+			};
 			/**
 			 * The selection mode is mixed: list boxes may be single or multiple as per select elements.
 			 * @var

--- a/wcomponents-theme/src/main/js/wc/ui/radioAnalog.js
+++ b/wcomponents-theme/src/main/js/wc/ui/radioAnalog.js
@@ -39,14 +39,17 @@ define(["wc/dom/ariaAnalog", "wc/dom/initialise", "wc/dom/Widget"],
 			 */
 			this.ITEM = new Widget("", "", {"role": "radio"});
 
+
 			/**
 			 * Select items immediately on navigation.
-			 * @var
+			 * @function
 			 * @protected
-			 * @type Boolean
+			 * @returns {Boolean} always true for this analog.
 			 * @override
 			 */
-			this.selectOnNavigate = true;
+			this.selectOnNavigate = function() {
+				return true;
+			};
 
 			/**
 			 * The selection mode is single.

--- a/wcomponents-theme/src/main/js/wc/ui/rowAnalog.js
+++ b/wcomponents-theme/src/main/js/wc/ui/rowAnalog.js
@@ -22,14 +22,6 @@ define(["wc/dom/ariaAnalog",
 		 */
 		function RowAnalog() {
 			/**
-			 * Select items immediately on navigation.
-			 * @var
-			 * @protected
-			 * @type Boolean
-			 * @override
-			 */
-			this.selectOnNavigate = false;
-			/**
 			 * The selection mode is mixed: list boxes may be single or multiple as per select elements.
 			 * @var
 			 * @protected

--- a/wcomponents-theme/src/main/js/wc/ui/tabset.js
+++ b/wcomponents-theme/src/main/js/wc/ui/tabset.js
@@ -83,19 +83,23 @@ define(["wc/dom/ariaAnalog",
 			 */
 			this.ITEM = new Widget("", "", {"role": "tab"});
 
+
 			/**
-			 * Do not automatically select a tab when navigating with the keyboard. NOTE: this directly contravenes the
-			 * WAI-ARIA keyboard guidelines for a Tab Panel widget but automatically activating a tab on navigate causes
-			 * all sorts of usability problems.
-			 *
-			 * @see {@link http://www.w3.org/TR/wai-aria-practices/#tabpanel}
-			 * @constant
-			 * @type {Boolean}
+			 * Select items immediately on navigation.
+			 * @function
 			 * @protected
+			 * @param {Element} element the tab being navigated to
+			 * @returns {Boolean} true unless the tab is in an accordion.
 			 * @override
-			 * @default false
 			 */
-			this.selectOnNavigate = false;
+			this.selectOnNavigate = function(element) {
+				var container = this.getGroupContainer(element);
+
+				if (container && container.getAttribute("aria-multiselectable")) {
+					return false;
+				}
+				return true;
+			};
 
 			/**
 			 * The selection mode for the group of tabs context. The select mode is mixed as accordions may be

--- a/wcomponents-theme/src/main/xslt/wc.ui.tabContent.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.tabContent.xsl
@@ -22,9 +22,6 @@
 		<div id="{@id}" role="tabpanel">
 			<xsl:attribute name="class">
 				<xsl:text>wc-tabcontent</xsl:text>
-				<xsl:if test="$mode='server'">
-					<xsl:text> wc_lame</xsl:text>
-				</xsl:if>
 				<xsl:choose>
 					<xsl:when test="$open=1">
 						<xsl:if test="$mode='dynamic'">


### PR DESCRIPTION
Fixed key navigation in tabsets. This has the following side effects:
* AriaAnalog.selectOnNavigate is now a function which accepts an optional argument of the element being navigated to;
* tabset.js uses this to switch activate on navigation depending on type as accordions do not  use this;
* updated WTab, WTabSet to map TabMode.SERVER to TabMode.DYNAMIC to fix a11y issues.

Fixes #692