### PR TITLE
Tree menu role change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
   will always return true; method `setDescEncode(boolean)` has been deprecated, made final and is now a no-op.
 
 ## Bug Fixes
+* Changed output of WMenu Type TREE from role tree to role menu #619.
 * Fixed bug which could result in messages causing XML validation failure #707.
 * Fixed issue which caused WTextarea to not include changes in AJAX posts when in rich-text mode #700.
 * Fixed accessibility problems in WDataTable #701.
@@ -61,6 +62,8 @@
 * Fixed GridLayout cell alignment on small screens #652.
 
 ## Enhancements
+* Changed the client handling of WTable Actions with constraints to make the action button disabled if the constraints
+  aren't met rather than outputting an error alert. #618
 * Reversed the date input polyfill used by WDateField. Previously we created all of the UI artefacts needed to support
   the polyfill and removed them if the browser supported native date inputs. This has been reversed to output a wrapper
   and input in XSLT and add the other artefacts if native date inputs are not supported. This significantly improves

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/HtmlClassUtil.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/HtmlClassUtil.java
@@ -83,8 +83,7 @@ public class HtmlClassUtil {
 	private static final String EDIT_ICON = CONFIG.getString("com.github.bordertech.wcomponents.HtmlClass.icon.edit", "fa-pencil");
 
 	/**
-	 * Provides a set of HTML class attribute values which can be used in
-	 * {@link com.github.bordertech.wcomponents.WComponent.setHtmlClass(HtmlClassName)}.
+	 * Provides a set of HTML class attribute values.
 	 */
 	public enum HtmlClassName {
 

--- a/wcomponents-theme/src/main/js/wc/ui/menu.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu.js
@@ -14,7 +14,7 @@
  * @requires module:wc/ui/menu/tree
  * @requires module:wc/ui/navigationButton
  */
-define(["wc/ui/menu/bar", "wc/ui/menu/column", "wc/ui/menu/tree", "wc/ui/navigationButton"],
+define(["wc/ui/menu/bar", "wc/ui/menu/column", "wc/ui/menu/tree", "wc/ui/menu/treemenu", "wc/ui/navigationButton"],
 	function() {
 		"use strict";
 		return 1;

--- a/wcomponents-theme/src/main/js/wc/ui/menu/treemenu.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/treemenu.js
@@ -1,5 +1,6 @@
 /**
- * Menu controller extension for WMenu of type COLUMN. This represents a vertical menu with optional flyout submenus.
+ * Menu controller extension for WMenu of type TREE. This represents a vertical menu with optional sliding submenus
+ * which may be indented. See WTree which produces a WAI-ARIA tree widget which is a selection tool.
  *
  * @see {@link http://www.w3.org/TR/wai-aria-practices/#menu}
  * @module
@@ -15,19 +16,14 @@ define(["wc/ui/menu/core", "wc/dom/keyWalker", "wc/dom/shed", "wc/dom/Widget", "
 	function(abstractMenu, keyWalker, shed, Widget, initialise) {
 		"use strict";
 
-		/* Unused dependencies:
-		 * We will need ["wc/ui/menu/menuItem" if we have any selectable items so we get it just in case rather than doing a
-		 * convoluted XPath lookup in XSLT.
-		 */
-
 		/**
-		 * Extends menu functionality to provide a specific implementation of a vertical menu with optional flyout sub-menus.
+		 * Extends menu functionality to provide a tree-like menu.
 		 * @constructor
-		 * @alias module:wc/ui/menu/column~Column
+		 * @alias module:wc/ui/menu/treemenu~TreeMenu
 		 * @extends module:wc/ui/menu/core~AbstractMenu
 		 * @private
 		 */
-		function Column() {
+		function TreeMenu() {
 			/**
 			 * The descriptors for this menu type.
 			 * @type {module:wc/dom/Widget}
@@ -42,7 +38,60 @@ define(["wc/ui/menu/core", "wc/dom/keyWalker", "wc/dom/shed", "wc/dom/Widget", "
 			 * @public
 			 * @override
 			 */
-			this.ROOT = new Widget("", "wc-menu-type-column");
+			this.ROOT = new Widget("", "wc-menu-type-tree");
+
+			/**
+			 * Trees do not cycle siblings.
+			 *
+			 * @var
+			 * @type {Boolean}
+			 * @protected
+			 * @override
+			 */
+			this._cycleSiblings = false;
+
+			/**
+			 * Trees do not enter on open.
+			 *
+			 * @var
+			 * @type {Boolean}
+			 * @protected
+			 * @override
+			 */
+			this.enterOnOpen = false;
+
+			/**
+			 * Trees are not transient.
+			 *
+			 * @var
+			 * @type boolean
+			 * @public
+			 */
+			this.isTransient = false;
+
+			/**
+			 * Tree menu allows multiple submenus to be open.
+			 *
+			 * @function
+			 * @protected
+			 * @override
+			 * @returns {Boolean} true if only one branch may be open at a time.
+			 */
+			this._oneOpen = function() {
+				return false;
+			};
+
+			/**
+			 * Keyboard walking of the tree.
+			 *
+			 * @function
+			 * @protected
+			 * @override
+			 * @returns {Boolean} true.
+			 */
+			this._treeWalkDepthFirst = function() {
+				return true;
+			};
 
 			/**
 			 * Reset the key map based on the type and/or state of the menu item passed in.
@@ -80,49 +129,12 @@ define(["wc/ui/menu/core", "wc/dom/keyWalker", "wc/dom/shed", "wc/dom/Widget", "
 					"DOM_VK_ESCAPE": this._FUNC_MAP.CLOSE_MY_BRANCH
 				};
 			};
-
-			/**
-			 * When a mobile device is used add a close button to the top of every submenu content as the submenus are
-			 * shown near full screen and there is (usually) no ESCAPE key.
-			 *
-			 * @function
-			 * @protected
-			 * @override
-			 * @param {Element} element The element which may be a menu, submenu or something containing a menu.
-			 */
-			this.updateMenusForMobile = function(element) {
-				var candidates,
-					MENU_FIXED = "data-wc-menufixed";
-				if (!this.isSmallScreen) {
-					return;
-				}
-				if (this.isSubMenu(element)) {
-					if (this.getRoot(element)) {
-						this.fixSubMenuContent(element);
-					}
-					return;
-				}
-
-				if (this.isRoot(element)) {
-					candidates = [element];
-				}
-				else {
-					candidates = this.ROOT.findDescendants(element);
-				}
-
-				Array.prototype.forEach.call(candidates, function(next) {
-					if (!next.hasAttribute(MENU_FIXED)) {
-						next.setAttribute(MENU_FIXED, "true");
-						Array.prototype.forEach.call(this.getSubMenu(next, true, true), this.fixSubMenuContent, this);
-					}
-				}, this);
-			};
 		}
 
-		var /** @alias module:wc/ui/menu/column */instance;
-		Column.prototype = abstractMenu;
-		instance = new Column();
-		instance.constructor = Column;
+		var /** @alias module:wc/ui/menu/treemenu */instance;
+		TreeMenu.prototype = abstractMenu;
+		instance = new TreeMenu();
+		instance.constructor = TreeMenu;
 		initialise.register(instance);
 		return instance;
 	});

--- a/wcomponents-theme/src/main/sass/_common.scss
+++ b/wcomponents-theme/src/main/sass/_common.scss
@@ -115,7 +115,7 @@ $wc-menu-flyout-vseparator-pad: $wc-gap-small 0 !default;
 // the gap bewtten the text label of a sub menu and its 'opener' image
 $wc-menu-bar-column-opener-indicator-before-after: $wc-gap-small !default;
 // width of the open state icon in WMenu type TREE
-$wc-menu-tree-iconwidth: $wc-icon-wider !default;
+$wc-menu-tree-iconwidth: $wc-icon-normal !default;
 
 // WFieldLayout
 $wc-fieldlayout-default-label-width: 50%; // Must be a percent between 0 and 100. 25, 33, 50 are recommended options

--- a/wcomponents-theme/src/main/sass/_common.scss
+++ b/wcomponents-theme/src/main/sass/_common.scss
@@ -110,7 +110,7 @@ $wc-menu-bar-column-item-pad: $wc-menu-item-pad-topbottom !default;
 // FLYOUT menu top level items
 $wc-menu-flyout-top-level-item-pad: $wc-gap-small !default;
 // padding of WSeparator at the top level of a BAR or FLYOUT menu (orientation='vertical')
-$wc-menu-bar-vseparator-pad: $wc-gap-normal 0 !default;
+$wc-menu-bar-vseparator-pad: (2 * $wc-menu-item-pad-topbottom) 0 0 0 !default;
 $wc-menu-flyout-vseparator-pad: $wc-gap-small 0 !default;
 // the gap bewtten the text label of a sub menu and its 'opener' image
 $wc-menu-bar-column-opener-indicator-before-after: $wc-gap-small !default;

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumn.scss
@@ -7,48 +7,64 @@
 	display: inline-block;
 }
 
-// full screen sub menus
-[role='menu'][aria-expanded='true'] {
-	@include border-box;
-	height: 100%;
-	left: 0;
-	overflow: auto;
-	position: fixed;
-	top: 0;
-	width: 100%;
+// make manu bars horizontal.
+.wc_menu_bar > .wc-submenu > .wc-submenu-o {
+	.wc-decoratedlabel {
+		display: inline-table;
+		width: auto;
+	}
 
-	> [role] {
-		font-size: $wc-font-larger;
+	.wc-labelbody {
+		width: auto;
+	}
+}
+
+// full screen sub menus
+.wc-menu-type-column,
+.wc_menu_bar {
+	.wc_submenucontent {
+		@include border-box;
+		height: 100%;
+		left: 0;
+		overflow: auto;
+		position: fixed;
+		top: 0;
+		width: 100%;
+
+		> [role] {
+			font-size: $wc-font-larger;
+		}
 	}
 }
 
 
+
 @include respond-not-phone {
-	[role^='menu'] .wc-submenu {
-		position: relative;
-	}
+	.wc-menu-type-column,
+	.wc_menu_bar {
 
-	[role='menu'][aria-expanded='true'] {
-		@include border;
-		// box-shadow: 3px 3px 3px $wc-ui-color-shadow;
-		height: auto; // override (mobile) default
-		min-width: 100%;
-		overflow: visible;
-		position: absolute;
-		top: 100%;
-
-		.wc-submenu > & {
-			// make more specific to override default [role] width in wc.ui.menu.scss
-			width: auto;
+		.wc-submenu {
+			position: relative;
 		}
 
-		> [role] { // override (mobile) default.
-			font-size: inherit;
+		.wc_submenucontent {
+			@include border;
+			// box-shadow: 3px 3px 3px $wc-ui-color-shadow;
+			height: auto; // override (mobile) default
+			min-width: 100%;
+			overflow: visible;
+			position: absolute;
+			top: 100%;
+			width: auto;
+
+			> [role] { // override (mobile) default.
+				font-size: inherit;
+			}
 		}
 	}
 
 	// Now for the collision detection...
-	[role='menubar'] [role='menu'] {
+	.wc_submenucontent {
 		&.wc_colsth { //south collision
 			left: 100%;
 
@@ -62,14 +78,15 @@
 			max-width: 100%;
 		}
 
-		[role='menu'].wc_coleast.wc_colwest { //nested submenus which collide both east and west - this is a design flaw and I refuse to cater for it!
+		.wc_submenucontent.wc_coleast.wc_colwest { //nested submenus which collide both east and west - this is a design flaw and I refuse to cater for it!
 			max-width: none;
 		}
 	}
 
-	[role='menu'] {
+	.wc-menu-type-column,
+	.wc_submenucontent {
 		 // nested sub-menus. These must appear before the colision detection overrides below.
-		[role='menu'] {
+		.wc_submenucontent {
 			left: 100%;
 			top: 0;
 
@@ -81,7 +98,9 @@
 				right: 100%;
 			}
 		}
+	}
 
+	.wc_submenucontent {
 		// viewport edge collisions
 		&.wc_coleast {
 			left: auto;

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.barColumnIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.barColumnIcons.scss
@@ -2,27 +2,26 @@
 // The opener iconoiography for WMenu type BAR, type FLYOUT, type COLUMN.
 @import 'mixins-common';
 
-.wc-submenu-o {
-	[role='menubar'] &:after {
-		@include wc-icon($fa-var-caret-down);
-		margin-left: $wc-menu-bar-column-opener-indicator-before-after;
-	}
-
-	[role='menu'] &:after {
-		content: '';
-		display: none;
-	}
-
-	[role='menu'] & > .wc-decoratedlabel:after {
+.wc-submenu-o > .wc-decoratedlabel:after {
+	.wc_menu_bar &,
+	.wc-menu-type-column & {
 		@include wc-icon($fa-var-caret-right);
 		display: table-cell;
 		padding-left: $wc-menu-bar-column-opener-indicator-before-after;
 	}
 
-	&.wc_hbgr:after { // the hamburger icon,
-		display: none;
+	.wc_menu_bar > .wc-submenu > & {
+		content: $fa-var-caret-down;
 	}
+
 }
+
+.wc_hbgr.wc-submenu-o > .wc-decoratedlabel:after { // the hamburger icon,
+	display: none;
+	margin-left: 0;
+}
+
+
 
 .closesubmenu::before {
 	content: $fa-var-caret-left;

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.color.scss
@@ -3,28 +3,28 @@
 // See wc.ui.menu.css for generic structure.
 @import 'mixins-common';
 
-[role='menubar'].wc-menu-type-bar,
-[role='menu'] {
+.wc-menu-type-bar,
+.wc-menu-type-column {
 	background-color: $wc-ui-color-menu-bg;
 	color: $wc-ui-color-menu-fg;
+}
 
-	[aria-busy] {
-		// override aria-busy transparency
-		// scss-lint:disable ImportantRule
-		background-color: $wc-ui-color-menu-bg !important;
+.wc_menu_bar,
+.wc-menu-type-column {
+	.wc_submenucontent {
+		background-color: $wc-ui-color-menu-bg;
+		color: $wc-ui-color-menu-fg;
+
+		&[aria-busy] {
+			// override aria-busy transparency
+			// scss-lint:disable ImportantRule
+			background-color: $wc-ui-color-menu-bg !important;
+		}
 	}
 }
 
 // selected elements
-// * WARNING: using the .class [role][aria-checked='true'] shorthand here will cause ANY element with an aria-checked
-// state to take on these styles. This shouldn't be a problem but I have left it with the longer form to allow for
-// odd/weird/stupid component nesting. Anyone want to put a WSelectToggle into a WMenuItem? it is possible...
-[role^='menuitem'][aria-checked='true'] {
+.wc-menuitem[aria-checked='true'] {
 	background-color: $wc-ui-color-highlight-bg;
 	color: $wc-ui-color-highlight-fg;
-}
-
-.wc-submenu[aria-checked='true'] {
-	background-color: transparent;
-	color: inherit;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.flyout.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.flyout.scss
@@ -1,0 +1,4 @@
+/* wc.ui.menu.flyout.scss */
+.wc-menu-type-flyout {
+	display: inline-block;
+}

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.scss
@@ -15,67 +15,24 @@
 // TODO (wishful thinking): Where the WMenu type allows use the menu element in the popup mode and its label/button.
 
 
-.wc-submenu,
-[role='menu'] {
-	// We need the important here otherwise we have to do a LOT of overriding of roles.
-	// scss-lint:disable ImportantRule
-	padding: 0 !important;
-}
+.wc-menuitem,
+.wc-submenu {
+	display: block;
+	width: 100%;
 
-[role^='menu'] {
-	[role],
-	.wc-submenu-o {
-		padding: $wc-menu-bar-column-item-pad;
-	}
-
-	.wc_hbgr { // the hamburger icon. This is here to override wc-submenu-o above.
-		padding: $wc-gap-small;
-	}
-
-	[role='separator'] {
-		padding: 0;
-
-		&[aria-orientation='vertical'] {
-			padding: $wc-menu-bar-vseparator-pad;
-		}
-	}
-}
-
-[role='menubar'] {
-	[role],
-	.wc-decoratedlabel {
+	.wc_menu_bar > & {
 		display: inline-block;
+		vertical-align: text-top;
 		white-space: nowrap;
+		width: auto;
 	}
 }
 
-//this role is any part of a COLUMN menu and submenus of a BAR or FLYOUT
-[role='menu'] {
-	// Do not make hidden by dfault and show on aria-expanded='true' as this will hide the root of Type.COLUMN.
-	&[aria-expanded='false'] {
-		// Save some long selector overrides
-		// scss-lint:disable ImportantRule
-		display: none !important;
-	}
-
-	[role^='menu'] & {
-		white-space: nowrap;
-	}
-
-	[role],
-	.wc-submenu-o {
-		display: block;
-		width: 100%;
-	}
-
-
-	&[aria-expanded='true'] {
-		z-index: $wc-z-index-common;
-
-		dialog & {
-			z-index: $wc-z-index-common-in-dialog;
-		}
-	}
+.wc-menuitem,
+.wc-submenu-o {
+	// Div menu items need explicit border box.
+	@include border-box;
+	padding: $wc-menu-bar-column-item-pad;
 
 	.wc-decoratedlabel {
 		display: table-row;
@@ -95,11 +52,39 @@
 	}
 }
 
-// Div menu items need explicit border box.
-[role^='menuitem'] {
-	@include border-box;
+// the hamburger icon. This is here to override wc-submenu-o above.
+.wc_hbgr {
+	padding: $wc-gap-small;
 }
 
-.wc-menu-type-flyout {
-	display: inline-block;
+.wc-menu [role='separator'] {
+	padding: 0;
+
+	&[aria-orientation='vertical'] {
+		padding: $wc-menu-bar-vseparator-pad;
+		vertical-align: bottom;
+	}
+}
+
+.wc_submenucontent {
+	display: none;
+	white-space: nowrap;
+
+	&[aria-expanded='true'] {
+		display: block;
+	}
+
+	.wc-menu-type-tree & {
+		white-space: normal;
+	}
+
+	.wc_menu_bar &,
+	.wc-menu-type-column & {
+		z-index: $wc-z-index-common;
+
+		dialog & {
+			z-index: $wc-z-index-common-in-dialog;
+		}
+	}
+
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.tree.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.tree.scss
@@ -2,34 +2,16 @@
 @import 'mixins-common';
 
 // TODO: try to work WMenu Type TREE to be more like WTree so we can get rid of this.
-.wc-menu[role="tree"] {
-	[role='treeitem'] {
+.wc-menu-type-tree {
+	.wc-menuitem {
 		padding: $wc-tree-item-pad;
 	}
 
 	.wc-submenu-o {
 		padding: $wc-tree-item-pad;
-
-		> .wc-decoratedlabel {
-			display: inline-table;
-			width: calc(100% - #{$wc-menu-tree-iconwidth}); // allow for icon.
-		}
 	}
 
-	.wc-decoratedlabel {
-		display: table-row;
-		width: 100%;
-	}
-
-	.wc_dlbl_seg {
-		display: table-cell;
-
-		+ .wc_dlbl_seg {
-			padding-left: $wc-gap-small;
-		}
-	}
-
-	.wc-labelbody {
-		width: 100%;
+	.wc_submenucontent {
+		margin-left: $wc-tree-indent;
 	}
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.treeIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.treeIcons.scss
@@ -5,8 +5,6 @@
 .wc-menu-type-tree .wc-submenu-o {
 	> .wc-decoratedlabel:before {
 		@include wc-icon-fw($fa-var-caret-right, $text-align: left, $width: $wc-menu-tree-iconwidth);
-		display: table-cell;
-		padding-right: $wc-gap-small;
 	}
 
 	&[aria-pressed='true'] > .wc-decoratedlabel:before {

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.treeIcons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.treeIcons.scss
@@ -2,12 +2,14 @@
 // tree menu branch indicators
 @import 'mixins-common';
 
-.wc-menu [role='treeitem'] {
-	&[aria-expanded] > button:before {
+.wc-menu-type-tree .wc-submenu-o {
+	> .wc-decoratedlabel:before {
 		@include wc-icon-fw($fa-var-caret-right, $text-align: left, $width: $wc-menu-tree-iconwidth);
+		display: table-cell;
+		padding-right: $wc-gap-small;
 	}
 
-	&[aria-expanded='true'] > button:before {
+	&[aria-pressed='true'] > .wc-decoratedlabel:before {
 		content: $fa-var-caret-down;
 	}
 }

--- a/wcomponents-theme/src/main/xslt/wc.ui.menu.n.hasStickyOpen.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.menu.n.hasStickyOpen.xsl
@@ -1,19 +1,17 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
 	<!--
-		This template is used to indicate whether a WSubMenu open state should 
-		be honoured.
+		This template is used to indicate whether a WSubMenu open state should be honoured.
 		
 		param type:
-		The WMenu Type. If type is not defined we are calling this template from
-		a WSubMenu in an ajax response, allow stickyness for all menus and fix 
-		it in JavaScript.
+		The WMenu Type. If type is not defined we are calling this template from a WSubMenu in an ajax response. These
+		should be closed.
 	-->
 	<xsl:template name="hasStickyOpen">
 		<xsl:param name="type"/>
 		<xsl:choose>
 			<!-- if type is not defined we are calling it from a submenu in
-					an ajax response, allow stickyness for all menus -->
-			<xsl:when test="$type='tree' or not($type)">
+					an ajax response and do not allow anything to be open -->
+			<xsl:when test="$type='tree'">
 				<xsl:number value="1"/>
 			</xsl:when>
 			<xsl:otherwise>

--- a/wcomponents-theme/src/main/xslt/wc.ui.menu.n.menuRoleIsSelectable.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.menu.n.menuRoleIsSelectable.xsl
@@ -1,4 +1,6 @@
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" 
+	xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
 	<xsl:import href="wc.constants.xsl"/>
 	<!--
 		This template is used to determine if a WMenuItem or WSubMenu (if
@@ -16,19 +18,11 @@
 			<xsl:when test="@selectable='false'">
 				<xsl:number value="0"/>
 			</xsl:when>
-			<!--In a tree a treeItem is only selectable if the tree supports selection.
-					remember: if we do not have a context menu we do not have $type -->
-			<xsl:when test="type='tree' and $myAncestorMenu/@selectMode">
-				<xsl:number value="1"/>
-			</xsl:when>
-			<xsl:when test="type='tree'">
-				<xsl:number value="0"/>
-			</xsl:when>
-			<!-- in menus which aren't trees then selection is granular -->
 			<xsl:when test="@selectable">
 				<xsl:number value="1"/>
 			</xsl:when>
-			<!-- if we do not have a context menu at all then let the ajax subscriber javascript worry about selection mode based on the transient attribute set from @selectable-->
+			<!-- if we do not have a context menu at all then let the ajax subscriber javascript worry about selection 
+				mode based on the transient attribute set from @selectable-->
 			<xsl:when test="not($myAncestorMenu or $myAncestorSubmenu)">
 				<xsl:number value="0"/>
 			</xsl:when>

--- a/wcomponents-theme/src/main/xslt/wc.ui.menu.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.menu.xsl
@@ -28,7 +28,11 @@
 		</xsl:variable>
 
 		<div>
-			<xsl:call-template name="commonAttributes"/>
+			<xsl:call-template name="commonAttributes">
+				<xsl:with-param name="class">
+					<xsl:if test="$isBarFlyout=1">wc_menu_bar</xsl:if>
+				</xsl:with-param>
+			</xsl:call-template>
 			<!--
 				attribute role
 				ARIA specifies three menu roles: tree, menu and menubar. The difference is in the
@@ -37,9 +41,6 @@
 			-->
 			<xsl:attribute name="role">
 				<xsl:choose>
-					<xsl:when test="@type='tree'">
-						<xsl:text>tree</xsl:text>
-					</xsl:when>
 					<xsl:when test="$isBarFlyout=1">
 						<xsl:text>menubar</xsl:text>
 					</xsl:when>
@@ -50,25 +51,9 @@
 			</xsl:attribute>
 			
 			<xsl:if test="@selectMode">
-				<xsl:choose>
-					<xsl:when test="@type='tree'">
-						<xsl:attribute name="aria-multiselectable">
-							<xsl:choose>
-								<xsl:when test="@selectMode='multiple'">
-									<xsl:copy-of select="$t"/>
-								</xsl:when>
-								<xsl:otherwise>
-									<xsl:text>false</xsl:text>
-								</xsl:otherwise>
-							</xsl:choose>
-						</xsl:attribute>
-					</xsl:when>
-					<xsl:otherwise>
-						<xsl:attribute name="data-wc-selectmode">
-							<xsl:value-of select="@selectMode"/>
-						</xsl:attribute>
-					</xsl:otherwise>
-				</xsl:choose>
+				<xsl:attribute name="data-wc-selectmode">
+					<xsl:value-of select="@selectMode"/>
+				</xsl:attribute>
 			</xsl:if>
 
 			<xsl:if test="$isError">

--- a/wcomponents-theme/src/main/xslt/wc.ui.menuItem.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.menuItem.xsl
@@ -1,4 +1,6 @@
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+	xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" 
+	xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
 	<xsl:import href="wc.ui.menu.n.hasStickyOpen.xsl"/>
 	<xsl:import href="wc.ui.menu.n.menuRoleIsSelectable.xsl"/>
 	<xsl:import href="wc.ui.menu.n.menuTabIndexHelper.xsl"/>
@@ -17,7 +19,8 @@
 	-->
 	<xsl:template match="ui:menuitem">
 		<xsl:variable name="myAncestorMenu" select="ancestor::ui:menu[1]"/>
-		<xsl:variable name="myAncestorSubmenu" select="ancestor::ui:submenu[ancestor::ui:menu[1]=$myAncestorMenu or not($myAncestorMenu)][1]"/>
+		<xsl:variable name="myAncestorSubmenu" 
+			select="ancestor::ui:submenu[ancestor::ui:menu[1]=$myAncestorMenu or not($myAncestorMenu)][1]"/>
 		<xsl:variable name="id" select="@id"/>
 		<xsl:variable name="menuType" select="$myAncestorMenu/@type"/>
 		<!-- this is a test for ui:menuitem in an ajax response without its context menu -->
@@ -155,10 +158,9 @@
 					</xsl:variable>
 					<xsl:attribute name="role">
 						<xsl:choose>
-							<xsl:when test="$menuType='tree'">
-								<xsl:text>treeitem</xsl:text>
-							</xsl:when>
-							<xsl:when test="$isSelectable=1 and ($myAncestorSubmenu[not(@selectMode='single')] or (not($myAncestorSubmenu) and $myAncestorMenu[not(@selectMode='single')]))">
+							<xsl:when test="$isSelectable=1 and 
+								($myAncestorSubmenu[not(@selectMode='single')] or 
+								(not($myAncestorSubmenu) and $myAncestorMenu[not(@selectMode='single')]))">
 								<xsl:text>menuitemcheckbox</xsl:text>
 							</xsl:when>
 							<xsl:when test="$isSelectable=1">
@@ -170,17 +172,7 @@
 						</xsl:choose>
 					</xsl:attribute>
 					<xsl:if test="$isSelectable=1">
-						<xsl:variable name="selectionAttribute">
-							<xsl:choose>
-								<xsl:when test="$menuType='tree'">
-									<xsl:text>aria-selected</xsl:text>
-								</xsl:when>
-								<xsl:otherwise>
-									<xsl:text>aria-checked</xsl:text>
-								</xsl:otherwise>
-							</xsl:choose>
-						</xsl:variable>
-						<xsl:attribute name="{$selectionAttribute}">
+						<xsl:attribute name="aria-checked">
 							<xsl:choose>
 								<xsl:when test="@selected">
 									<xsl:copy-of select="$t"/>
@@ -212,7 +204,8 @@
 						-->
 						<xsl:variable name="disabledAncestor" select="ancestor::*[@disabled and
 							(($noContextMenu=1 and self::ui:submenu) or
-							($myAncestorMenu and (self::ui:menu[.=$myAncestorMenu] or self::ui:submenu[ancestor::ui:menu[1]=$myAncestorMenu])))]"/>
+							($myAncestorMenu and (self::ui:menu[.=$myAncestorMenu] or 
+							self::ui:submenu[ancestor::ui:menu[1]=$myAncestorMenu])))]"/>
 						<xsl:if test="$disabledAncestor">
 							<xsl:call-template name="disabledElement">
 								<xsl:with-param name="field" select="$disabledAncestor"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.submenu.content.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.submenu.content.xsl
@@ -20,58 +20,42 @@
 			<xsl:value-of select="../@id"/>
 		</xsl:variable>
 
-		<div id="{@id}" arial-labelledby="{concat($submenuId, '_o')}">
+		<div id="{@id}" arial-labelledby="{concat($submenuId, '_o')}" role="menu">
 			<xsl:attribute name="class">
 				<xsl:text>wc_submenucontent</xsl:text>
-				<xsl:choose>
-					<xsl:when test="$isAjaxMode=1">
-						<xsl:text> wc_magic</xsl:text>
-						<xsl:if test="$mode='dynamic'">
-							<xsl:text> wc_dynamic</xsl:text>
-						</xsl:if>
-					</xsl:when>
-					<xsl:when test="$mode='server'">
-						<xsl:text> wc_lame</xsl:text>
-					</xsl:when>
-				</xsl:choose>
+				<xsl:if test="$isAjaxMode=1">
+					<xsl:text> wc_magic</xsl:text>
+					<xsl:if test="$mode='dynamic'">
+						<xsl:text> wc_dynamic</xsl:text>
+					</xsl:if>
+				</xsl:if>
 			</xsl:attribute>
 			<xsl:if test="$isAjaxMode=1">
 				<xsl:attribute name="data-wc-ajaxalias">
 					<xsl:value-of select="$submenuId"/>
 				</xsl:attribute>
 			</xsl:if>
-			<xsl:attribute name="role">
+			<xsl:attribute name="aria-expanded">
 				<xsl:choose>
-					<xsl:when test="$type='tree'">
-						<xsl:text>group</xsl:text>
+					<xsl:when test="$open=1">
+						<xsl:copy-of select="$t"/>
 					</xsl:when>
 					<xsl:otherwise>
-						<xsl:text>menu</xsl:text>
+						<xsl:text>false</xsl:text>
 					</xsl:otherwise>
 				</xsl:choose>
 			</xsl:attribute>
-			<xsl:if test="not($type='tree')">
-				<xsl:attribute name="aria-expanded">
-					<xsl:choose>
-						<xsl:when test="$open=1">
-							<xsl:copy-of select="$t"/>
-						</xsl:when>
-						<xsl:otherwise>
-							<xsl:text>false</xsl:text>
-						</xsl:otherwise>
-					</xsl:choose>
+			<xsl:if test="not(*)">
+				<!-- make the sub menu busy.
+					Why?
+					We have to keep the menu role on the content wrapper to make the menu function but role menu
+					must have at least one descendant role menuitem[(?:radio)|(?:checkbox)]? _or_ be aria-busy.
+				-->
+				<xsl:attribute name="aria-busy">
+					<xsl:copy-of select="$t"/>
 				</xsl:attribute>
-				<xsl:if test="not(*)">
-					<!-- make the sub menu busy.
-						Why?
-						We have to keep the menu role on the content wrapper to make the menu function but role menu
-						must have at least one descendant role menuitem[(?:radio)|(?:checkbox)]? _or_ be aria-busy.
-					-->
-					<xsl:attribute name="aria-busy">
-						<xsl:copy-of select="$t"/>
-					</xsl:attribute>
-				</xsl:if>
 			</xsl:if>
+			
 			<xsl:apply-templates select="*"/>
 		</div>
 	</xsl:template>

--- a/wcomponents-theme/src/main/xslt/wc.ui.submenu.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.submenu.xsl
@@ -63,7 +63,7 @@
 			</xsl:choose>
 		</xsl:variable>
 
-		<div id="{$id}">
+		<div id="{$id}" role="presentation">
 			<!--
 				We try not to tie functionality or display to classes when we have suitable ARIA
 				attributes but the need to differentiate functionality based on whether an
@@ -77,36 +77,11 @@
 			-->
 			<xsl:call-template name="hideElementIfHiddenSet"/>
 			<xsl:call-template name="makeCommonClass"/>
-			<xsl:if test="$type='tree'">
-				<xsl:attribute name="aria-expanded">
-					<xsl:choose>
-						<xsl:when test="$open=1">
-							<xsl:copy-of select="$t"/>
-						</xsl:when>
-						<xsl:otherwise>
-							<xsl:text>false</xsl:text>
-						</xsl:otherwise>
-					</xsl:choose>
-				</xsl:attribute>
-			</xsl:if>
-			<xsl:if test="@selectMode and not($type='tree')">
+			<xsl:if test="@selectMode">
 				<xsl:attribute name="data-wc-selectmode">
 					<xsl:value-of select="@selectMode"/>
 				</xsl:attribute>
 			</xsl:if>
-			<xsl:attribute name="role">
-				<xsl:choose>
-					<xsl:when test="$type='tree'"><!-- this will only be met if we can get to the ancestor menu -->
-						<xsl:text>treeitem</xsl:text>
-					</xsl:when>
-					<xsl:when test="$myAncestorMenu">
-						<xsl:text>presentation</xsl:text>
-					</xsl:when>
-					<xsl:otherwise>
-						<xsl:text>${wc.ui.menu.dummyRole}</xsl:text>
-					</xsl:otherwise>
-				</xsl:choose>
-			</xsl:attribute>
 			<!--
 				Determination of disabled state
 
@@ -126,7 +101,9 @@
 			<xsl:variable name="this" select="."/>
 			<xsl:variable name="disabledAncestor" select="ancestor-or-self::*[@disabled and
 									(self::ui:submenu[.=$this] or
-									($myAncestorMenu and (self::ui:menu[.=$myAncestorMenu] or self::ui:submenu[ancestor::ui:menu[1]=$myAncestorMenu])) or
+									($myAncestorMenu and 
+										(self::ui:menu[.=$myAncestorMenu] or 
+										self::ui:submenu[ancestor::ui:menu[1]=$myAncestorMenu])) or
 									($noContextMenu=1 and self::ui:submenu))]"/>
 			<xsl:if test="$disabledAncestor">
 				<xsl:call-template name="disabledElement">
@@ -134,13 +111,13 @@
 				</xsl:call-template>
 			</xsl:if>
 			<!-- This is the submenu opener/label element. -->
-			<button type="button" id="{concat($id, '_o')}" name="{$id}" class="wc-nobutton wc-invite wc-submenu-o" aria-controls="{$id}">
-				<xsl:if test="not($type='tree')">
-					<xsl:attribute name="aria-haspopup">
-						<xsl:copy-of select="$t"/>
-					</xsl:attribute>
-					<xsl:attribute name="role">menuitem</xsl:attribute>
-				</xsl:if>
+			<button type="button" id="{concat($id, '_o')}" name="{$id}" class="wc-nobutton wc-invite wc-submenu-o" aria-controls="{$id}" aria-haspopup="true">
+				<xsl:attribute name="aria-pressed">
+					<xsl:choose>
+						<xsl:when test="$open = 1">true</xsl:when>
+						<xsl:otherwise>false</xsl:otherwise>
+					</xsl:choose>
+				</xsl:attribute>
 				<xsl:call-template name="title"/>
 				<!-- see above for how we determine disabled state: it is ugly -->
 				<xsl:if test="$disabledAncestor">


### PR DESCRIPTION
WMenu Type.TREE was exposed as a tree. A tree is a selection tool. 

Converted WMenu Type.TREE to a menu. This has required a significant rewrite of CSS but has resulted in **much** less CSS and a little less JS.

Fixes #619