### PR TITLE
WDataTable accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,12 @@
   entities to their unicode characters but will not unescape the five basic XML character entities. Very handy for
   converting HTML to valid XML! Needed for #620.
 * WAjaxControl: deprecated set/getLoadCount. In future use set/isLoadOnce. Required for #495.
+* WDataTable PaginationMode.SERVER remapped to PaginationMode.DYNAMIC (has been enforced in client for over 2 years);
+  removed submitOnRowSelect (never supported in client); SortMode.SERVER mapped to SortMode.DYNAMIC;
+  ExpansionMode.SERVER mapped to ExpansionMode.DYNAMIC. These were all required as part of #701.
 
 ## Bug Fixes
+* Fixed accessibility problems in WDataTable #701.
 * WAjaxControl addressed API errors #495
 * Added HTML sanitizer character entity converter #620.
 * Fixed accessibility problems in WDialog #606.

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WDataTable.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WDataTable.java
@@ -487,21 +487,27 @@ public class WDataTable extends WBeanComponent implements Disableable, Container
 	}
 
 	/**
-	 * Indicates whether the form should submit whenever the row selection changes.
+	 * Indicates whether the form should submit whenever the row selection changes. This <strong>must</strong> be
+	 * <code>false</code> and would be removed if this class was not already deprecated. See
+	 * <a href="https://github.com/BorderTech/wcomponents/issues/701">#701</a>.
 	 *
-	 * @return true if form submission should occur on row selection change, false otherwise.
+	 * @return false
+	 * @deprecated 1.2.0
 	 */
 	public boolean isSubmitOnRowSelect() {
-		return getComponentModel().submitOnRowSelect;
+		return false;
 	}
 
 	/**
-	 * Sets whether the form should submit whenever the row selection changes.
+	 * Sets whether the form should submit whenever the row selection changes. This <strong>must</strong> be
+	 * <code>false</code> and would be removed if this class was not already deprecated. See
+	 * <a href="https://github.com/BorderTech/wcomponents/issues/701">#701</a>.
 	 *
 	 * @param submitOnRowSelect true if form submission should occur on row selection change, false otherwise.
+	 * @deprecated 1.2.0
 	 */
 	public void setSubmitOnRowSelect(final boolean submitOnRowSelect) {
-		getOrCreateComponentModel().submitOnRowSelect = submitOnRowSelect;
+		// No Op
 	}
 
 	/**
@@ -629,12 +635,13 @@ public class WDataTable extends WBeanComponent implements Disableable, Container
 	}
 
 	/**
-	 * Sets the pagination mode.
+	 * Sets the pagination mode. Mode.SERVER mapped to Mode.DYNAMIC to overcome accessibility problem.
 	 *
 	 * @param paginationMode The paginationMode to set.
 	 */
 	public void setPaginationMode(final PaginationMode paginationMode) {
-		getOrCreateComponentModel().paginationMode = paginationMode;
+		getOrCreateComponentModel().paginationMode = paginationMode == PaginationMode.SERVER ? PaginationMode.DYNAMIC
+				: paginationMode;
 	}
 
 	/**
@@ -701,7 +708,7 @@ public class WDataTable extends WBeanComponent implements Disableable, Container
 	 * @param sortMode The sort mode to set.
 	 */
 	public void setSortMode(final SortMode sortMode) {
-		getOrCreateComponentModel().sortMode = sortMode;
+		getOrCreateComponentModel().sortMode = sortMode == SortMode.SERVER ? SortMode.DYNAMIC : sortMode;
 	}
 
 	/**
@@ -746,12 +753,13 @@ public class WDataTable extends WBeanComponent implements Disableable, Container
 	}
 
 	/**
-	 * Sets the row expansion mode.
+	 * Sets the row expansion mode. ExpandMode.SERVER mapped to ExpandMode.DYNAMIC to overcome accessibility problems.
 	 *
 	 * @param expandMode The expand mode to set.
 	 */
 	public void setExpandMode(final ExpandMode expandMode) {
-		getOrCreateComponentModel().expandMode = expandMode;
+		getOrCreateComponentModel().expandMode = expandMode == ExpandMode.SERVER ? ExpandMode.DYNAMIC
+				: expandMode;
 	}
 
 	/**
@@ -1557,7 +1565,7 @@ public class WDataTable extends WBeanComponent implements Disableable, Container
 		/**
 		 * This controls how sorting should function. Sortability is determined by the data model.
 		 */
-		private SortMode sortMode = SortMode.SERVER;
+		private SortMode sortMode = SortMode.DYNAMIC;
 
 		/**
 		 * The data model for the table.
@@ -1654,11 +1662,6 @@ public class WDataTable extends WBeanComponent implements Disableable, Container
 		 * Holds the currently selected row indices.
 		 */
 		private List<Integer> selectedRows;
-
-		/**
-		 * Indicates whether the client should round-trip every time a row is selected.
-		 */
-		private boolean submitOnRowSelect = false;
 
 		// Row expansion
 		/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WDataTableRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WDataTableRenderer.java
@@ -150,7 +150,6 @@ final class WDataTableRenderer extends AbstractWebXmlRenderer {
 			}
 
 			xml.appendOptionalAttribute("groupName", table.getSelectGroup());
-			xml.appendOptionalAttribute("submitOnChange", table.isSubmitOnRowSelect(), "true");
 			xml.appendEnd();
 		}
 
@@ -161,12 +160,10 @@ final class WDataTableRenderer extends AbstractWebXmlRenderer {
 				case CLIENT:
 					xml.appendAttribute("mode", "client");
 					break;
-				case SERVER:
-					xml.appendAttribute("mode", "server");
-					break;
 				case LAZY:
 					xml.appendAttribute("mode", "lazy");
 					break;
+				case SERVER:
 				case DYNAMIC:
 					xml.appendAttribute("mode", "dynamic");
 					break;
@@ -190,11 +187,9 @@ final class WDataTableRenderer extends AbstractWebXmlRenderer {
 			xml.appendOptionalAttribute("descending", col >= 0 && !ascending, "true");
 
 			switch (table.getSortMode()) {
+				case SERVER:
 				case DYNAMIC:
 					xml.appendAttribute("mode", "dynamic");
-					break;
-				case SERVER:
-					xml.appendAttribute("mode", "server");
 					break;
 				default:
 					throw new SystemException("Unknown sort mode: " + table.getSortMode());

--- a/wcomponents-core/src/main/resources/schema/ui/v1/table.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/table.xsd
@@ -187,7 +187,6 @@
 								<xs:documentation>Provides a link with a WSelectToggle so that the WSelectToggle can include row selection in its target group. Only applicable if @multiple is "true".</xs:documentation>
 							</xs:annotation>
 						</xs:attribute>
-						<xs:attributeGroup ref="ui:submitOnChange.attributes"/>
 						<xs:attribute name="selectAll">
 							<xs:annotation>
 								<xs:documentation>Indicates that the user should be provided with control(s) to select and deselect all selectable rows. Only applicable if @multiple is "true".</xs:documentation>

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WDataTable_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WDataTable_Test.java
@@ -154,7 +154,7 @@ public final class WDataTable_Test extends AbstractWComponentTestCase {
 	@Test
 	public void testExpandModeAccessors() {
 		WDataTable table = new WDataTable();
-		WDataTable.ExpandMode type1 = WDataTable.ExpandMode.SERVER;
+		WDataTable.ExpandMode type1 = WDataTable.ExpandMode.CLIENT;
 		WDataTable.ExpandMode type2 = WDataTable.ExpandMode.DYNAMIC;
 
 		Assert.assertEquals("Incorrect default select mode", WDataTable.ExpandMode.NONE, table.
@@ -200,18 +200,17 @@ public final class WDataTable_Test extends AbstractWComponentTestCase {
 	@Test
 	public void testSortModeAccessors() {
 		WDataTable table = new WDataTable();
-		WDataTable.SortMode type1 = WDataTable.SortMode.SERVER;
-		WDataTable.SortMode type2 = WDataTable.SortMode.DYNAMIC;
+		WDataTable.SortMode type1 = WDataTable.SortMode.NONE;
 
-		Assert.assertEquals("Incorrect default select mode", type1, table.getSortMode());
+		Assert.assertEquals("Incorrect default select mode", WDataTable.SortMode.DYNAMIC, table.getSortMode());
 
 		table.setLocked(true);
 		setActiveContext(createUIContext());
-		table.setSortMode(type2);
-		Assert.assertSame("Incorrect select mode for modified session", type2, table.getSortMode());
+		table.setSortMode(type1);
+		Assert.assertSame("Incorrect select mode for modified session", type1, table.getSortMode());
 
 		setActiveContext(createUIContext());
-		Assert.assertSame("Incorrect select mode for other sessions", type1, table.getSortMode());
+		Assert.assertSame("Incorrect select mode for other sessions", WDataTable.SortMode.DYNAMIC, table.getSortMode());
 	}
 
 	@Test
@@ -296,28 +295,6 @@ public final class WDataTable_Test extends AbstractWComponentTestCase {
 
 		setActiveContext(createUIContext());
 		Assert.assertTrue("Incorrect show row indices for other sessions", table.isShowRowIndices());
-	}
-
-	@Test
-	public void testSubmitOnRowSelectAccessors() {
-		WDataTable table = new WDataTable();
-
-		Assert.
-				assertFalse("Should not submit on row select by default", table.
-						isSubmitOnRowSelect());
-
-		table.setSubmitOnRowSelect(true);
-		Assert.assertTrue("Incorrect default submit on row select", table.isSubmitOnRowSelect());
-
-		table.setLocked(true);
-		setActiveContext(createUIContext());
-		table.setSubmitOnRowSelect(false);
-		Assert.assertFalse("Incorrect submit on row select for modified session", table.
-				isSubmitOnRowSelect());
-
-		setActiveContext(createUIContext());
-		Assert.assertTrue("Incorrect submit on row select for other sessions", table.
-				isSubmitOnRowSelect());
 	}
 
 	@Test
@@ -979,9 +956,9 @@ public final class WDataTable_Test extends AbstractWComponentTestCase {
 	@Test
 	public void testSetSortMode() {
 		WDataTable table = new WDataTable();
-		table.setSortMode(WDataTable.SortMode.SERVER);
+		table.setSortMode(WDataTable.SortMode.DYNAMIC);
 
-		Assert.assertEquals("should return SortMode set", WDataTable.SortMode.SERVER, table.
+		Assert.assertEquals("should return SortMode set", WDataTable.SortMode.DYNAMIC, table.
 				getSortMode());
 	}
 

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WDataTableRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WDataTableRenderer_Test.java
@@ -372,7 +372,6 @@ public class WDataTableRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertXpathEvaluatesTo("control", "//ui:table/ui:rowselection/@selectAll", component);
 		assertXpathEvaluatesTo(component.getSelectGroup(), "//ui:table/ui:rowselection/@groupName",
 				component);
-		assertXpathEvaluatesTo(TRUE, "//ui:table/ui:rowselection/@submitOnChange", component);
 	}
 
 	@Test
@@ -391,6 +390,7 @@ public class WDataTableRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertXpathEvaluatesTo("client", "//ui:table/ui:rowexpansion/@mode", component);
 	}
 
+	// SERVER outputs "dynamic" see https://github.com/BorderTech/wcomponents/issues/701
 	@Test
 	public void testDoPaintExpandModeServer() throws IOException, SAXException, XpathException {
 		WDataTable component = new WDataTable();
@@ -404,7 +404,7 @@ public class WDataTableRenderer_Test extends AbstractWebXmlRendererTestCase {
 		component.setExpandMode(ExpandMode.SERVER);
 
 		assertSchemaMatch(component);
-		assertXpathEvaluatesTo("server", "//ui:table/ui:rowexpansion/@mode", component);
+		assertXpathEvaluatesTo("dynamic", "//ui:table/ui:rowexpansion/@mode", component);
 	}
 
 	@Test
@@ -501,6 +501,7 @@ public class WDataTableRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertXpathEvaluatesTo("100", "//ui:table/ui:thead/ui:th[3]/@width", table);
 	}
 
+	// SERVER outputs "dynamic" see https://github.com/BorderTech/wcomponents/issues/701
 	@Test
 	public void testDoPaintSortableSortModeServer() throws IOException, SAXException, XpathException {
 		WDataTable component = new WDataTable();
@@ -514,7 +515,7 @@ public class WDataTableRenderer_Test extends AbstractWebXmlRendererTestCase {
 		component.setSortMode(SortMode.SERVER);
 
 		assertSchemaMatch(component);
-		assertXpathEvaluatesTo("server", "//ui:table/ui:sort/@mode", component);
+		assertXpathEvaluatesTo("dynamic", "//ui:table/ui:sort/@mode", component);
 		assertXpathEvaluatesTo(TRUE, "//ui:table/ui:thead/ui:th[1]/@sortable", component);
 		assertXpathNotExists("//ui:table/ui:thead/ui:th[2]/@sortable", component);
 		assertXpathEvaluatesTo(TRUE, "//ui:table/ui:thead/ui:th[3]/@sortable", component);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/datatable/DataTableOptionsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/datatable/DataTableOptionsExample.java
@@ -355,7 +355,7 @@ public class DataTableOptionsExample extends WContainer {
 			rbsPaging.setSelected(WDataTable.PaginationMode.DYNAMIC);
 			rbsStriping.setSelected(WDataTable.StripingType.NONE);
 			rbsSeparator.setSelected(WDataTable.SeparatorType.NONE);
-			rbsSorting.setSelected(WDataTable.SortMode.SERVER);
+			rbsSorting.setSelected(WDataTable.SortMode.DYNAMIC);
 			showColHeaders.setSelected(true);
 			applySettings();
 			setInitialised(true);

--- a/wcomponents-theme/src/main/js/wc/ui/table/sort.js
+++ b/wcomponents-theme/src/main/js/wc/ui/table/sort.js
@@ -98,7 +98,7 @@ define(["wc/dom/initialise",
 					id = element.id,
 					sorted,
 					controlGroup;
-				if (element === target || (!isEventInLabel(target) && isAcceptableEventTarget(element, target)) && !shed.isDisabled(element)) {
+				if ((element === target || (!isEventInLabel(target) && isAcceptableEventTarget(element, target))) && !shed.isDisabled(element)) {
 					sorted = element.getAttribute(SORT_ATTRIB);
 
 					if (!sorted || sorted.indexOf("reversed") > -1) {

--- a/wcomponents-theme/src/main/js/wc/ui/table/sort.js
+++ b/wcomponents-theme/src/main/js/wc/ui/table/sort.js
@@ -4,16 +4,19 @@
  *
  * @module
  * @requires module:wc/dom/initialise
- * @requires module:wc/dom/Widget
-		"wc/dom/event",
-		"wc/dom/formUpdateManager",
-		"wc/dom/attribute",
+ * @requires module:wc/dom/event
+ * @requires module:wc/dom/formUpdateManager
+ * @requires module:wc/dom/attribute
+ * @requires module:wc/dom/group
  * @requires module:wc/ui/ajaxRegion
  * @requires module:wc/ui/ajax/processResponse
  * @requires module:wc/ui/onloadFocusControl
+ * @requires module:wc/dom/isEventInLabel
+ * @requires module:wc/dom/isAcceptableTarget
+ * @requires module:wc/dom/shed
+ * @requires module:wc/ui/table/common
  */
 define(["wc/dom/initialise",
-		"wc/dom/Widget",
 		"wc/dom/event",
 		"wc/dom/formUpdateManager",
 		"wc/dom/attribute",
@@ -23,10 +26,10 @@ define(["wc/dom/initialise",
 		"wc/ui/onloadFocusControl",
 		"wc/dom/isEventInLabel",
 		"wc/dom/isAcceptableTarget",
-		"wc/timers",
+		"wc/dom/shed",
 		"wc/ui/table/common"],
-	/** @param initialise @param Widget @param event @param formUpdateManager @param attribute @param ajaxRegion @param processResponse @param onloadFocusControl @param isEventInLabel @param isAcceptableEventTarget @param timers @param common @ignore */
-	function(initialise, Widget, event, formUpdateManager, attribute, group, ajaxRegion, processResponse, onloadFocusControl, isEventInLabel, isAcceptableEventTarget, timers, common) {
+	/** @param initialise @param event @param formUpdateManager @param attribute @param ajaxRegion @param processResponse @param onloadFocusControl @param isEventInLabel @param isAcceptableEventTarget @param shed @param common @ignore */
+	function(initialise, event, formUpdateManager, attribute, group, ajaxRegion, processResponse, onloadFocusControl, isEventInLabel, isAcceptableEventTarget, shed, common) {
 		"use strict";
 
 		/**
@@ -50,8 +53,7 @@ define(["wc/dom/initialise",
 				BOOTSTRAPPED = "wc.ui.table.sort.BS",
 				SORT_ATTRIB = "sorted",
 				ARIA_SORT_ATTRIB = "aria-sort",
-				SORTED_COL = SORT_CONTROL.extend("", {"sorted": null}),
-				FORM;
+				SORTED_COL = SORT_CONTROL.extend("", {"sorted": null});
 
 			THEAD.descendFrom(SORTABLE_TABLE, true);
 			SORT_CONTROL.descendFrom(THEAD);
@@ -94,10 +96,9 @@ define(["wc/dom/initialise",
 				var target = $event.target,
 					alias,
 					id = element.id,
-					form,
 					sorted,
 					controlGroup;
-				if (element === target || (!isEventInLabel(target) && isAcceptableEventTarget(element, target))) {
+				if (element === target || (!isEventInLabel(target) && isAcceptableEventTarget(element, target)) && !shed.isDisabled(element)) {
 					sorted = element.getAttribute(SORT_ATTRIB);
 
 					if (!sorted || sorted.indexOf("reversed") > -1) {
@@ -128,12 +129,6 @@ define(["wc/dom/initialise",
 						});
 
 						ajaxRegion.requestLoad(element);
-					}
-					else {
-						FORM = FORM || new Widget("form");
-						if ((form = FORM.findAncestor(element))) {
-							timers.setTimeout(event.fire, 0, form, event.TYPE.submit);
-						}
 					}
 				}
 			}
@@ -168,7 +163,8 @@ define(["wc/dom/initialise",
 						tableId = container.id,
 						sortedColumn;
 
-					if ((sortedColumn = SORTED_COL.findDescendant(next)) && next === SORTABLE_TABLE.findAncestor(sortedColumn)) { // we need to do the reverse to allow for the possibility of nested tables.
+					// we need to do the reverse look-up to allow for the possibility of nested tables.
+					if ((sortedColumn = SORTED_COL.findDescendant(next)) && next === SORTABLE_TABLE.findAncestor(sortedColumn)) {
 						formUpdateManager.writeStateField(stateContainer, tableId + ".sort", sortedColumn.getAttribute("data-wc-columnidx"));
 						if (sortedColumn.getAttribute("sorted").indexOf("reversed") > -1) {
 							formUpdateManager.writeStateField(stateContainer, tableId + ".sortDesc", "true");

--- a/wcomponents-theme/src/main/sass/wc.ui.table.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.color.scss
@@ -3,7 +3,30 @@
 
 thead {
 	background-color: $wc-ui-color-table-head-bg;
-	color: $wc-ui-color-table-head-fg;
+
+	&,
+	.wc-nobutton,
+	.wc-linkbutton,
+	a,
+	a:visited {
+		color: $wc-ui-color-table-head-fg;
+	}
+
+	th[aria-disabled='true'],
+	.wc-nobutton[disabled],
+	.wc-nobutton[disabled],
+	a[aria-disabled='true'] {
+		color: $wc-ui-color-table-head-disabled;
+	}
+
+	th[sorted] {
+		&[aria-disabled='true'],
+		.wc-nobutton[disabled],
+		.wc-nobutton[disabled],
+		a[aria-disabled='true'] {
+			color: $wc-ui-color-disabled-fg;
+		}
+	}
 }
 
 .wc_table_bottom_controls {

--- a/wcomponents-theme/src/main/xslt/wc.common.collapsibleToggle.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.collapsibleToggle.xsl
@@ -1,4 +1,6 @@
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" 
+	xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
 	<xsl:import href="wc.common.toggleElement.xsl"/>
 	<xsl:import href="wc.common.ajax.xsl"/>
 	<xsl:import href="wc.common.n.className.xsl"/>
@@ -22,7 +24,7 @@
 
 		<xsl:variable name="mode">
 			<xsl:choose>
-				<xsl:when test="@roundTrip or @mode='server'">
+				<xsl:when test="@roundTrip"><!-- WCollapsibleToggle, to be removed. -->
 					<xsl:text>server</xsl:text>
 				</xsl:when>
 				<xsl:when test="@mode='dynamic' or @mode='lazy'">
@@ -42,16 +44,16 @@
 		<xsl:variable name="group" select="key('collapsibleGroupKey', $for)"/>
 		<xsl:variable name="targetList">
 			<xsl:choose>
-				<xsl:when test="$mode='server'"><!--server mode does not need a target list, the expansion is done on the server -->
-					<xsl:value-of select="''"/>
-				</xsl:when>
 				<xsl:when test="self::ui:rowexpansion"><!-- a table's rowExpansion always targets the table -->
 					<xsl:value-of select="$for"/>
 				</xsl:when>
 				<xsl:when test="$group">
 					<xsl:apply-templates select="$group" mode="getIdList"/>
 				</xsl:when>
-				<!-- Do not need otherwise as implicit in this is when self::ui:collapsibleToggle and not($group) the value is '' -->
+				<!-- 
+					Do not need otherwise as implicit in this is when self::ui:collapsibleToggle and not($group) the 
+					value is '' 
+				-->
 			</xsl:choose>
 		</xsl:variable>
 		<xsl:variable name="toggleClass">

--- a/wcomponents-theme/src/main/xslt/wc.common.selectToggle.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.selectToggle.xsl
@@ -45,7 +45,6 @@
 		<xsl:param name="name"/>
 		<xsl:param name="for"/>
 		<xsl:param name="selected"/>
-		<xsl:param name="roundTrip"/>
 		<xsl:param name="label"/><!--not set for ui:selecttoggle -->
 		<xsl:param name="type" select="'text'"/>
 
@@ -58,7 +57,7 @@
 
 		<xsl:variable name="mode">
 			<xsl:choose>
-				<xsl:when test="$roundTrip=$t">
+				<xsl:when test="self::ui:selectToggle and @roundTrip">
 					<xsl:text>server</xsl:text>
 				</xsl:when>
 				<xsl:otherwise>

--- a/wcomponents-theme/src/main/xslt/wc.ui.selectToggle.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.selectToggle.xsl
@@ -15,7 +15,6 @@
 		<xsl:call-template name="selectToggle">
 			<xsl:with-param name="for" select="@target"/>
 			<xsl:with-param name="name" select="@id"/>
-			<xsl:with-param name="roundTrip" select="@roundTrip"/>
 			<xsl:with-param name="selected" select="@selected"/>
 			<xsl:with-param name="type">
 				<xsl:choose>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.rowSelection.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.rowSelection.xsl
@@ -68,7 +68,6 @@
 				<xsl:with-param name="id" select="$bodyId"/>
 				<xsl:with-param name="selected" select="$selected"/>
 				<xsl:with-param name="label" select="$controlLabel"/>
-				<xsl:with-param name="roundTrip" select="@submitOnChange"/>
 				<xsl:with-param name="type" select="@selectAll"/>
 			</xsl:call-template>
 		</xsl:if>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.th_thead.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.th_thead.xsl
@@ -59,27 +59,16 @@
 							</xsl:otherwise>
 						</xsl:choose>
 					</xsl:attribute>
-
-					<xsl:variable name="sortMode">
-						<xsl:choose>
-							<xsl:when test="$sortControl/@mode">
-								<xsl:value-of select="$sortControl/@mode"/>
-							</xsl:when>
-							<xsl:otherwise>
-								<xsl:text>dynamic</xsl:text>
-							</xsl:otherwise>
-						</xsl:choose>
-					</xsl:variable>
-
-					<xsl:if test="$sortMode='dynamic'">
-						<xsl:call-template name="tableAjaxController">
-							<xsl:with-param name="tableId" select="$tableId"/>
-						</xsl:call-template>
+					
+					<xsl:call-template name="tableAjaxController">
+						<xsl:with-param name="tableId" select="$tableId"/>
+					</xsl:call-template>
+					
+					<xsl:if test="../../@disabled"><!-- WDataTable only: to be removed. -->
+						<xsl:attribute name="aria-disabled">
+							<xsl:value-of select="$t"/>
+						</xsl:attribute>
 					</xsl:if>
-
-					<xsl:attribute name="data-wc-sortmode">
-						<xsl:value-of select="$sortMode"/>
-					</xsl:attribute>
 				</xsl:if>
 			</xsl:if>
 			<xsl:apply-templates select="ui:decoratedlabel">


### PR DESCRIPTION
* Mapped all WDataTable modes SERVER to DYNAMIC. This removed the
possibility of unexpected changes of context (a11y) and unexpected side
effects (poor UX) from this component.
* Removed Java support for WDataTable’s rowSelection’s submitOnChange.
Note: this has not been supported in client code for a **very** long
time.
* Fixed a flaw which resulted in disabled WDataTables srt columns not being disabled on the client.

Fixes #701.