### PR TITLE
Unescape HTML entities messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,16 +32,16 @@
 * WDialog.isResizeable will always return true as part of fixing #606
 * New utility class `com.github.bordertech.wcomponents.util.HtmlSanitizer` which can be used to sanitize HTML input
   (as shown in WTextArea). Needed for #620.
-* New utility class `com.github.bordertech.wcomponents.util.StringEscapeHTMLToXML` which extends apache-commons lang3
-  StringEscapeUtils. It adds exactly one (static) method `unescapeToXML(String)` which will convert HTML character
-  entities to their unicode characters but will not unescape the five basic XML character entities. Very handy for
-  converting HTML to valid XML! Needed for #620.
+* New utility class `com.github.bordertech.wcomponents.util.StringEscapeHTMLToXML`. It adds exactly one (static) method
+  `unescapeToXML(String)` which will convert HTML character entities to their unicode characters but will not unescape
+  the five basic XML character entities. Very handy for converting HTML to valid XML! Needed for #620.
 * WAjaxControl: deprecated set/getLoadCount. In future use set/isLoadOnce. Required for #495.
 * WDataTable PaginationMode.SERVER remapped to PaginationMode.DYNAMIC (has been enforced in client for over 2 years);
   removed submitOnRowSelect (never supported in client); SortMode.SERVER mapped to SortMode.DYNAMIC;
   ExpansionMode.SERVER mapped to ExpansionMode.DYNAMIC. These were all required as part of #701.
 
 ## Bug Fixes
+* Fixed bug which could result in messages causing XML validation failure #707.
 * Fixed issue which caused WTextarea to not include changes in AJAX posts when in rich-text mode #700.
 * Fixed accessibility problems in WDataTable #701.
 * WAjaxControl addressed API errors #495

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WMessageBox.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WMessageBox.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents;
 
 import com.github.bordertech.wcomponents.util.Duplet;
 import com.github.bordertech.wcomponents.util.I18nUtilities;
+import com.github.bordertech.wcomponents.util.StringEscapeHTMLToXMLUtil;
 import java.io.Serializable;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -240,7 +241,7 @@ public class WMessageBox extends AbstractWComponent implements AjaxTarget, Subor
 
 		for (Duplet<Serializable, Boolean> message : model.messages) {
 			String text = I18nUtilities.format(null, message.getFirst());
-			messages.add(message.getSecond() ? WebUtilities.encode(text) : text);
+			messages.add(message.getSecond() ? WebUtilities.encode(text) : StringEscapeHTMLToXMLUtil.unescapeToXML(text));
 		}
 
 		return Collections.unmodifiableList(messages);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WMessagesExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WMessagesExample.java
@@ -23,15 +23,24 @@ public class WMessagesExample extends WContainer {
 
 		messages.error("Message with encoded mark-up: <a href='http://localhost'>link</a>");
 		messages.error("<a href='http://localhost'>Message with a link</a>", false);
+		messages.error("This is a message with an &bull; entitity");
+		messages.error("This is a message with an &bull; entitity", false);
+
 
 		messages.warn("Message with encoded mark-up: <a href='http://localhost'>link</a>");
 		messages.warn("<a href='http://localhost'>Message with a link</a>", false);
+		messages.warn("This is a message with an &bull; entitity");
+		messages.warn("This is a message with an &bull; entitity", false);
 
 		messages.success("Message with encoded mark-up: <a href='http://localhost'>link</a>");
 		messages.success("<a href='http://localhost'>Message with a link</a>", false);
+		messages.success("This is a message with an &bull; entitity");
+		messages.success("This is a message with an &bull; entitity", false);
 
 		messages.info("Message with encoded mark-up: <a href='http://localhost'>link</a>");
 		messages.info("<a href='http://localhost'>Message with a link</a>", false);
+		messages.info("This is a message with an &bull; entitity");
+		messages.info("This is a message with an &bull; entitity", false);
 
 	}
 


### PR DESCRIPTION
Added means to convert XML-invalid HTML entities in WMessages to their characters. Fixes #707