### PR TITLE
Responsive design opt in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@
 * Fixed GridLayout cell alignment on small screens #652.
 
 ## Enhancements
+* Added utility class `com.github.bordertech.wcomponents.util.HtmlClassUtil` which provides an enum of HTML class
+  attribute values which may be used in `setHtmlClass`. Part of #682.
 * Added new boolean property `sanitizeOnOutput` to WComponents which can output unencoded HTML (WText, WTextArea,
   WLabel). This defaults to false. If set true then the content of the component will be run through the HTML
   sanitizer using the lax policy. This is a necessary extension of #620.

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWComponent.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWComponent.java
@@ -3,6 +3,7 @@ package com.github.bordertech.wcomponents;
 import com.github.bordertech.wcomponents.layout.UIManager;
 import com.github.bordertech.wcomponents.registry.UIRegistry;
 import com.github.bordertech.wcomponents.util.Config;
+import com.github.bordertech.wcomponents.util.HtmlClassUtil;
 import com.github.bordertech.wcomponents.util.I18nUtilities;
 import com.github.bordertech.wcomponents.util.SystemException;
 import com.github.bordertech.wcomponents.util.Util;
@@ -1656,9 +1657,18 @@ public abstract class AbstractWComponent implements WComponent {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void setHtmlClass(final String text, final Serializable... args) {
+	public void setHtmlClass(final String text) {
 		ComponentModel model = getOrCreateComponentModel();
-		model.setHtmlClass(text, args);
+		model.setHtmlClass(text);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void setHtmlClass(final HtmlClassUtil.HtmlClassName className) {
+		ComponentModel model = getOrCreateComponentModel();
+		model.setHtmlClass(className);
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/ComponentModel.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/ComponentModel.java
@@ -1,5 +1,6 @@
 package com.github.bordertech.wcomponents;
 
+import com.github.bordertech.wcomponents.util.HtmlClassUtil;
 import com.github.bordertech.wcomponents.util.I18nUtilities;
 import com.github.bordertech.wcomponents.util.ReflectionUtil;
 import com.github.bordertech.wcomponents.util.Util;
@@ -319,10 +320,7 @@ public class ComponentModel implements WebModel, Externalizable {
 					Object sharedValue = field.get(sharedModel);
 					Object sessionValue = copyData(sharedValue);
 					field.set(this, sessionValue);
-				} catch (IllegalAccessException e) {
-					LOG.error("Failed to set field " + field.getName() + " on " + getClass().
-							getName(), e);
-				} catch (IllegalArgumentException e) {
+				} catch (IllegalAccessException | IllegalArgumentException e) {
 					LOG.error("Failed to set field " + field.getName() + " on " + getClass().
 							getName(), e);
 				}
@@ -543,10 +541,16 @@ public class ComponentModel implements WebModel, Externalizable {
 
 	/**
 	 * @param text The HTML class name text to set.
-	 * @param args optional message format arguments.
 	 */
-	protected void setHtmlClass(final String text, final Serializable... args) {
-		this.htmlClass = I18nUtilities.asMessage(text, args);
+	protected void setHtmlClass(final String text) {
+		this.htmlClass = text;
+	}
+
+	/**
+	 * @param className The HTML class name to set.
+	 */
+	protected void setHtmlClass(final HtmlClassUtil.HtmlClassName className) {
+		this.htmlClass = className.toString();
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WComponent.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WComponent.java
@@ -1,5 +1,6 @@
 package com.github.bordertech.wcomponents;
 
+import com.github.bordertech.wcomponents.util.HtmlClassUtil;
 import com.github.bordertech.wcomponents.validation.Diagnostic;
 import com.github.bordertech.wcomponents.validation.ValidatingAction;
 import java.io.Serializable;
@@ -499,9 +500,15 @@ public interface WComponent extends WebComponent {
 	 * theme and are used for core functionality and styling.
 	 *
 	 * @param className the HTML class attribute's value to add to the component.
-	 * @param args optional arguments for the message format string.
 	 */
-	void setHtmlClass(final String className, Serializable... args);
+	void setHtmlClass(final String className);
+
+	/**
+	 * Sets additional HTML class name for this component from a set of preset values.
+	 *
+	 * @param className the HTML class attribute's value to add to the component derived from the utility enum
+	 */
+	void setHtmlClass(final HtmlClassUtil.HtmlClassName className);
 
 	/**
 	 * Returns the HTML class name string to apply to a component. Some values in the HTML class name attribute are

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/HtmlClassUtil.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/HtmlClassUtil.java
@@ -1,0 +1,406 @@
+package com.github.bordertech.wcomponents.util;
+
+import org.apache.commons.configuration.Configuration;
+
+
+/**
+ * Provides an enum which can be used to add HTML class attribute values to components.
+ *
+ * <p>
+ * Included are a set of helpers to attach icons. By default these will apply icons from the <a href="http://fontawesome.io/icons/">Font Awesome</a>
+ * library included with the default theme. Each icon may be individually overridden using a configuration property. Each overrideable icon
+ * includes documentation of the configuration parameter used to set the icon's HTML class attribute value. If the default icons are changed your
+ * theme must include a way to ensure the new icon is available. This is safest if simply changing to an alternate
+ * <a href="http://fontawesome.io/icons/">Font Awesome</a> icon.
+ * </p>
+ *
+ * @author Mark Reeves
+ * @since 1.2.0
+ */
+public class HtmlClassUtil {
+	/**
+	 * The configuration instance.
+	 */
+	private static final Configuration CONFIG = Config.getInstance();
+
+	/**
+	 * The help icon HTML class. Defaults to a <a href="http://fontawesome.io/icons/">Font Awesome</a> question mark icon.
+	 */
+	private static final String HELP_ICON = CONFIG.getString("com.github.bordertech.wcomponents.HtmlClass.icon.help", "fa-question-circle");
+
+	/**
+	 * The info icon HTML class. Defaults to a <a href="http://fontawesome.io/icons/">Font Awesome</a> icon as per the default theme.
+	 */
+	private static final String INFO_ICON = CONFIG.getString("com.github.bordertech.wcomponents.HtmlClass.icon.info", "fa-info-circle");
+
+	/**
+	 * The warning icon. Defaults to a <a href="http://fontawesome.io/icons/">Font Awesome</a> icon as per the default theme.
+	 */
+	private static final String WARN_ICON = CONFIG.getString("com.github.bordertech.wcomponents.HtmlClass.icon.warn", "fa-exclamation-triangle");
+
+	/**
+	 * The error icon. Defaults to a <a href="http://fontawesome.io/icons/">Font Awesome</a> icon as per the default theme.
+	 */
+	private static final String ERROR_ICON = CONFIG.getString("com.github.bordertech.wcomponents.HtmlClass.icon.error", "fa-minus-circle");
+
+	/**
+	 * The success icon. Defaults to a <a href="http://fontawesome.io/icons/">Font Awesome</a> icon as per the default theme.
+	 */
+	private static final String SUCCESS_ICON = CONFIG.getString("com.github.bordertech.wcomponents.HtmlClass.icon.success", "fa-check-circle");
+
+	// ACTION ICONS
+
+	/**
+	 * The save icon HTML class. Defaults to a <a href="http://fontawesome.io/icons/">Font Awesome</a> icon.
+	 */
+	private static final String SAVE_ICON = CONFIG.getString("com.github.bordertech.wcomponents.HtmlClass.icon.save", "fa-floppy-o");
+
+	/**
+	 * The search icon. Defaults to a <a href="http://fontawesome.io/icons/">Font Awesome</a> icon.
+	 */
+	private static final String SEARCH_ICON = CONFIG.getString("com.github.bordertech.wcomponents.HtmlClass.icon.search", "fa-search");
+
+	/**
+	 * The cancel icon. Defaults to a <a href="http://fontawesome.io/icons/">Font Awesome</a> icon.
+	 */
+	private static final String CANCEL_ICON = CONFIG.getString("com.github.bordertech.wcomponents.HtmlClass.icon.cancel", "fa-ban");
+
+	/**
+	 * The add icon. Defaults to a <a href="http://fontawesome.io/icons/">Font Awesome</a> icon. The default icon is the same as is used in
+	 * {@link com.github.bordertech.wcomponents.WMultiTextField} and {@link com.github.bordertech.wcomponents.WMultiDropdown}.
+	 */
+	private static final String ADD_ICON = CONFIG.getString("com.github.bordertech.wcomponents.HtmlClass.icon.add", "fa-plus-square");
+
+	/**
+	 * The delete icon. Defaults to a <a href="http://fontawesome.io/icons/">Font Awesome</a> icon. The default icon is the same as is used in
+	 * {@link com.github.bordertech.wcomponents.WMultiTextField} and {@link com.github.bordertech.wcomponents.WMultiDropdown}.
+	 */
+	private static final String DELETE_ICON = CONFIG.getString("com.github.bordertech.wcomponents.HtmlClass.icon.delete", "fa-minus-square");
+
+	/**
+	 * The edit icon. Defaults to a <a href="http://fontawesome.io/icons/">Font Awesome</a> icon.
+	 */
+	private static final String EDIT_ICON = CONFIG.getString("com.github.bordertech.wcomponents.HtmlClass.icon.edit", "fa-pencil");
+
+	/**
+	 * Provides a set of HTML class attribute values which can be used in
+	 * {@link com.github.bordertech.wcomponents.WComponent.setHtmlClass(HtmlClassName)}.
+	 */
+	public static enum HtmlClassName {
+
+		/**
+		 * Center align the content of any component.
+		 *
+		 * <p>
+		 * Should not be used with {@link com.github.bordertech.wcomponents.WColumn}, {@link com.github.bordertech.wcomponents.WList},
+		 * {@link com.github.bordertech.wcomponents.layout.ListLayout} or {@link com.github.bordertech.wcomponents.layout.ColumnLayout} as these all
+		 * have the ability to set alignment intrinsically to the component/layout.
+		 * </p>
+		 */
+		ALIGN_CENTER ("wc-align-center"),
+
+		/**
+		 * Left align the content of any component. This is not terribly useful as this is the default alignment but can be used to re-set alignment
+		 * if one has used {@link #ALIGN_CENTER} or {@link #ALIGN_CENTER}.
+		 *
+		 * <p>
+		 * Should not be used with {@link com.github.bordertech.wcomponents.WColumn}, {@link com.github.bordertech.wcomponents.WList},
+		 * {@link com.github.bordertech.wcomponents.layout.ListLayout} or {@link com.github.bordertech.wcomponents.layout.ColumnLayout} as these all
+		 * have the ability to set alignment intrinsically to the component/layout.
+		 * </p>
+		 */
+		ALIGN_LEFT ("wc-align-left"),
+
+		/**
+		 * Right align the content of any component.
+		 *
+		 * <p>
+		 * Should not be used with {@link com.github.bordertech.wcomponents.WColumn}, {@link com.github.bordertech.wcomponents.WList},
+		 * {@link com.github.bordertech.wcomponents.layout.ListLayout} or {@link com.github.bordertech.wcomponents.layout.ColumnLayout} as these all
+		 * have the ability to set alignment intrinsically to the component/layout.
+		 * </p>
+		 */
+		ALIGN_RIGHT ("wc-align-center"),
+
+		/**
+		 * Move a component out of the viewport but leave it available for accessibility purposes. This is most useful for
+		 * {@link com.github.bordertech.wcomponents.WHeading} to set accessibility markers but can be used for other explanatory components.
+		 *
+		 * <p>For example one could use this with {@link com.github.bordertech.wcomponents.WStyledText} with whitespace PARAGRAPHS to add some
+		 * explanatory information for visually impaired users if one's UI design is dependent on visual context.</p>
+		 */
+		OFF_SCREEN ("wc-off"),
+
+		/**
+		 * Indicates that this component will opt-in to responsive design options. This is usually relevant to layout components such as
+		 * {@link com.github.bordertech.wcomponents.WPanel} or {@link com.github.bordertech.wcomponents.WRow}
+		 *//**
+		 * Indicates that this component will opt-in to responsive design options. This is usually relevant to layout components such as
+		 * {@link com.github.bordertech.wcomponents.WPanel} or {@link com.github.bordertech.wcomponents.WRow}
+		 */
+		RESPOND ("wc-respond"),
+
+		// ICONS
+
+		/**
+		 * Apply an icon to a component. The icon will appear before any other content in the component. If you have other visible content in the
+		 * component you may prefer to use {@link #ICON_BEFORE} which will put a small gap between the icon and the following content.
+		 *
+		 * <p>
+		 * Must be used in conjunction with  another value available to your theme. By default these are from
+		 * <a href="http://fontawesome.io/icons/">Font Awesome</a>. This is extremely useful for {@link com.github.bordertech.wcomponents.WButton} or
+		 * {@link com.github.bordertech.wcomponents.WLink} when the component has no other visible content.
+		 * </p>
+		 */
+		ICON ("wc-icon"),
+
+		/**
+		 * Apply an icon to the end of a component. The icon will appear after any other content in the component and there will be a small gap
+		 * between the end of the content and the icon.
+		 *
+		 * <p>
+		 * Must be used in conjunction with  another value available to your theme. By default these are from
+		 * <a href="http://fontawesome.io/icons/">Font Awesome</a>. This is extremely useful for {@link com.github.bordertech.wcomponents.WButton} or
+		 * {@link com.github.bordertech.wcomponents.WLink} when the component has visible text.
+		 * </p>
+		 */
+		ICON_AFTER ("wc-icon-after"),
+
+		/**
+		 * Apply an icon to the beginning of a component. The icon will appear before any other content in the component.and there will be a small gap
+		 * between the icon and the content.
+		 *
+		 * <p>
+		 * Must be used in conjunction with  another value available to your theme. By default these are from
+		 * <a href="http://fontawesome.io/icons/">Font Awesome</a>. This is extremely useful for {@link com.github.bordertech.wcomponents.WButton} or
+		 * {@link com.github.bordertech.wcomponents.WLink} when the component has visible text.
+		 * </p>
+		 */
+		ICON_BEFORE ("wc-icon-before"),
+
+		// START OF ICONS: some helpers to attach common icons.
+
+		/**
+		 * Apply a "help" icon to a component. Most useful for {@link com.github.bordertech.wcomponents.WButton} or
+		 * {@link com.github.bordertech.wcomponents.WLink}
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.help".</p>
+		 */
+		ICON_HELP ("wc-icon " + HELP_ICON),
+
+		/**
+		 * Apply a "help" icon to the end of a component.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.help".</p>
+		 */
+		ICON_HELP_AFTER ("wc-icon-after " + HELP_ICON),
+
+		/**
+		 * Apply a "help" icon to the beginning of a component.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.help".</p>
+		 */
+		ICON_HELP_BEFORE ("wc-icon-before " + HELP_ICON),
+
+		// STATUS ICONS
+
+		/**
+		 * Apply an "information" icon to a component. Do not use with {@link com.github.bordertech.wcomponents.WMessageBox}.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.info".</p>
+		 */
+		ICON_INFO ("wc-icon " + INFO_ICON),
+
+		/**
+		 * Apply an "information" icon to the end of a component. Do not use with {@link com.github.bordertech.wcomponents.WMessageBox}.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.info".</p>
+		 */
+		ICON_INFO_AFTER ("wc-icon-after " + INFO_ICON),
+
+		/**
+		 * Apply an "information" icon to the beginning of a component. Do not use with {@link com.github.bordertech.wcomponents.WMessageBox}.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.info".</p>
+		 */
+		ICON_INFO_BEFORE ("wc-icon-before " + INFO_ICON),
+
+		/**
+		 * Apply a "warning" icon to a component. Do not use with {@link com.github.bordertech.wcomponents.WMessageBox}.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.warn".</p>
+		 */
+		ICON_WARN ("wc-icon " + WARN_ICON),
+
+		/**
+		 * Apply a "warning" icon to the end of a component. Do not use with {@link com.github.bordertech.wcomponents.WMessageBox}.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.warn".</p>
+		 */
+		ICON_WARN_AFTER ("wc-icon-after " + WARN_ICON),
+
+		/**
+		 * Apply a "warning" icon to the end of a component. Do not use with {@link com.github.bordertech.wcomponents.WMessageBox}.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.warn".</p>
+		 */
+		ICON_WARN_BEFORE ("wc-icon-before " + WARN_ICON),
+
+		/**
+		 * Apply an "error" icon to a component. Do not use with {@link com.github.bordertech.wcomponents.WMessageBox}.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.error".</p>
+		 */
+		ICON_ERROR ("wc-icon " + ERROR_ICON),
+
+		/**
+		 * Apply an "error" icon to the end of a component. Do not use with {@link com.github.bordertech.wcomponents.WMessageBox}.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.error".</p>
+		 */
+		ICON_ERROR_AFTER ("wc-icon-after " + ERROR_ICON),
+
+		/**
+		 * Apply an "error" icon to the beginning of a component. Do not use with {@link com.github.bordertech.wcomponents.WMessageBox}.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.error".</p>
+		 */
+		ICON_ERROR_BEFORE ("wc-icon-before " + ERROR_ICON),
+
+		/**
+		 * Apply a "success" icon to a component. Do not use with {@link com.github.bordertech.wcomponents.WMessageBox}.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.success".</p>
+		 */
+		ICON_SUCCESS ("wc-icon " + SUCCESS_ICON),
+
+		/**
+		 * Apply a "success" icon to the end of a component. Do not use with {@link com.github.bordertech.wcomponents.WMessageBox}.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.success".</p>
+		 */
+		ICON_SUCCESS_AFTER ("wc-icon-after " + SUCCESS_ICON),
+
+		/**
+		 * Apply a "success" icon to the beginning of a component. Do not use with {@link com.github.bordertech.wcomponents.WMessageBox}.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.success".</p>
+		 */
+		ICON_SUCCESS_BEFORE ("wc-icon-before " + SUCCESS_ICON),
+
+		// ACTION ICONS
+
+		/**
+		 * Add an "add" icon. The default icon is the same as is used in WMultiTextField and WMultiDropdown.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.add".</p>
+		 */
+		ICON_ADD ("wc-icon " + ADD_ICON),
+
+		/**
+		 * Add an "add" icon to the end of a component. The default icon is the same as is used in WMultiTextField and WMultiDropdown.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.add".</p>
+		 */
+		ICON_ADD_AFTER ("wc-icon-after " + ADD_ICON),
+
+		/**
+		 * Add an "add" icon to the beginning of a component. The default icon is the same as is used in WMultiTextField and WMultiDropdown.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.add".</p>
+		 */
+		ICON_ADD_BEFORE ("wc-icon-before " + ADD_ICON),
+
+		/**
+		 * Add a "delete" icon. The default icon is the same as is used in WMultiTextField and WMultiDropdown.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.delete".</p>
+		 */
+		ICON_DELETE ("wc-icon " + DELETE_ICON),
+
+		/**
+		 * Add a "delete" icon to the end of a component. The default icon is the same as is used in WMultiTextField and WMultiDropdown.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.delete".</p>
+		 */
+		ICON_DELETE_AFTER ("wc-icon-after " + DELETE_ICON),
+
+		/**
+		 * Add a "delete" icon to the beginning of a component. The default icon is the same as is used in WMultiTextField and WMultiDropdown.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.delete".</p>
+		 */
+		ICON_DELETE_BEFORE ("wc-icon-before " + DELETE_ICON),
+
+		/**
+		 * Add an "edit" icon.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.edit".</p>
+		 */
+		ICON_EDIT ("wc-icon " + EDIT_ICON),
+
+		/**
+		 * Add an "edit" icon to the end of a component.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.edit".</p>
+		 */
+		ICON_EDIT_AFTER ("wc-icon-after " + EDIT_ICON),
+
+		/**
+		 * Add an "edit" icon to the beginning of a component.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.edit".</p>
+		 */
+		ICON_EDIT_BEFORE ("wc-icon-before " + EDIT_ICON),
+
+		/**
+		 * Add a "save" icon.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.save".</p>
+		 */
+		ICON_SAVE ("wc-icon " + SAVE_ICON),
+
+		/**
+		 * Add a "save" icon to the end of a component.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.save".</p>
+		 */
+		ICON_SAVE_AFTER ("wc-icon-after " + SAVE_ICON),
+
+		/**
+		 * Add a "save" icon to the beginning of a component.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.save".</p>
+		 */
+		ICON_SAVE_BEFORE ("wc-icon-before " + SAVE_ICON),
+
+		/**
+		 * Add a "search" icon.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.search".</p>
+		 */
+		ICON_SEARCH ("wc-icon " + SEARCH_ICON),
+
+		/**
+		 * Add a "search" icon to the end of a component.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.search".</p>
+		 */
+		ICON_SEARCH_AFTER ("wc-icon-after " + SEARCH_ICON),
+
+		/**
+		 * Add a "search" icon to the beginning of a component.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.search".</p>
+		 */
+		ICON_SEARCH_BEFORE ("wc-icon-before " + SEARCH_ICON),
+
+		/**
+		 * Add a "cancel" icon.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.cancel".</p>
+		 */
+		ICON_CANCEL ("wc-icon " + CANCEL_ICON),
+
+		/**
+		 * Add a "cancel" icon to the end of a component.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.cancel".</p>
+		 */
+		ICON_CANCEL_AFTER ("wc-icon-after " + CANCEL_ICON),
+
+		/**
+		 * Add a "cancel" icon to the beginning of a component.
+		 * <p>To change the icon use configuration param "com.github.bordertech.wcomponents.HtmlClass.icon.cancel".</p>
+		 */
+		ICON_CANCEL_BEFORE ("wc-icon-before " + CANCEL_ICON);
+
+		// END OF ICONS
+
+		private final String className;
+
+		/**
+		 * Instantiate each item in the enum.
+		 * @param className the string value of the item
+		 */
+		HtmlClassName(final String className) {
+			this.className = className;
+		}
+
+		/**
+		 * @return the value to be used in the HTML element's class attribute
+		 */
+		@Override
+		public String toString() {
+			return this.className;
+		}
+	}
+}

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/HtmlClassUtil.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/HtmlClassUtil.java
@@ -86,7 +86,7 @@ public class HtmlClassUtil {
 	 * Provides a set of HTML class attribute values which can be used in
 	 * {@link com.github.bordertech.wcomponents.WComponent.setHtmlClass(HtmlClassName)}.
 	 */
-	public static enum HtmlClassName {
+	public enum HtmlClassName {
 
 		/**
 		 * Center align the content of any component.

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/util/HtmlClassUtilTest.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/util/HtmlClassUtilTest.java
@@ -1,0 +1,26 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.github.bordertech.wcomponents.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for HtmlClassUtil.
+ * @author Mark Reeves
+ * @since 1.2.0
+ */
+public class HtmlClassUtilTest {
+
+
+	@Test
+	public void testToString() {
+		for (HtmlClassUtil.HtmlClassName className : HtmlClassUtil.HtmlClassName.values()) {
+			Assert.assertTrue(className.toString().indexOf("wc-") == 0);
+		}
+	}
+
+}

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WButtonExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WButtonExample.java
@@ -19,6 +19,7 @@ import com.github.bordertech.wcomponents.WText;
 import com.github.bordertech.wcomponents.WTextField;
 import com.github.bordertech.wcomponents.examples.common.ExplanatoryText;
 import com.github.bordertech.wcomponents.layout.FlowLayout;
+import com.github.bordertech.wcomponents.util.HtmlClassUtil;
 
 /**
  * <p>
@@ -165,18 +166,34 @@ public class WButtonExample extends WPanel implements MessageContainer {
 				true));
 
 		add(new WHeading(HeadingLevel.H4, "Using theme icons"));
-		add(new ExplanatoryText("This example shows ways to add a Font-Awesome icon to a button."));
+
+		add(new ExplanatoryText("These examples show ways to add an icon to a button using 'HtmlClassUtil'."));
+
 		WButton iconButton = new WButton("\u200b"); // \u200b is a zero-width space.
+		iconButton.setToolTip("Edit");
+		iconButton.setHtmlClass(HtmlClassUtil.HtmlClassName.ICON_EDIT);
+		add(iconButton);
+
+		iconButton = new WButton("Save");
+		iconButton.setHtmlClass(HtmlClassUtil.HtmlClassName.ICON_SAVE_BEFORE);
+		add(iconButton);
+
+		iconButton = new WButton("Search");
+		iconButton.setHtmlClass(HtmlClassUtil.HtmlClassName.ICON_SEARCH_AFTER);
+		add(iconButton);
+
+		add(new ExplanatoryText("These examples show ways to add a Font-Awesome icon to a button using 'setHtmlClass(String)'."));
+		iconButton = new WButton("\u200b"); // \u200b is a zero-width space.
 		iconButton.setToolTip("Open Menu");
 		iconButton.setHtmlClass("wc-icon fa-bars");
 		add(iconButton);
 
-		iconButton = new WButton(" With text content");
-		iconButton.setHtmlClass("wc-icon fa-hand-o-left");
+		iconButton = new WButton("With text content");
+		iconButton.setHtmlClass("wc-icon-before fa-hand-o-left");
 		add(iconButton);
 
 		iconButton = new WButton("Right icon with text content");
-		iconButton.setHtmlClass("wc-icon-right fa-hand-o-right");
+		iconButton.setHtmlClass("wc-icon-after fa-hand-o-right");
 		add(iconButton);
 	}
 

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/layout/ColumnLayoutExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/layout/ColumnLayoutExample.java
@@ -1,7 +1,12 @@
 package com.github.bordertech.wcomponents.examples.layout;
 
+import com.github.bordertech.wcomponents.Action;
+import com.github.bordertech.wcomponents.ActionEvent;
 import com.github.bordertech.wcomponents.HeadingLevel;
+import com.github.bordertech.wcomponents.WButton;
+import com.github.bordertech.wcomponents.WCheckBox;
 import com.github.bordertech.wcomponents.WContainer;
+import com.github.bordertech.wcomponents.WFieldLayout;
 import com.github.bordertech.wcomponents.WHeading;
 import com.github.bordertech.wcomponents.WHorizontalRule;
 import com.github.bordertech.wcomponents.WPanel;
@@ -9,6 +14,7 @@ import com.github.bordertech.wcomponents.WText;
 import com.github.bordertech.wcomponents.examples.common.ExplanatoryText;
 import com.github.bordertech.wcomponents.layout.ColumnLayout;
 import com.github.bordertech.wcomponents.layout.ColumnLayout.Alignment;
+import com.github.bordertech.wcomponents.util.HtmlClassUtil;
 
 /**
  * Example showing how to use the {@link ColumnLayout} component.
@@ -34,7 +40,6 @@ public class ColumnLayoutExample extends WContainer {
 	 * Creates a ColumnLayoutExample.
 	 */
 	public ColumnLayoutExample() {
-
 		for (int[] colWidths : EXAMPLE_COLUMN_WIDTHS) {
 			addExample(colWidths);
 		}
@@ -44,6 +49,7 @@ public class ColumnLayoutExample extends WContainer {
 		addAlignmentExample();
 		addAutoWidthExample();
 		addAppLevelCSSExample();
+		addResponsiveExample();
 	}
 
 	/**
@@ -53,7 +59,7 @@ public class ColumnLayoutExample extends WContainer {
 	 */
 	private void addExample(final int[] colWidths) {
 
-		add(new WHeading(WHeading.SECTION, getTitle(colWidths)));
+		add(new WHeading(HeadingLevel.H2, getTitle(colWidths)));
 
 		WPanel panel = new WPanel();
 		panel.setLayout(new ColumnLayout(colWidths));
@@ -62,7 +68,26 @@ public class ColumnLayoutExample extends WContainer {
 		for (int i = 0; i < colWidths.length; i++) {
 			panel.add(new BoxComponent(colWidths[i] + "%"));
 		}
-		add(new WHorizontalRule());
+	}
+
+	/**
+	 * Add a column layout which will change its rendering on small screens.
+	 */
+	private void addResponsiveExample() {
+		add(new WHeading(HeadingLevel.H2, "Default responsive design"));
+		add(new ExplanatoryText("This example applies the theme's default responsive design rules for ColumnLayout.\n "
+				+ "The columns have width and alignment and there is also a hgap and a vgap."));
+				WPanel panel = new WPanel();
+		panel.setLayout(new ColumnLayout(new int[]{33, 33, 33},
+				new Alignment[]{Alignment.LEFT, Alignment.CENTER, Alignment.RIGHT}, 12, 18));
+		panel.setHtmlClass(HtmlClassUtil.HtmlClassName.RESPOND);
+		add(panel);
+		panel.add(new BoxComponent("Left"));
+		panel.add(new BoxComponent("Center"));
+		panel.add(new BoxComponent("Right"));
+		panel.add(new BoxComponent("Left"));
+		panel.add(new BoxComponent("Center"));
+		panel.add(new BoxComponent("Right"));
 	}
 
 	/**
@@ -122,6 +147,9 @@ public class ColumnLayoutExample extends WContainer {
 		add(new WHorizontalRule());
 	}
 
+	/**
+	 * This example shows a column which does not have widths set in Java. This is a "good thing": widths should be set in CSS.
+	 */
 	private void addAutoWidthExample() {
 		add(new WHeading(HeadingLevel.H2, "Automatic (app defined) widths"));
 		add(new ExplanatoryText("This example shows what happens if you use undefined (0) column width and do not then define them in CSS."));

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/layout/GridLayoutOptionsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/layout/GridLayoutOptionsExample.java
@@ -13,6 +13,7 @@ import com.github.bordertech.wcomponents.WHorizontalRule;
 import com.github.bordertech.wcomponents.WNumberField;
 import com.github.bordertech.wcomponents.WPanel;
 import com.github.bordertech.wcomponents.layout.GridLayout;
+import com.github.bordertech.wcomponents.util.HtmlClassUtil;
 import com.github.bordertech.wcomponents.validation.Diagnostic;
 import com.github.bordertech.wcomponents.validation.ValidatingAction;
 import com.github.bordertech.wcomponents.validation.WValidationErrors;
@@ -80,6 +81,11 @@ public class GridLayoutOptionsExample extends WContainer {
 	private final WCheckBox cbVisible = new WCheckBox(true);
 
 	/**
+	 * Turn on responsive design.
+	 */
+	private final WCheckBox cbResponsive = new WCheckBox();
+
+	/**
 	 * Creates a GridLayoutExample.
 	 */
 	public GridLayoutOptionsExample() {
@@ -130,6 +136,7 @@ public class GridLayoutOptionsExample extends WContainer {
 		layout.addField("Number of Boxes", boxCount);
 
 		layout.addField("Visible", cbVisible);
+		layout.addField("Allow responsive design", cbResponsive);
 
 		// Apply Button
 		WButton apply = new WButton("Apply");
@@ -140,7 +147,7 @@ public class GridLayoutOptionsExample extends WContainer {
 			}
 		});
 
-		fieldSet.add(apply);
+		layout.addField(apply);
 
 		fieldSet.add(new WAjaxControl(apply, container));
 		fieldSet.setMargin(new Margin(0, 0, 12, 0));
@@ -155,6 +162,11 @@ public class GridLayoutOptionsExample extends WContainer {
 		// Now show an example of the number of different columns
 
 		WPanel gridLayoutPanel = new WPanel();
+
+		if (cbResponsive.isSelected()) {
+			gridLayoutPanel.setHtmlClass(HtmlClassUtil.HtmlClassName.RESPOND);
+		}
+
 		GridLayout layout = new GridLayout(rowCount.getValue().intValue(), columnCount.getValue()
 				.intValue(),
 				hGap.getValue().intValue(),

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/picker/TreePicker.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/picker/TreePicker.java
@@ -14,6 +14,7 @@ import com.github.bordertech.wcomponents.WTextField;
 import com.github.bordertech.wcomponents.examples.common.ExplanatoryText;
 import com.github.bordertech.wcomponents.layout.ColumnLayout;
 import com.github.bordertech.wcomponents.layout.ListLayout;
+import com.github.bordertech.wcomponents.util.HtmlClassUtil;
 import com.github.bordertech.wcomponents.util.Util;
 import com.github.bordertech.wcomponents.validation.ValidatingAction;
 import java.text.SimpleDateFormat;
@@ -79,6 +80,7 @@ public class TreePicker extends WContainer {
 		mainPanel.setIdName("main_panel");
 		mainPanel.setLayout(new ColumnLayout(COL_WIDTH, COL_ALIGN, COL_HGAP, COL_VGAP));
 		mainPanel.setMargin(new Margin(COL_HGAP));
+		mainPanel.setHtmlClass(HtmlClassUtil.HtmlClassName.RESPOND);
 
 		buildUI();
 	}

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WRowExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WRowExample.java
@@ -9,6 +9,7 @@ import com.github.bordertech.wcomponents.WText;
 import com.github.bordertech.wcomponents.examples.common.ExplanatoryText;
 import com.github.bordertech.wcomponents.layout.FlowLayout;
 import com.github.bordertech.wcomponents.layout.FlowLayout.Alignment;
+import com.github.bordertech.wcomponents.util.HtmlClassUtil;
 
 /**
  * Example showing how to use the {@link WRow} component.
@@ -47,10 +48,15 @@ public class WRowExample extends WPanel {
 		add(createRow(0, new int[]{0, 0, 0}));
 		addAppLevelCSSExample();
 
-		// WRow with no responsive design
-		WRow unresponsiveRow = createRow(8, new int[]{25, 25, 25, 25});
-		add(unresponsiveRow);
-		unresponsiveRow.setHtmlClass("wc-norespond");
+		// create a WRow with responsive design turned on.
+		add(new WHeading(HeadingLevel.H2, "WRow with default responsive design"));
+		WRow responsiveRow = createRow(16, new int[]{20, 50, 30});
+		responsiveRow.setHtmlClass(HtmlClassUtil.HtmlClassName.RESPOND);
+		add(responsiveRow);
+
+		((WColumn) responsiveRow.getChildAt(responsiveRow.getChildCount() - 1)).setAlignment(WColumn.Alignment.RIGHT);
+		((WColumn) responsiveRow.getChildAt(1)).setAlignment(WColumn.Alignment.CENTER);
+
 	}
 
 	/**

--- a/wcomponents-theme/build-css.xml
+++ b/wcomponents-theme/build-css.xml
@@ -223,12 +223,17 @@
 		<attribute name="destFile" />
 		<sequential>
 			<property name="cleancss.executable" location="${basedir}/node_modules/clean-css/bin/cleancss"/>
-			<echo>node ${cleancss.executable} --skip-rebase --skip-import --rounding-precision -1 -o @{destFile} @{sourceFile}</echo>
+			<echo>node ${cleancss.executable} --skip-import --skip-aggressive-merging --skip-rebase --rounding-precision -1 -o @{destFile} @{sourceFile}</echo>
 			<nodejs.exec failonerror="true" cwd="${target.rootdir}">
 				<arguments>
 					<arg value="${cleancss.executable}"/>
-					<arg value="--skip-rebase"/>
 					<arg value="--skip-import"/>
+<!--					<arg value="-\-skip-advanced"/>-->
+					<arg value="--skip-aggressive-merging"/>
+<!--					<arg value="-\-skip-media-merging"/>-->
+					<arg value="--skip-rebase"/>
+<!--					<arg value="-\-skip-restructuring"/>
+					<arg value="-\-skip-shorthand-compacting"/> -->
 					<arg value="--rounding-precision"/>
 					<arg value="-1"/>
 					<arg value="-o"/>
@@ -243,8 +248,9 @@
 	<target name="imagesToDataUrl" description="Convert images urls to base64 data urls in CSS files">
 		<if>
 			<and>
-				<available file="${images.tmp.src.dir}" type="dir" />
+				<istrue value="${build.optimise.http1}"/>
 				<istrue value="${images.to.base64.dataurls}" />
+				<available file="${images.tmp.src.dir}" type="dir" />
 			</and>
 			<then>
 				<stopwatch name="imagesToDataUrl" action="start" />

--- a/wcomponents-theme/build-import.xml
+++ b/wcomponents-theme/build-import.xml
@@ -3,6 +3,14 @@
 
 	<import file="build-import-overrides.xml" optional="true"/>
 
+	<!--
+		Eventually this build will optimise for http2 unless this property is true. Also eventually the default for
+		this property will be false.
+
+		As a first cut, if this property is "false" then we will not base64 encode images into the CSS.
+	-->
+	<property name="build.optimise.http1" value="true"/>
+
 	<!-- GLOBAL PROPERTIES: used in both input and output tasks -->
 	<property name="tmp.dir" location="${theme.tmp.dir}"/>
 	<property name="maven.project.name" value="${project.name}"/>

--- a/wcomponents-theme/src/main/sass/_gridLayout.respond.scss
+++ b/wcomponents-theme/src/main/sass/_gridLayout.respond.scss
@@ -1,0 +1,154 @@
+// Default responsive design for GridLayout
+// opt-in by setting class "wc-respond" on its containing WPanel.
+// This is a proof of concept and is probably overkill.
+@include respond-small-screen {
+	.wc-respond {
+		// NOTE: I used loops here but removed them as the output CSS is much larger .
+		// It seems that the Sass compiler and css-cleaner are not able to compress these complex rules correctly.
+		> .wc-gridlayout-col-6,
+		> .wc-gridlayout-col-7,
+		> .wc-gridlayout-col-8,
+		> .wc-gridlayout-col-9,
+		> .wc-gridlayout-col-10,
+		> .wc-gridlayout-col-11,
+		> .wc-gridlayout-col-12 {
+			> .wc_gl_row {
+				@include flex-wrap(wrap);
+
+				+ .wc_gl_row,
+				> .wc-cell {
+					margin-top: $wc-gap-small;
+				}
+
+				> :first-child,
+				> :nth-child(2),
+				> :nth-child(3) {
+					margin-top: 0;
+				}
+			}
+		}
+
+		// 6, 9 cols simulate 3 cols
+		> .wc-gridlayout-col-6,
+		> .wc-gridlayout-col-9 {
+			> .wc_gl_row {
+				> .wc-cell {
+					width: percentage(1 / 3);
+				}
+
+				> :nth-child(3n) {
+					padding-right: 0;
+				}
+
+				> :nth-child(3n - 2) {
+					padding-left: 0;
+				}
+			}
+
+		}
+
+		// 7, 8, 11, 12 simulate 4 cols.
+		> .wc-gridlayout-col-7,
+		> .wc-gridlayout-col-8,
+		> .wc-gridlayout-col-11,
+		> .wc-gridlayout-col-12 {
+			> .wc_gl_row {
+				> .wc-cell {
+					width: 25%;
+				}
+
+				> :nth-child(4) {
+					margin-top: 0;
+				}
+
+				> :nth-child(4n) {
+					padding-right: 0;
+				}
+
+				> :nth-child(4n - 3) {
+					padding-left: 0;
+				}
+			}
+		}
+
+		// 10 cols simulate 5 cols.
+		> .wc-gridlayout-col-10 > .wc_gl_row {
+			> .wc-cell {
+				width: 20%;
+			}
+
+			> :nth-child(4),
+			> :nth-child(5) {
+				margin-top: 0;
+			}
+
+			> :nth-child(5n) {
+				padding-right: 0;
+			}
+
+			> :nth-child(5n - 4) {
+				padding-left: 0;
+			}
+		}
+	}
+}
+
+@include respond-phonelike {
+	.wc-respond {
+		> .wc-gridlayout-col-5 > .wc_gl_row {
+			@include flex-wrap(wrap);
+		}
+
+		> .wc-gridlayout > .wc_gl_row {
+			> .wc-cell {
+				margin-top: $wc-gap-small;
+				width: 50%;
+			}
+
+			> :first-child,
+			> :nth-child(2) {
+				margin-top: 0;
+			}
+		}
+
+		> .wc-gridlayout-col-4,
+		> .wc-gridlayout-col-5,
+		> .wc-gridlayout-col-7,
+		> .wc-gridlayout-col-8,
+		> .wc-gridlayout-col-11 {
+			> .wc_gl_row {
+
+				> :nth-child(even) {
+					padding-right: 0;
+				}
+
+				> :nth-child(odd) {
+					padding-left: 0;
+				}
+			}
+		}
+
+		> .wc-gridlayout-col-3,
+		> .wc-gridlayout-col-6,
+		> .wc-gridlayout-col-9,
+		> .wc-gridlayout-col-12 {
+			> .wc_gl_row {
+				> .wc-cell {
+					width: percentage(1 / 3);
+				}
+
+				> :nth-child(3) {
+					margin-top: 0;
+				}
+
+				> :nth-child(3n) {
+					padding-right: 0;
+				}
+
+				> :nth-child(3n - 2) {
+					padding-left: 0;
+				}
+			}
+		}
+	}
+}

--- a/wcomponents-theme/src/main/sass/_implementation_vars.scss
+++ b/wcomponents-theme/src/main/sass/_implementation_vars.scss
@@ -1,2 +1,2 @@
-// This file left blank. Override it in your implementation to override default vars. This is the first import in
-// _vars.scss.
+// This file left blank. Override it in your implementation to override default vars.
+// This is the first import in _vars.scss.

--- a/wcomponents-theme/src/main/sass/_rowColumn.respond.scss
+++ b/wcomponents-theme/src/main/sass/_rowColumn.respond.scss
@@ -1,0 +1,19 @@
+// Default responsive design for rows and columns
+// opt-in for ColumnLayout by setting class "wc-respond" on its containing WPanel.
+// opt in for WRow/WColumn by setting class "wc-respond" the WRow.
+@include respond-phonelike {
+	.wc-row.wc-respond {
+		display: block;
+
+		> .wc-column {
+			display: block;
+			padding-left: 0;
+			padding-right: 0;
+			width: 100%;
+
+			+ .wc-column {
+				margin-top: $wc-gap-small;
+			}
+		}
+	}
+}

--- a/wcomponents-theme/src/main/sass/wc.common.page.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.page.scss
@@ -39,12 +39,18 @@ pre {
 	@include align(center);
 }
 
+
 .wc-icon:before,
-.wc-icon-right:before {
+.wc-icon-before:before,
+.wc-icon-after:before {
 	@include wc-icon;
 }
 
-.wc-icon-right:before {
+.wc-icon-before:before {
+	margin-right: $wc-gap-small;
+}
+
+.wc-icon-after:before {
 	float: right;
 	margin-left: $wc-gap-small;
 }

--- a/wcomponents-theme/src/main/sass/wc.common.rowColumn.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.rowColumn.scss
@@ -33,30 +33,4 @@
 // 	}
 // }
 
-
-@include respond-phonelike {
-	.wc-row:not(.wc-norespond),
-	.wc-panel:not(.wc-norespond) > .wc-columnlayout > .wc-row {
-		display: block;
-
-		> .wc-column {
-			display: block;
-			// width is set inline for WColumn and ColumnLayout. Important to override this inline css.
-			// TODO: Fix this at least for common widths as per WFieldLayout.
-			// scss-lint:disable ImportantRule
-			width: 100%;
-
-			+ .wc-column {
-				margin-top: $wc-gap-small;
-			}
-
-			&,
-			.wc_hgap_sm > &, // see wc.common.hvgap.scss
-			.wc_hgap_med > &,
-			.wc_hgap_lg > & {
-				padding-left: 0;
-				padding-right: 0;
-			}
-		}
-	}
-}
+@import 'rowColumn.respond';

--- a/wcomponents-theme/src/main/sass/wc.ui.checkableSelect.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.checkableSelect.scss
@@ -17,3 +17,26 @@
 		@include padded-box(1px);
 	}
 }
+
+// Normally rows/columns collapse at phonelike size. For checkable selects with columns we collapse
+// at small-screen size to make the groups more usable
+@include respond-small-screen {
+	.wc_chkgrp {
+		.wc-row {
+			@include flex-wrap(wrap);
+		}
+
+		.wc-column {
+			@include flex-grow(1);
+			margin-top: $wc-gap-small;
+			padding-left: 0;
+			padding-right: 0;
+			width: 50%;
+
+			&:first-of-type,
+			&:nth-of-type(2) {
+				margin-top: 0;
+			}
+		}
+	}
+}

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.borderLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.borderLayout.scss
@@ -2,8 +2,8 @@
 @import 'mixins-common';
 
 .wc_bl_mid {
-	@include flex($justify: space-between);
 	// NOTE: the justification should be moot but keep it here
+	@include flex($justify: space-between);
 }
 
 .wc-center,
@@ -34,5 +34,5 @@
 
 .wc-east {
 	@include flex-justify-content(flex-end);
-	text-align: right; // TODO really?
+	text-align: right;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.panel.gridLayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.panel.gridLayout.scss
@@ -6,16 +6,7 @@
 // layout tool and is considered "legacy" and is best avoided. See https://github.com/BorderTech/wcomponents/wiki/WPanel-GridLayout
 
 // The styles in this file assume we allow nested grids or grids with other nested layouts. It would make less CSS if
-// we did not assume this as we could get of the intermediate row class in the the width settings.
-//
-
-// .wc-gridlayout {
-// 	// When there is only one column we do not have rows.
-// 	> .wc-cell {
-// 		display: block;
-// 		width: 100%;
-// 	}
-// }
+// we did not assume this as we could get of the intermediate row class in the  width settings.
 
 // rows in the GridLayout.
 .wc_gl_row {
@@ -28,3 +19,5 @@
 		width: percentage(1 / $i);
 	}
 }
+
+@import 'gridLayout.respond';

--- a/wcomponents-theme/src/main/xslt/wc.common.checkableSelect.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.checkableSelect.xsl
@@ -152,6 +152,10 @@
 						particular positions from this template and use those options to apply the
 						rest of the options in that column.
 					-->
+					
+					<xsl:variable name="rowClass">
+						<xsl:text>wc-row wc_hgap_med wc-respond</xsl:text>
+					</xsl:variable>
 					<xsl:choose>
 						<xsl:when test="$readOnly=1 and $rows=0">
 							<ul>
@@ -184,7 +188,7 @@
 							</xsl:apply-templates>
 						</xsl:when>
 						<xsl:when test="$readOnly=1">
-							<div class="wc-row wc_hgap_med">
+							<div class="{$rowClass}">
 								<xsl:apply-templates select="ui:option[@selected][position() mod $rows = 1]" mode="checkableGroup">
 									<xsl:with-param name="firstItemAccessKey" select="$firstItemAccessKey"/>
 									<xsl:with-param name="inputName" select="$id"/>
@@ -224,7 +228,7 @@
 							</xsl:apply-templates>
 						</xsl:when>
 						<xsl:when test="ui:option">
-							<div class="wc-row wc_hgap_med">
+							<div class="{$rowClass}">
 								<xsl:apply-templates select="ui:option[position() mod $rows = 1]" mode="checkableGroup">
 									<xsl:with-param name="firstItemAccessKey" select="$firstItemAccessKey"/>
 									<xsl:with-param name="inputName" select="$id"/>

--- a/wcomponents-theme/src/main/xslt/wc.common.column.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.column.xsl
@@ -5,7 +5,7 @@
 		Helper template for WColumn and ColumnLayout cells.
 	-->
 	<xsl:template name="column">
-		<xsl:param name="align" select="@align"/>
+		<xsl:param name="align" select="''"/>
 		<xsl:param name="width" select="@width"/>
 
 		<div>
@@ -17,12 +17,24 @@
 			</xsl:if>
 			<xsl:call-template name="makeCommonClass">
 				<xsl:with-param name="additional">
-					<xsl:if test="not($align) or $align = ''">
-						<xsl:text>wc-align-left</xsl:text>
-					</xsl:if>
-					<xsl:if test="not(self::ui:column)">
-						<xsl:text> wc-column</xsl:text>
-					</xsl:if>
+					<xsl:choose>
+						<xsl:when test="self::ui:column">
+							<xsl:if test="not(@align)">
+								<xsl:text>wc-align-left</xsl:text>
+							</xsl:if>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:text>wc-column</xsl:text>
+							<xsl:choose>
+								<xsl:when test="not($align) or $align = ''">
+									<xsl:text> wc-align-left</xsl:text>
+								</xsl:when>
+								<xsl:otherwise>
+									<xsl:value-of select="concat(' wc-align-', $align)"/>
+								</xsl:otherwise>
+							</xsl:choose>
+						</xsl:otherwise>
+					</xsl:choose>
 					<xsl:if test="$width and $width != 0">
 						<xsl:value-of select="concat(' wc_col_',$width)"/>
 					</xsl:if>

--- a/wcomponents-theme/src/main/xslt/wc.ui.columnLayout.cell.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.columnLayout.cell.xsl
@@ -1,4 +1,6 @@
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" 
+	xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
 	<xsl:import href="wc.common.column.xsl"/>
 	<xsl:import href="wc.common.getHVGap.xsl"/>
 	<!--
@@ -24,6 +26,9 @@
 				<xsl:call-template name="getHVGapClass">
 					<xsl:with-param name="gap" select="../@hgap"/>
 				</xsl:call-template>
+				<xsl:if test="contains(ancestor::ui:panel[1]/@class, 'wc-respond')">
+					<xsl:text> wc-respond</xsl:text>
+				</xsl:if>
 			</xsl:attribute>
 			<xsl:call-template name="column">
 				<xsl:with-param name="align" select="$align"/>

--- a/wcomponents-theme/user.xml
+++ b/wcomponents-theme/user.xml
@@ -8,33 +8,33 @@
 		************************************************************************
 		FILE NAME:
 		************************************************************************
-		You must rename this file for it to take effect. You have two choices 
+		You must rename this file for it to take effect. You have two choices
 		for naming:
-		1. {user.name}.xml (e.g. if your user name is mary.jones then name it 
+		1. {user.name}.xml (e.g. if your user name is mary.jones then name it
 			"mary.jones.xml")
 		2. wc_theme_build_properties.xml
 
-		If BOTH files exist and define the same property then the definition/s 
+		If BOTH files exist and define the same property then the definition/s
 		in {user.name}.xml will take precedence.
 
 		************************************************************************
 		FILE LOCATION:
 		************************************************************************
 		You can place these files in two locations:
-		1. The {user.home}/.wc directory (where ever java thinks your home 
+		1. The {user.home}/.wc directory (where ever java thinks your home
 			directory is, create a directory called .wc).
-		2. The "theme" project root directory (e.g. right alongside the build 
+		2. The "theme" project root directory (e.g. right alongside the build
 			scripts)
 
-		If files exist in both locations and define the same property then the 
+		If files exist in both locations and define the same property then the
 		definitions from files in {user.home}/.wc take precedence over those in
 		the project root dir.
 
 		************************************************************************
 		CONTROLLING WHICH THEME IS BUILT
 		************************************************************************
-		This section has been deleted. The WComponent build will now only build 
-		wcomponents-theme. All implementations have been moved to a different Maven 
+		This section has been deleted. The WComponent build will now only build
+		wcomponents-theme. All implementations have been moved to a different Maven
 		project.
 
 		************************************************************************
@@ -48,16 +48,16 @@
 		<property name="npm.loglevel" value="verbose"/>
 
 		minifiy.resources.off:
-			Turning off minification speeds up a build slightly for testing 
-			during development but should not be used routinely. Needing to do 
+			Turning off minification speeds up a build slightly for testing
+			during development but should not be used routinely. Needing to do
 			this is a strong indicator that you need a new dev machine.
 
 		<property name="minifiy.resources.off" value="true"/>
 
 		images.to.base64.dataurls:
-			Turning off base64 encoding of images will also decrease build time 
+			Turning off base64 encoding of images will also decrease build time
 			slightly but again is not recommended or necessary for routine use.
-			It can be handy for debugging SVG issues but usually loading the 
+			It can be handy for debugging SVG issues but usually loading the
 			recalcitrant SVG directly from the target directory will give you
 			better info.
 
@@ -66,17 +66,23 @@
 		tmp.dir:
 			The directory to use as temp during build. Defaults to the JAVA
 			temp directory. Useful in conjunction with build.preserve.tmp.onexit
-			
+
 		<property name="tmp.dir" location="/path/to/temp/build/dir"/>
-		
+
 		build.preserve.tmp.onexit:
-			By default the intermediate artefacts created during the build are 
+			By default the intermediate artefacts created during the build are
 			deleted once the build has finished. If you ever need to debug build
-			problems you may want to preserve these intermediate artefacts. To 
+			problems you may want to preserve these intermediate artefacts. To
 			do so set this property. Not recommended or necessary for routine
 			use.
 
 		<property name="build.preserve.tmp.onexit" value="true"/>
+
+		************************************************************************
+		Optimisation for HTTP2
+		************************************************************************
+		Eventually the build will optimise for http2 unless this property is true.
+		<property name="build.optimise.http1" value="true"/>
 		************************************************************************
 		UNIT TESTING
 		************************************************************************
@@ -84,19 +90,19 @@
 			Comment out this one to run real tests, uncomment it when developing
 			otherwise you will not be able to debug your JavaScript.
 
-			The tests will run against the compressed theme files unless this 
+			The tests will run against the compressed theme files unless this
 			property is set to debug.
 
 			values are one of: minified | debug
 		<property name="test.target.mode" value="debug"/>
-		
+
 		test.environments:
 			Determines which browsers to run tests against.
 			This is written into the intern config file in the "environments" array.
 			By default the value is "{ browserName: 'chrome' }"
-			
+
 			If you wanted, for example, to test IE11 you could uncomment the line below:
-		
+
 		<property name="test.environments" value="{ browserName: 'internet explorer', version: '11' }"/>
 	-->
 </project>


### PR DESCRIPTION
* Updated default small-screen renderings of WRow, WColumn, ColumnLayout, GridLayout and set them to only occur if the relevant component has className `wc-respond` applied.
* Added a utility class to set commonly used HTML class names (including `wc-respond`).
* Added an overload of addHtmlClass to use the enum from the new utility class
* Updated a bunch of examples to use this. Added new WButton examples showing use of ICON parts of the className enum.