### PR TITLE
Toggle accordions

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/CollapsibleGroup.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/CollapsibleGroup.java
@@ -7,14 +7,16 @@ import java.util.List;
 
 /**
  * <p>
- * This class is used to group multiple {@link WCollapsible} components and one {@link WCollapsibleToggle} component
+ * This class is used to group multiple {@link WCollapsible} or [@link WTabSet} components and one {@link WCollapsibleToggle} component
  * together. Each collapsible component in the same group has the same name.</p>
  *
  * <p>
  * The <code>WCollapsibleToggle</code> component of the group applies to only the <code>collapsible</code> components in
- * the same group.</p>
+ * the same group. A WTabSet of type accordion is considered a collapsible component <strong>unless its single property is set</strong>.
+ * </p>
  *
  * @author Christina Harris
+ * @author Mark Reeves
  * @since 1.0.0
  */
 public class CollapsibleGroup implements Serializable {
@@ -27,10 +29,10 @@ public class CollapsibleGroup implements Serializable {
 	/**
 	 * The list of collapsibles in this group.
 	 */
-	private final List<WCollapsible> collapsibleList = new ArrayList<>();
+	private final List<WComponent> collapsibleList = new ArrayList<>();
 
 	/**
-	 * The Collapsbile toggle for this group.
+	 * The Collapsible toggle for this group.
 	 */
 	private WCollapsibleToggle collapsibleToggle;
 
@@ -63,9 +65,17 @@ public class CollapsibleGroup implements Serializable {
 	}
 
 	/**
+	 * Adds a {@link WTabSet} to this group. Only really useful for accordions.
+	 * @param collapsible the WTabSet to add to the group.
+	 */
+	public void addCollapsible(final WTabSet collapsible) {
+		collapsibleList.add(collapsible);
+	}
+
+	/**
 	 * @return a list of all collapsible components for this group.
 	 */
-	public List<WCollapsible> getAllCollapsibles() {
+	public List<WComponent> getAllCollapsibles() {
 		return Collections.unmodifiableList(collapsibleList);
 	}
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
@@ -741,6 +741,31 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	public boolean isSingle() {
 		return getComponentModel().single;
 	}
+	/**
+	 * The "collapsible" group name that this tabset belongs to.
+	 *
+	 * @return the collapsible group name
+	 */
+	public String getGroupName() {
+		if (TabSetType.ACCORDION.equals(getType())) {
+			CollapsibleGroup group = getComponentModel().group;
+			return (group == null ? null : group.getGroupName());
+		}
+		return null;
+	}
+
+	/**
+	 * Set the {@link com.github.bordertech.wcomponents.CollapsibleGroup} that this component belongs to. This will enable a
+	 * {@link com.github.bordertech.wcomponents.WCollapsibleToggle} component to target the tabset as part of the group.
+	 *
+	 * @param group the group to set
+	 */
+	public void setGroup(final CollapsibleGroup group) {
+		if (TabSetType.ACCORDION.equals(getType())) {
+			getOrCreateComponentModel().group = group;
+			group.addCollapsible(this);
+		}
+	}
 
 	/**
 	 * @return a String representation of this component, for debugging purposes.
@@ -820,5 +845,11 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 		 * Accordion tab only opens one tab at a time.
 		 */
 		private boolean single;
+
+		/**
+		 * The CollapsibleGroup, primarily used with a {@link com.github.bordertech.wcomponents.WCollapsibleToggle} to toggle a group of collapsibles
+		 * and/or accordion tabs at once. Only applies to Type.ACCORDION.
+		 */
+		private CollapsibleGroup group;
 	}
 }

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WTabSetRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WTabSetRenderer.java
@@ -38,6 +38,9 @@ final class WTabSetRenderer extends AbstractWebXmlRenderer {
 		xml.appendOptionalAttribute("single",
 				TabSetType.ACCORDION.equals(tabSet.getType()) && tabSet.isSingle(),
 				"true");
+		if (WTabSet.TabSetType.ACCORDION.equals(tabSet.getType())) {
+			xml.appendOptionalAttribute("groupName", tabSet.getGroupName());
+		}
 		xml.appendClose();
 
 		// Render margin

--- a/wcomponents-core/src/main/resources/schema/ui/v1/tabset.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/tabset.xsd
@@ -96,6 +96,11 @@
 						content without scrolling.</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
+			<xs:attribute name="groupName" type="xs:NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Indicates that the collapsible is part of a group of collapsibles the open state of which is controlled by a WCollapsibleToggle.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
 		</xs:complexType>
 	</xs:element>
 

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/CollapsibleGroup_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/CollapsibleGroup_Test.java
@@ -64,4 +64,14 @@ public class CollapsibleGroup_Test {
 		group.setCollapsibleToggle(toggle);
 		Assert.assertSame("Incorrect collapsible toggle", toggle, group.getCollapsibleToggle());
 	}
+
+	@Test
+	public void testAddTabSet() {
+		CollapsibleGroup group = new CollapsibleGroup();
+		Assert.assertTrue(0 == group.getAllCollapsibles().size());
+		WTabSet tabset = new WTabSet(WTabSet.TabSetType.ACCORDION);
+		group.addCollapsible(tabset);
+		Assert.assertTrue(1 == group.getAllCollapsibles().size());
+		Assert.assertSame("Incorrect collapsible", tabset, group.getAllCollapsibles().get(0));
+	}
 }

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WTabSet_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WTabSet_Test.java
@@ -632,4 +632,30 @@ public class WTabSet_Test extends AbstractWComponentTestCase {
 		assertAccessorsCorrect(new WTabSet(), "single", false, true, false);
 	}
 
+	@Test
+	public void testSetGroup() {
+		CollapsibleGroup group = new CollapsibleGroup();
+		WTabSet tabset = new WTabSet(WTabSet.TYPE_ACCORDION);
+		tabset.setGroup(group);
+		Assert.assertNotNull(tabset.getGroupName());
+	}
+
+	@Test
+	public void testGetGroupName() {
+		CollapsibleGroup group = new CollapsibleGroup();
+		WCollapsibleToggle toggle = new WCollapsibleToggle();
+		group.setCollapsibleToggle(toggle);
+		WTabSet tabset = new WTabSet(WTabSet.TYPE_ACCORDION);
+		tabset.setGroup(group);
+		Assert.assertEquals(group.getGroupName(), tabset.getGroupName());
+	}
+
+	@Test
+	public void testSetGroupNotAccordion() {
+		CollapsibleGroup group = new CollapsibleGroup();
+		WTabSet tabset = new WTabSet(WTabSet.TYPE_TOP);
+		tabset.setGroup(group);
+		Assert.assertNull(tabset.getGroupName());
+	}
+
 }

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WCollapsibleGroupExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WCollapsibleGroupExample.java
@@ -5,6 +5,7 @@ import com.github.bordertech.wcomponents.WCollapsible;
 import com.github.bordertech.wcomponents.WCollapsibleToggle;
 import com.github.bordertech.wcomponents.WHorizontalRule;
 import com.github.bordertech.wcomponents.WPanel;
+import com.github.bordertech.wcomponents.WTabSet;
 import com.github.bordertech.wcomponents.WText;
 import com.github.bordertech.wcomponents.layout.GridLayout;
 
@@ -79,5 +80,14 @@ public class WCollapsibleGroupExample extends WPanel {
 				WCollapsible.CollapsibleMode.CLIENT);
 		collapsible5.setCollapsed(true);
 		add(collapsible5);
+
+
+		WTabSet accordion = new WTabSet(WTabSet.TabSetType.ACCORDION);
+		add(accordion);
+		accordion.setGroup(group2);
+		accordion.addTab(new WText("Tab 1 content"), "Tab 1", WTabSet.TabMode.CLIENT);
+		accordion.addTab(new WText("Tab 2 content"), "Tab 2", WTabSet.TabMode.CLIENT);
+		accordion.addTab(new WText("Tab 3 content"), "Tab 3", WTabSet.TabMode.CLIENT);
+		accordion.addTab(new WText("Tab 4 content"), "Tab 4", WTabSet.TabMode.CLIENT);
 	}
 }

--- a/wcomponents-theme/src/main/js/wc/ui/tabset.js
+++ b/wcomponents-theme/src/main/js/wc/ui/tabset.js
@@ -83,7 +83,6 @@ define(["wc/dom/ariaAnalog",
 			 */
 			this.ITEM = new Widget("", "", {"role": "tab"});
 
-
 			/**
 			 * Select items immediately on navigation.
 			 * @function
@@ -142,14 +141,13 @@ define(["wc/dom/ariaAnalog",
 			 *
 			 * @function
 			 * @private
-			 * @param {Element} tabset The tabset to test.
+			 * @param {Element} tablist The tablist to test.
 			 * @returns {String} The value of the aria-multiselectable attribute "true" or "false" (or undefined if not
 			 *    an accordion).
 			 */
-			function getAccordion(tabset) {
-				return tabset.getAttribute("aria-multiselectable");
+			function getAccordion(tablist) {
+				return tablist.getAttribute("aria-multiselectable");
 			}
-
 
 			/**
 			 * Collapse single-select accordion tabs when a particular tab is opened. NOTE: this is required because
@@ -173,6 +171,60 @@ define(["wc/dom/ariaAnalog",
 				}
 			}
 
+			function expandCollapseAll(tabset, expand) {
+				var list = TABLIST.findDescendant(tabset),
+					func,
+					accordion;
+
+				if (!list) {
+					return;
+				}
+
+				accordion = getAccordion(list);
+				if (!accordion || (expand && accordion !== "true")) {
+					return;
+				}
+
+				func = expand ? "expand" : "collapse";
+
+				Array.prototype.forEach.call(instance.ITEM.findDescendants(list), function(next) {
+					if (shed.isExpanded(next) !== expand) {
+						shed[func](next);
+					}
+				});
+			}
+
+			this.collapseAll = function(tabset) {
+				expandCollapseAll(tabset, false);
+			};
+
+			this.expandAll = function(tabset) {
+				expandCollapseAll(tabset, true);
+			};
+
+			/**
+			 * Are all tabs in a tabset inthe same expanded state?
+			 * @param {Element} tabset The tabset to test
+			 * @param {boolean} expanded true is testing for
+			 * @returns {Boolean}
+			 */
+			this.areAllInExpandedState = function(tabset, expanded) {
+				var list = TABLIST.findDescendant(tabset), accordion;
+
+				if (!(list && (accordion = getAccordion(list)))) { // only accordions can have all items in a state.
+					return false;
+				}
+
+				if (accordion === "false" && expanded) {
+					return false; // single accordion all in the same state only if collapsed.
+				}
+
+				return Array.prototype.every.call(this.ITEM.findDescendants(list), function(next) {
+					if (shed.isExpanded(next) === expanded) {
+						return true;
+					}
+				});
+			};
 
 			/**
 			 * Helper for shedObserver, called when there has been a EXPAND or COLLAPSE.
@@ -202,7 +254,6 @@ define(["wc/dom/ariaAnalog",
 					}
 				}
 			}
-
 
 			/**
 			 * Helper for shedObserver, called when there has been a SELECT or DESELECT.

--- a/wcomponents-theme/src/main/xslt/wc.common.collapsibleToggle.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.collapsibleToggle.xsl
@@ -5,7 +5,7 @@
 	<xsl:import href="wc.common.ajax.xsl"/>
 	<xsl:import href="wc.common.n.className.xsl"/>
 	<!-- Key used by collapsibleToggle to get the list of controlled collapsibles -->
-	<xsl:key name="collapsibleGroupKey" match="//ui:collapsible[@groupName]" use="@groupName"/>
+	<xsl:key name="collapsibleGroupKey" match="//ui:collapsible[@groupName]|//ui:tabset[@groupName]" use="@groupName"/>
 
 	<!--
 		Output expand all and collapse all buttons.


### PR DESCRIPTION
Updated CollapsibleGroup, WTabSet to allow a WCollapsibleToggle to set
the expanded/collapsed state of all tabs in a WTabSet of
`TabSetType.ACCORDION`.

Fixes #627