### PR TITLE
Add wc icon class

### DIFF
--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WButtonExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WButtonExample.java
@@ -163,6 +163,21 @@ public class WButtonExample extends WPanel implements MessageContainer {
 				true));
 		buttonLayoutPanel.add(makeImageButtonWithPosition("Image on the West", ImagePosition.WEST,
 				true));
+
+		add(new WHeading(HeadingLevel.H4, "Using theme icons"));
+		add(new ExplanatoryText("This example shows ways to add a Font-Awesome icon to a button."));
+		WButton iconButton = new WButton("\u200b"); // \u200b is a zero-width space.
+		iconButton.setToolTip("Open Menu");
+		iconButton.setHtmlClass("wc-icon fa-bars");
+		add(iconButton);
+
+		iconButton = new WButton(" With text content");
+		iconButton.setHtmlClass("wc-icon fa-hand-o-left");
+		add(iconButton);
+
+		iconButton = new WButton("Right icon with text content");
+		iconButton.setHtmlClass("wc-icon-right fa-hand-o-right");
+		add(iconButton);
 	}
 
 	/**

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/picker/ExampleSection.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/picker/ExampleSection.java
@@ -88,8 +88,10 @@ final class ExampleSection extends WSection implements MessageContainer {
 		tabset.addTab(source, new WDecoratedLabel(srcImage), WTabSet.TAB_MODE_LAZY).setToolTip("View Source");
 
 		// The refresh current view button.
-		WButton refreshButton = new WButton("Refresh");
-		refreshButton.setImage("/image/refresh-w.png");
+		WButton refreshButton = new WButton("\u200b");
+		refreshButton.setToolTip("Refresh");
+		refreshButton.setHtmlClass("wc-icon fa-refresh");
+		//refreshButton.setImage("/image/refresh-w.png");
 		refreshButton.setRenderAsLink(true);
 		refreshButton.setAction(new ValidatingAction(messages.getValidationErrors(), refreshButton) {
 			@Override
@@ -99,8 +101,10 @@ final class ExampleSection extends WSection implements MessageContainer {
 		});
 
 		// The reset example button.
-		final WButton resetButton = new WButton("Reset");
-		resetButton.setImage("/image/cancel-w.png");
+		final WButton resetButton = new WButton("\u200b");
+		resetButton.setToolTip("Reset");
+		resetButton.setHtmlClass("wc-icon fa-times-circle");
+		//resetButton.setImage("/image/cancel-w.png");
 		resetButton.setRenderAsLink(true);
 		resetButton.setAction(new ValidatingAction(messages.getValidationErrors(), resetButton) {
 			@Override

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/picker/TreePicker.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/picker/TreePicker.java
@@ -209,11 +209,14 @@ public class TreePicker extends WContainer {
 		 * Add the UI controls to the utility bar.
 		 */
 		private void setUp() {
+			setMargin(new Margin(0, 8, 0, 0));
 			setLayout(new ListLayout(ListLayout.Type.FLAT, ListLayout.Alignment.RIGHT, ListLayout.Separator.NONE,
 					false));
 			// The select another example button.
-			final WButton selectOtherButton = new WButton("Select");
-			selectOtherButton.setImage("/image/open-in-browser-w.png");
+			final WButton selectOtherButton = new WButton("\u200b");
+			selectOtherButton.setToolTip("Select");
+			//selectOtherButton.setImage("/image/open-in-browser-w.png");
+			selectOtherButton.setHtmlClass("wc-icon fa-file-code-o");
 			selectOtherButton.setRenderAsLink(true);
 			selectOtherButton.setAction(new ValidatingAction(exampleSection.getMessages().getValidationErrors(),
 					selectOtherButton) {

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/table/FilterableTableExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/table/FilterableTableExample.java
@@ -2,6 +2,8 @@ package com.github.bordertech.wcomponents.examples.table;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.MenuItemSelectable;
+import com.github.bordertech.wcomponents.MenuSelectContainer;
 import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.SimpleBeanBoundTableModel;
 import com.github.bordertech.wcomponents.WAjaxControl;
@@ -43,7 +45,7 @@ public class FilterableTableExample extends WContainer {
 	/**
 	 * The bean properties used to populate the table.
 	 */
-	private static String[] beanProperties = new String[]{"firstName", "lastName", "dateOfBirth"};
+	private static final String[] BEAN_PROPERTIES = new String[]{"firstName", "lastName", "dateOfBirth"};
 
 	/**
 	 * column index for the first name column.
@@ -88,7 +90,7 @@ public class FilterableTableExample extends WContainer {
 	/**
 	 * filter mode: SINGLE or MULTIPLE.
 	 */
-	private static final WMenu.SelectMode SELECT_MODE = WMenu.SelectMode.MULTIPLE;
+	private static final MenuSelectContainer.SelectionMode SELECTION_MODE = MenuSelectContainer.SelectionMode.MULTIPLE;
 
 	/**
 	 * a button to clear all filters from all columns at once.
@@ -180,7 +182,7 @@ public class FilterableTableExample extends WContainer {
 		super.preparePaintComponent(request);
 		if (!isInitialised()) {
 			// Setup model
-			FilterableBeanBoundDataModel model = new FilterableBeanBoundDataModel(beanProperties);
+			FilterableBeanBoundDataModel model = new FilterableBeanBoundDataModel(BEAN_PROPERTIES);
 			table.setTableModel(model);
 			// Set the data as the bean on the table
 			table.setBean(ExampleDataUtil.createExampleData());
@@ -188,9 +190,9 @@ public class FilterableTableExample extends WContainer {
 			buildFilterMenus();
 
 			String caption = "Use the menus in the column headers to show only the rows where the column value matches the value"
-					+ ((SELECT_MODE == WMenu.SelectMode.MULTIPLE) ? "s " : " ")
+					+ ((SELECTION_MODE == MenuSelectContainer.SelectionMode.MULTIPLE) ? "s " : " ")
 					+ " of the selected option"
-					+ ((SELECT_MODE == WMenu.SelectMode.MULTIPLE) ? "s." : ".");
+					+ ((SELECTION_MODE == MenuSelectContainer.SelectionMode.MULTIPLE) ? "s." : ".");
 			if (getFilterableTableModel().isCaseInsensitiveMatch()) {
 				caption += " The case of the text is ignored.";
 			}
@@ -262,18 +264,20 @@ public class FilterableTableExample extends WContainer {
 
 		final List<String> found = new ArrayList<>();
 
-		final WImage filterImage = new WImage("/image/view-filter.png",
-				"Filter table using this column");
-		filterImage.setCacheKey("filterImage");
-		final WDecoratedLabel filterSubMenuLabel = new WDecoratedLabel(filterImage);
+//		final WImage filterImage = new WImage("/image/view-filter.png",
+//				"Filter table using this column");
+//		filterImage.setCacheKey("filterImage");
+		final WDecoratedLabel filterSubMenuLabel = new WDecoratedLabel(new WText("\u200b"));
+		filterSubMenuLabel.setToolTip("Filter this column");
+		filterSubMenuLabel.setHtmlClass("wc-icon fa-filter");
 		final WSubMenu submenu = new WSubMenu(filterSubMenuLabel);
-		submenu.setSelectMode(SELECT_MODE);
+		submenu.setSelectionMode(SELECTION_MODE);
 		menu.add(submenu);
 
 		WMenuItem item = new WMenuItem(CLEAR_ALL, new ClearFilterAction());
 		submenu.add(item);
 		item.setActionObject(item);
-		item.setSelectable(false);
+		item.setSelectability(false);
 		add(new WAjaxControl(item, table));
 
 		Object cellObject;
@@ -282,9 +286,11 @@ public class FilterableTableExample extends WContainer {
 
 		for (int i = 0; i < rows; ++i) {
 			bean = beanList.get(i);
+			if (bean == null) {
+				continue;
+			}
 
-			cellObject = getFilterableTableModel().getBeanPropertyValueFullList(
-					beanProperties[column], bean);
+			cellObject = getFilterableTableModel().getBeanPropertyValueFullList(BEAN_PROPERTIES[column], bean);
 			if (cellObject == null) {
 				continue; //nothing to add to the sub menu
 			}
@@ -347,7 +353,7 @@ public class FilterableTableExample extends WContainer {
 			}
 			WMenuItem target = (WMenuItem) event.getActionObject();
 			WMenu menu = WebUtilities.getAncestorOfClass(WMenu.class, target);
-			menu.clearSelectedItems();
+			menu.clearSelectedMenuItems();
 			getFilterableTableModel().filterBeanList();
 		}
 	}
@@ -496,7 +502,8 @@ public class FilterableTableExample extends WContainer {
 		}
 
 		/**
-		 * Determines if a given bean matches any applied filters.
+		 * Determines if a given bean matches any applied filters. This is a poorly formed function just as a proof of
+		 * concept. Do not copy this, use it as inspiration to write better Java than the CSS guy!
 		 *
 		 * @param bean the bean to test
 		 * @return the bean if it matches all applied filters or null if it does not.
@@ -506,7 +513,7 @@ public class FilterableTableExample extends WContainer {
 				return null;
 			}
 
-			List<WComponent> selectedItems;
+			List<MenuItemSelectable> selectedItems;
 			Object testBean;
 			String itemText;
 			String beanText;
@@ -514,7 +521,7 @@ public class FilterableTableExample extends WContainer {
 
 			/* AND filter: do each one */
 			if (firstNameFilterMenu.isVisible()) {
-				selectedItems = firstNameFilterMenu.getSelectedItems();
+				selectedItems = firstNameFilterMenu.getSelectedMenuItems();
 				if (selectedItems != null && !selectedItems.isEmpty()) {
 					testBean = getBeanPropertyValue("firstName", bean);
 					if (testBean == null) {
@@ -551,7 +558,7 @@ public class FilterableTableExample extends WContainer {
 			}
 
 			if (lastNameFilterMenu.isVisible()) {
-				selectedItems = lastNameFilterMenu.getSelectedItems();
+				selectedItems = lastNameFilterMenu.getSelectedMenuItems();
 				if (selectedItems != null && !selectedItems.isEmpty()) {
 					testBean = getBeanPropertyValue("lastName", bean);
 					if (testBean == null) {
@@ -586,7 +593,7 @@ public class FilterableTableExample extends WContainer {
 			}
 
 			if (dobFilterMenu.isVisible()) {
-				selectedItems = dobFilterMenu.getSelectedItems();
+				selectedItems = dobFilterMenu.getSelectedMenuItems();
 				if (selectedItems != null && !selectedItems.isEmpty()) {
 					testBean = getBeanPropertyValue("dateOfBirth", bean);
 					if (testBean == null) {

--- a/wcomponents-theme/src/main/js/wc/ui/backToTop.js
+++ b/wcomponents-theme/src/main/js/wc/ui/backToTop.js
@@ -108,7 +108,7 @@ define(["wc/i18n/i18n", "wc/dom/event", "wc/dom/focus", "wc/dom/initialise", "wc
 				if (show) {
 					if (!link) {
 						link = document.createElement("a");
-						link.className = "wc_btt";
+						link.className = "wc_btt wc-icon";
 						link.href = "#";
 						link.innerHTML = "<span>" + i18n.get("${wc.ui.backToTop.i18n.text}") + "</span>";
 						document.body.appendChild(link);

--- a/wcomponents-theme/src/main/js/wc/ui/menu/bar.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/bar.js
@@ -271,7 +271,7 @@ define(["wc/ui/menu/core", "wc/dom/keyWalker", "wc/dom/shed", "wc/dom/Widget", "
 					button.title = i18n.get("${wc.ui.menu.bar.i18n.submenuOpenLabelDefault}");
 					contentId = uid();
 					button.setAttribute("aria-controls", contentId);
-					button.className = "wc-nobutton wc-submenu-o wc_hbgr";
+					button.className = "wc-nobutton wc-submenu-o wc_hbgr wc-icon";
 					button.setAttribute(ROLE, "menuitem");
 					branchElement.appendChild(button);
 

--- a/wcomponents-theme/src/main/js/wc/ui/menu/core.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/core.js
@@ -72,7 +72,8 @@ define(["wc/has",
 				COLLIDE_SOUTH: "wc_colsth",
 				// no collide north...
 				DEFAULT_DIRECTION: i18n.get("${wc.ui.menu.i18n.defaultDirection}"),
-				AGAINST_DEFAULT: i18n.get("${wc.ui.menu.i18n.otherDirection}")
+				AGAINST_DEFAULT: i18n.get("${wc.ui.menu.i18n.otherDirection}"),
+				CLOSER: "closesubmenu"
 			},
 			/**
 			 * This object is used to map functions to particular event conditions.
@@ -1557,7 +1558,7 @@ define(["wc/has",
 				return false;
 			}
 			if (this.isSmallScreen) {
-				CLOSE_BUTTON = CLOSE_BUTTON || new Widget(BUTTON, "closesubmenu", {"role": "menuitem"});
+				CLOSE_BUTTON = CLOSE_BUTTON || new Widget(BUTTON, CLASS.CLOSER, {"role": "menuitem"});
 				if (CLOSE_BUTTON.isOneOfMe(item)) {
 					this[FUNC_MAP.CLOSE_MY_BRANCH](item);
 					return true;
@@ -2048,10 +2049,9 @@ define(["wc/has",
 		AbstractMenu.prototype.fixSubMenuContent = function(nextSubmenu) {
 			var closeMenuButton = document.createElement(BUTTON),
 				opener = nextSubmenu.previousSibling,
-				openerContent,
-				CLOSER_CLASS = "closesubmenu";
+				openerContent;
 
-			CLOSE_BUTTON = CLOSE_BUTTON || new Widget(BUTTON, CLOSER_CLASS, {"role": MENUITEM_ROLE});
+			CLOSE_BUTTON = CLOSE_BUTTON || new Widget(BUTTON, CLASS.CLOSER, {"role": MENUITEM_ROLE});
 
 			if (nextSubmenu.firstChild) {
 				if (CLOSE_BUTTON.isOneOfMe(nextSubmenu.firstChild)) {
@@ -2065,7 +2065,7 @@ define(["wc/has",
 
 			closeMenuButton.setAttribute(ROLE_ATTRIB, MENUITEM_ROLE);
 			closeMenuButton.type = BUTTON;
-			closeMenuButton.className = CLOSER_CLASS + " wc-nobutton";
+			closeMenuButton.className = CLASS.CLOSER + " wc-nobutton wc-icon";
 
 			openerContent = opener ? textContent.get(opener) : "";
 			closeMenuButton.innerHTML = openerContent || (DEFAULT_CLOSE_LABEL = DEFAULT_CLOSE_LABEL || i18n.get("${wc.ui.menu.bar.i18n.submenuCloseLabelDefault}"));

--- a/wcomponents-theme/src/main/resource/dialog.xml
+++ b/wcomponents-theme/src/main/resource/dialog.xml
@@ -10,6 +10,6 @@
 	{{message.loading}}
 </div>
 <${wc.dom.html5.element.footer}>
-<button class="wc-nobutton wc_resize" data-wc-resize="wc_dlgid" type="button">&#x2002;</button>
+<button class="wc-nobutton wc_resize wc-icon" data-wc-resize="wc_dlgid" type="button">&#x2002;</button>
 </${wc.dom.html5.element.footer}>
 </${wc.dom.html5.element.dialog}>

--- a/wcomponents-theme/src/main/sass/_common.scss
+++ b/wcomponents-theme/src/main/sass/_common.scss
@@ -1,3 +1,6 @@
+// Override Font Awesoe font path.
+$fa-font-path: '../resource';
+
 // FONTS
 $wc-default-font: sans-serif !default;
 $wc-mono-font: monospace !default;

--- a/wcomponents-theme/src/main/sass/_label-mixins.scss
+++ b/wcomponents-theme/src/main/sass/_label-mixins.scss
@@ -4,4 +4,5 @@
 	color: $std-color-secondary;
 	display: block;
 	font-size: 82.5%;
+	font-weight: normal;
 }

--- a/wcomponents-theme/src/main/sass/_mixins-icon.scss
+++ b/wcomponents-theme/src/main/sass/_mixins-icon.scss
@@ -2,8 +2,8 @@
 // Moved out of mixins-common for ease of override.
 
 // FontAwesome mixins and vars...
+@import 'vars';
 @import 'mixins-animate';
-@import 'common';
 @import 'libs/fa/variables';
 @import 'libs/fa/mixins';
 
@@ -18,6 +18,15 @@
 /// Make a fixed-width icon.
 @mixin wc-icon-fw ($icon: -1, $text-align: center, $width: $wc-icon-normal) {
 	@include wc-icon($icon);
+	text-align: $text-align;
+	width: $width;
+}
+
+/// Add content and fixed-width to an icon. Used with class .wc-icon and .wc-icon-after.
+@mixin wc-icon-fw-content($icon: -1, $text-align: center, $width: $wc-icon-normal) {
+	@if($icon != -1) {
+		content: $icon;
+	}
 	text-align: $text-align;
 	width: $width;
 }

--- a/wcomponents-theme/src/main/sass/libs/fa/_variables.scss
+++ b/wcomponents-theme/src/main/sass/libs/fa/_variables.scss
@@ -1,7 +1,7 @@
 // Variables
 // --------------------------
 
-$fa-font-path:        "../resource" !default;
+$fa-font-path:        "../fonts" !default;
 $fa-font-size-base:   14px !default;
 $fa-line-height-base: 1 !default;
 //$fa-font-path:        "//netdna.bootstrapcdn.com/font-awesome/4.6.2/fonts" !default; // for referencing Bootstrap CDN font files directly

--- a/wcomponents-theme/src/main/sass/wc.common.checkRadioIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.checkRadioIcons.scss
@@ -1,17 +1,15 @@
 /* wc.common.checkRadioIcons.scss */
 @import 'mixins-common';
 
-/// WCheckBox and WRadioButton in read-only mode.
-.wc-checkbox,
-.wc-radiobutton {
+/// read-only WCheckBox.
+.wc-checkbox {
 	&.wc_ro:before {
-		@include wc-icon($fa-var-square-o);
+		content: $fa-var-square-o;
 	}
-}
 
-/// Selected, read-only WCheckBox.
-.wc-checkbox.wc_ro_sel:before {
-	content: $fa-var-check-square-o;
+	&.wc_ro_sel:before {
+		content: $fa-var-check-square-o;
+	}
 }
 
 /// read-only WRadioButton.

--- a/wcomponents-theme/src/main/sass/wc.common.collapsibleToggleIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.collapsibleToggleIcons.scss
@@ -5,8 +5,8 @@
 
 .wc_coltog {
 	button:before {
-		@include wc-icon($fa-var-plus-square-o);
 		@include margin($pos: right);
+		content: $fa-var-plus-square-o;
 	}
 
 	[data-wc-value='collapse']:before {

--- a/wcomponents-theme/src/main/sass/wc.common.libs.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.libs.scss
@@ -1,2 +1,5 @@
+// Make sure WCompoennts vars are included before lib vars are declared.
+@import 'vars';
+
 // include font-awesome
 @import 'libs/fa/font-awesome';

--- a/wcomponents-theme/src/main/sass/wc.common.page.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.page.scss
@@ -35,6 +35,16 @@ pre {
 	@include align(center);
 }
 
+.wc-icon:before,
+.wc-icon-right:before {
+	@include wc-icon;
+}
+
+.wc-icon-right:before {
+	float: right;
+	margin-left: $wc-gap-small;
+}
+
 // [hidden] hides content. Class .wc-off moves the content so it is still available to assistive technologies but is not
 // visible on screen. Applying this to [hidden] is redundant but needed because of irregular hidden support. It is
 // important to override more specific selectors for individual components. Again, this is needed for re-applying hidden

--- a/wcomponents-theme/src/main/sass/wc.ui.backToTopIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.backToTopIcons.scss
@@ -3,5 +3,5 @@
 
 /// The back to top of page link.
 .wc_btt:before {
-	@include wc-icon($fa-var-chevron-circle-up);
+	content: $fa-var-chevron-circle-up;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.collapsibleIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.collapsibleIcons.scss
@@ -12,7 +12,7 @@
 
 summary {
 	&:before {
-		@include wc-icon-fw($fa-var-caret-right, left);
+		@include wc-icon-fw-content($fa-var-caret-right, left);
 	}
 
 	[open] > &:before {

--- a/wcomponents-theme/src/main/sass/wc.ui.label.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.label.scss
@@ -28,7 +28,7 @@
 	}
 }
 
-[type='radio'],
+[type='checkbox'],
 [type='radio'] {
 	+ .wc_req {
 		&:before {
@@ -43,10 +43,14 @@
 }
 
 // space between a checkable and its label
-[type='radio'] + label,
-[type='checkbox'] + label,
+input + label,
+.wc-selecttoggle + label,
 .wc_ro + .wc-label {
 	display: inline; // .wc-label's inline-block can cause the label to fall under the input when there is not enough room for the label
 	font-weight: normal;
+	margin-left: $wc-gap-small;
+}
+
+label + input {
 	margin-left: $wc-gap-small;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.loadingIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.loadingIcons.scss
@@ -4,9 +4,9 @@
 
 // loading indicator is generated and identified
 //scss-lint:disable IdSelector
-#wc_ui_loading  div:before {
-	@include wc-icon($fa-var-spinner);
+#wc_ui_loading div:before {
 	@include wc-spin; // fa do not yet have a mixin for this.
+	content: $fa-var-spinner;
 	font-size: $wc-icon-large;
 }
 

--- a/wcomponents-theme/src/main/sass/wc.ui.mediaPlayerIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.mediaPlayerIcons.scss
@@ -2,11 +2,8 @@
 // styles for WAudio and WVideo when the media is not able to be handled by the user agent natively. */
 @import 'mixins-common';
 
-.wc-src,
-.wc-track {
-	&:before {
-		@include wc-icon($fa-var-play);
-	}
+.wc-src:before {
+	content: $fa-var-play;
 }
 
 .wc-track:before {

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumnIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumnIcons.scss
@@ -19,16 +19,16 @@
 		padding-left: $wc-menu-bar-column-opener-indicator-before-after;
 	}
 
-	&.wc_hbgr:after { // the hambirger icon
-		margin-left: $wc-gap-small;
+	&.wc_hbgr:after { // the hamburger icon,
+		display: none;
 	}
 }
 
 .closesubmenu::before {
-	@include wc-icon($fa-var-caret-left);
+	content: $fa-var-caret-left;
 	margin-right: $wc-gap-normal;
 }
 
 .wc_hbgr::before {
-	@include wc-icon($fa-var-bars);
+	content: $fa-var-bars;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.messageBoxIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.messageBoxIcons.scss
@@ -3,7 +3,7 @@
 
 h1:before {
 	.wc_msgbox > & { // Use error box as default.
-		@include wc-icon-fw($fa-var-minus-circle, $width: $wc-icon-wider);
+		@include wc-icon-fw-content($fa-var-minus-circle, $width: $wc-icon-wider);
 		vertical-align: middle;
 	}
 

--- a/wcomponents-theme/src/main/sass/wc.ui.resizeableIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.resizeableIcons.scss
@@ -2,7 +2,7 @@
 @import 'mixins-common';
 
 .wc_resize:before {
-	@include wc-icon($fa-var-arrows-alt);
+	content: $fa-var-arrows-alt;
 	opacity: 0.5;
 }
 

--- a/wcomponents-theme/src/main/sass/wc.ui.selectToggleIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.selectToggleIcons.scss
@@ -2,14 +2,9 @@
 @import 'mixins-common';
 
 .wc_seltog {
-	// &[data-wc-value]:before,
-	// &[role='checkbox']:before {
-	// 	@include wc-icon-fw($fa-var-square-o, left);
-	// }
-
 	&[role='checkbox'] { // Rendered as a control
 		&:before {
-			@include wc-icon-fw($fa-var-square-o, left);
+			@include wc-icon-fw-content($fa-var-square-o, left);
 		}
 
 		&[aria-checked='true']:before {
@@ -21,10 +16,6 @@
 		}
 	}
 
-	// &[data-wc-value='all']:before {
-	// 	content: $fa-var-check-square-o;
-	// }
-	//
 	&[data-wc-value][aria-checked='true'] {
 		font-weight: bold;
 	}

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansionIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowExpansionIcons.scss
@@ -4,7 +4,7 @@
 // ROW EXPANSION iconography and expand/collapse all iconography.
 tr[role='row'] {
 	> td[role='button']:before {
-		@include wc-icon-fw($fa-var-caret-right);
+		@include wc-icon-fw-content($fa-var-caret-right);
 	}
 
 	&[aria-expanded='true'] {

--- a/wcomponents-theme/src/main/sass/wc.ui.table.rowSelectionIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.rowSelectionIcons.scss
@@ -4,7 +4,7 @@
 // only want to style aria-selected rows, nothing else
 .wc_table_sel_wrapper:before {
 	tr[aria-selected] > & {
-		@include wc-icon-fw($fa-var-circle-o, left);
+		@include wc-icon-fw-content($fa-var-circle-o, left);
 	}
 
 	tr[aria-selected='true'] > & {

--- a/wcomponents-theme/src/main/sass/wc.ui.treeIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.treeIcons.scss
@@ -5,7 +5,8 @@
 .wc_leaf_noimg,
 .wc_leaf_hopener {
 	&:before {
-		@include wc-icon-fw($text-align: left);
+		text-align: left;
+		width: $wc-icon-normal;
 	}
 }
 

--- a/wcomponents-theme/src/main/xslt/wc.common.checkableInput.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.checkableInput.xsl
@@ -53,8 +53,9 @@
 			<xsl:when test="@readOnly">
 				<xsl:call-template name="readOnlyControl">
 					<xsl:with-param name="class">
+						<xsl:text>wc-icon</xsl:text>
 						<xsl:if test="@selected">
-							<xsl:text>wc_ro_sel</xsl:text>
+							<xsl:text> wc_ro_sel</xsl:text>
 						</xsl:if>
 					</xsl:with-param>
 					<xsl:with-param name="toolTip">

--- a/wcomponents-theme/src/main/xslt/wc.common.collapsibleToggle.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.collapsibleToggle.xsl
@@ -55,7 +55,7 @@
 			</xsl:choose>
 		</xsl:variable>
 		<xsl:variable name="toggleClass">
-			<xsl:value-of select="concat('wc_', local-name(.))"/>
+			<xsl:value-of select="concat('wc-icon wc_', local-name(.))"/>
 		</xsl:variable>
 		<ul id="{$id}" role="radiogroup">
 			<xsl:call-template name="makeCommonClass">

--- a/wcomponents-theme/src/main/xslt/wc.common.feedback.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.feedback.xsl
@@ -28,7 +28,7 @@
 				</xsl:with-param>
 			</xsl:call-template>
 
-			<h1>
+			<h1 class="wc-icon">
 				<span>
 					<xsl:choose>
 						<xsl:when test="@title">

--- a/wcomponents-theme/src/main/xslt/wc.common.selectToggle.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.selectToggle.xsl
@@ -263,7 +263,7 @@
 					</xsl:if>
 					<xsl:call-template name="makeCommonClass">
 						<xsl:with-param name="additional">
-							<xsl:text>wc_seltog wc-nobutton</xsl:text>
+							<xsl:text>wc_seltog wc-nobutton wc-icon</xsl:text>
 						</xsl:with-param>
 					</xsl:call-template>
 					<xsl:if test="self::ui:selecttoggle">

--- a/wcomponents-theme/src/main/xslt/wc.ui.collapsible.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.collapsible.xsl
@@ -43,6 +43,9 @@
 			<xsl:call-template name="hideElementIfHiddenSet"/>
 			<xsl:apply-templates select="ui:margin"/>
 			<xsl:element name="${wc.dom.html5.element.summary}">
+				<xsl:attribute name="class">
+					<xsl:text>wc-icon</xsl:text>
+				</xsl:attribute>
 				<xsl:attribute name="tabIndex">
 					<xsl:text>0</xsl:text>
 				</xsl:attribute>

--- a/wcomponents-theme/src/main/xslt/wc.ui.root.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.root.xsl
@@ -113,7 +113,7 @@
 					</noscript>
 				</div>
 				<div id="wc_ui_loading">
-					<div tabindex="0">
+					<div tabindex="0" class="wc-icon">
 						<xsl:value-of select="$$${wc.ui.loading.loadMessage}"/>
 					</div>
 				</div>

--- a/wcomponents-theme/src/main/xslt/wc.ui.src_link.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.src_link.xsl
@@ -3,7 +3,7 @@
 		Outputs an A element linking to a source file.
 	-->
 	<xsl:template match="ui:src" mode="link">
-		<a href="{@uri}" class="wc-src">
+		<a href="{@uri}" class="wc-src wc-icon">
 			<xsl:attribute name="${wc.common.attrib.attach}">
 				<xsl:text>${wc.common.attrib.attach}</xsl:text>
 			</xsl:attribute>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.th_thead.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.th_thead.xsl
@@ -1,15 +1,15 @@
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" 
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0"
 	xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
 	<xsl:import href="wc.ui.table.n.tableAjaxController.xsl"/>
 	<xsl:import href="wc.constants.xsl"/>
 	<xsl:import href="wc.common.n.className.xsl" />
-	
+
 	<xsl:template match="ui:th" mode="thead">
 		<xsl:param name="hasRole" select="0"/>
 
 		<xsl:variable name="tableId" select="../../@id"/>
-		
+
 		<th id="{concat($tableId,'_thh', position())}" scope="col" data-wc-columnidx="{position() - 1}">
 			<xsl:if test="$hasRole &gt; 0">
 				<xsl:attribute name="role">
@@ -23,7 +23,6 @@
 
 				<xsl:if test="$sortControl">
 					<xsl:attribute name="tabindex">0</xsl:attribute>
-
 					<xsl:variable name="sortDesc" select="$sortControl/@descending"/>
 					<xsl:variable name="sortCol" select="$sortControl/@col"/>
 
@@ -77,7 +76,7 @@
 							<xsl:with-param name="tableId" select="$tableId"/>
 						</xsl:call-template>
 					</xsl:if>
-					
+
 					<xsl:attribute name="data-wc-sortmode">
 						<xsl:value-of select="$sortMode"/>
 					</xsl:attribute>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.tr.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.tr.xsl
@@ -241,7 +241,7 @@
 			selection mechanism and state. The primary indicators are the aria-selected state.
 			-->
 			<xsl:if test="$tableRowSelection=1">
-				<td class="wc_table_sel_wrapper">
+				<td class="wc_table_sel_wrapper wc-icon">
 					<xsl:choose>
 						<xsl:when test="$hasRowExpansion + $tableRowSelection = 2 and $myTable/ui:rowselection/@toggle and ui:subtr/ui:tr[not(@unselectable)]">
 							<xsl:attribute name="role">
@@ -321,7 +321,7 @@
 			-->
 			<xsl:if test="$myTable/ui:rowexpansion">
 				<!-- The rowExpansion cell will hold the expansion control (if any) -->
-				<td class="wc_table_rowexp_container">
+				<td class="wc_table_rowexp_container wc-icon">
 					<xsl:if test="ui:subtr">
 						<xsl:attribute name="role">button</xsl:attribute>
 						<xsl:attribute name="aria-controls">

--- a/wcomponents-theme/src/main/xslt/wc.ui.tree.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.tree.xsl
@@ -32,7 +32,7 @@
 					<xsl:value-of select="@mode"/>
 				</xsl:attribute>
 			</xsl:if>
-	
+
 			<xsl:call-template name="requiredElement"/>
 			<xsl:call-template name="ajaxController"/>
 
@@ -41,14 +41,14 @@
 			<xsl:if test="$isError">
 				<xsl:call-template name="invalid"/>
 			</xsl:if>
-			
+
 			<xsl:variable name="groupId" select="concat(@id, '-content')"/>
 			<div role="group" class="wc_tree_root" id="{$groupId}" data-wc-resizedirection="h">
 				<xsl:apply-templates select="ui:treeitem">
 					<xsl:with-param name="disabled" select="@disabled"/>
 				</xsl:apply-templates>
 				<span class="wc_branch_resizer" aria-hidden="true">
-					<button type="button" class="wc-nobutton wc_btn_icon wc-invite wc_resize wc_branch_resize_handle" data-wc-resize="{$groupId}" role="presentation">
+					<button type="button" class="wc-nobutton wc_btn_icon wc-invite wc_resize wc_branch_resize_handle wc-icon" data-wc-resize="{$groupId}" role="presentation">
 						<xsl:call-template name="offscreenSpan">
 							<xsl:with-param name="text" select="'resize handle'"></xsl:with-param>
 						</xsl:call-template>

--- a/wcomponents-theme/src/main/xslt/wc.ui.treeitem.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.treeitem.xsl
@@ -49,7 +49,7 @@
 			<xsl:attribute name="role">
 				<xsl:text>treeitem</xsl:text>
 			</xsl:attribute>
-			
+
 			<xsl:attribute name="aria-selected">
 				<xsl:choose>
 					<xsl:when test="@selected">
@@ -78,13 +78,13 @@
 					<xsl:attribute name="type">
 						<xsl:text>button</xsl:text>
 					</xsl:attribute>
-					
+
 					<!-- leave tabindex on this butten, it is used as a short-hand to find fousable controls in the core menu JavaScript. -->
 					<xsl:attribute name="tabindex">
 						<xsl:text>0</xsl:text>
 					</xsl:attribute>
 					<xsl:call-template name="title"/>
-					<span class="wc_leaf_vopener" aria-hidden="true">
+					<span class="wc_leaf_vopener wc-icon" aria-hidden="true">
 						<xsl:text>&#x0a;</xsl:text>
 					</span>
 					<xsl:call-template name="treeitemContent"/>
@@ -103,7 +103,7 @@
 					<xsl:variable name="nameButtonId">
 							<xsl:value-of select="concat(@id, '-branch-name')"/>
 					</xsl:variable>
-					<button class="wc-nobutton wc-invite wc_leaf_vopener" aria-hidden="true" type="button" tabindex="-1">
+					<button class="wc-nobutton wc-invite wc_leaf_vopener wc-icon" aria-hidden="true" type="button" tabindex="-1">
 						<xsl:text>&#x0a;</xsl:text>
 					</button>
 					<!-- leave tabindex="0" on this button, it is used as a short-hand to find focusable controls in the core menu JavaScript. -->
@@ -130,7 +130,7 @@
 							</xsl:with-param>
 						</xsl:apply-templates>
 						<span class="wc_branch_resizer" aria-hidden="true">
-							<button type="button" class="wc-nobutton wc_btn_icon wc-invite wc_resize wc_branch_resize_handle" data-wc-resize="{$groupId}" role="presentation">
+							<button type="button" class="wc-nobutton wc_btn_icon wc-invite wc_resize wc_branch_resize_handle wc-icon" data-wc-resize="{$groupId}" role="presentation">
 								<xsl:call-template name="offscreenSpan">
 									<xsl:with-param name="text" select="'resize handle'"></xsl:with-param>
 								</xsl:call-template>
@@ -147,7 +147,7 @@
 			<xsl:attribute name="class">
 				<xsl:text>wc_leaf_img</xsl:text>
 				<xsl:if test="not(@imageUrl)">
-					<xsl:text> wc_leaf_noimg</xsl:text>
+					<xsl:text> wc_leaf_noimg wc-icon</xsl:text>
 				</xsl:if>
 			</xsl:attribute>
 			<xsl:if test="@imageUrl">
@@ -157,7 +157,7 @@
 		<span class="wc_leaf_name">
 			<xsl:value-of select="@label"/>
 		</span>
-		<span class="wc_leaf_hopener" aria-hidden="true">
+		<span class="wc_leaf_hopener wc-icon" aria-hidden="true">
 			<xsl:text>&#x0a;</xsl:text>
 		</span>
 	</xsl:template>

--- a/wcomponents-theme/src/main/xslt/wc.ui.video.track_link.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.video.track_link.xsl
@@ -3,7 +3,7 @@
  Output an A element linking to a track file.
 -->
 	<xsl:template match="ui:track" mode="link">
-		<a href="{@src}" class="wc-track">
+		<a href="{@src}" class="wc-track wc-icon">
 			<xsl:if test="@lang">
 				<xsl:attribute name="lang">
 					<xsl:value-of select="@lang"/>


### PR DESCRIPTION
Added utility classes `wc-icon` and `wc-icon-right`.

`wc-icon` is used internally to reduce the amount of generated Sass. It
can be used as an add-on class value to add an FA icon to other
components. Updated the WButtonExample to show this in action.

`wc-icon-after` puts the icon to the right of the content by floating
the `before` pseudo-element. This is because FA uses the `before` and
does not allow us to easily move it to `after`.

Updated the Examples furniture to use `wc-icon` rather than using pngs
in the image buttons to select an example, refresh and reset.

This forms part of #689