### PR TITLE
Table actions, collapsibleToggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,12 @@
   WRadioButtonSelect and WSingleSelect. In all cases except WCheckBoxSelect using unencoded text could result in
   catastrophic failure as these must not contain HTML. Method `getDescEncode()` has been deprecated, made final and
   will always return true; method `setDescEncode(boolean)` has been deprecated, made final and is now a no-op.
+* Removed "round trip" mode WCollapsibleToggle. Constructor `WCollapsibleToggle(boolean)` has been deprecated in favour
+  of `WCollapsibleToggle)`. Constructor `WCollapsibleToggle(boolean, CollapsibleGroup )` has been deprecated in favour
+  of `WCollapsibleToggle(CollapsibleGroup)` Method `isClientSide()` deprecated as it will always return true.
 
 ## Bug Fixes
+* Fixed an accessibility error caused by unexpected side effects of WCollapsibleToggle.
 * Changed output of WMenu Type TREE from role tree to role menu #619.
 * Fixed bug which could result in messages causing XML validation failure #707.
 * Fixed issue which caused WTextarea to not include changes in AJAX posts when in rich-text mode #700.
@@ -62,8 +66,10 @@
 * Fixed GridLayout cell alignment on small screens #652.
 
 ## Enhancements
-* Changed the client handling of WTable Actions with constraints to make the action button disabled if the constraints
-  aren't met rather than outputting an error alert. #618
+* Added WTabSet as a potential target of WCollapsibleToggle. This is only effective if the WTabSet is of TabSetType
+  ACCORDION.
+* Changed the client handling of WTable Actions with constraints to make the action button disabled if "error" level
+  constraints aren't met rather than outputting an error alert. #618
 * Reversed the date input polyfill used by WDateField. Previously we created all of the UI artefacts needed to support
   the polyfill and removed them if the browser supported native date inputs. This has been reversed to output a wrapper
   and input in XSLT and add the other artefacts if native date inputs are not supported. This significantly improves

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WCollapsibleToggleRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WCollapsibleToggleRenderer.java
@@ -29,7 +29,6 @@ final class WCollapsibleToggleRenderer extends AbstractWebXmlRenderer {
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
 		xml.appendAttribute("groupName", toggle.getGroupName());
-		xml.appendOptionalAttribute("roundTrip", !toggle.isClientSideToggleable(), "true");
 		xml.appendEnd();
 	}
 }

--- a/wcomponents-core/src/main/resources/schema/ui/v1/collapsibleToggle.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/collapsibleToggle.xsd
@@ -5,28 +5,6 @@
 		<xs:annotation>
 			<xs:documentation>
 				<p>WCollapsibleToggle represents an interactive control used to expand and collapse a group of WCollapsibles.</p>
-				<p>WCollapsibleToggle expects that the POSTed form data contains:</p>
-				<table>
-					<thead>
-						<tr>
-							<th>Field name</th>
-							<th>Type</th>
-							<th>Mandatory</th>
-							<th>Value</th>
-							<th>Notes</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td>@id</td>
-							<td>String</td>
-							<td>no</td>
-							<td>"expand" or "collapse"</td>
-							<td>Used only when the WCollapsibleToggle has its roundTrip attribute "true"; "expand" indicates that the controlled group of WCollapsibles should all
-								be opened, "collapse" that they should all be closed.</td>
-						</tr>
-					</tbody>
-				</table>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:complexType>
@@ -44,13 +22,6 @@
 			<xs:attribute name="groupName" type="xs:NMTOKEN" use="required">
 				<xs:annotation>
 					<xs:documentation>The name of the group of WCollapsibles which is controlled by the WCollapsibleToggle.</xs:documentation>
-				</xs:annotation>
-			</xs:attribute>
-
-			<xs:attribute name="roundTrip" type="xs:boolean">
-				<xs:annotation>
-					<xs:documentation>Indicates that the expansion and collapsing of the WCollapsibleToggles should be done in a server process and submits the entire application
-						to the server. Not output if "false". <strong>Deprecated</strong> you should avoid using this attribute.</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
 		</xs:complexType>

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WCollapsibleToggle_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WCollapsibleToggle_Test.java
@@ -1,8 +1,6 @@
 package com.github.bordertech.wcomponents;
 
-import com.github.bordertech.wcomponents.util.mock.MockRequest;
 import junit.framework.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -13,94 +11,69 @@ import org.junit.Test;
  */
 public class WCollapsibleToggle_Test extends AbstractWComponentTestCase {
 
-	private WPanel panel;
-	private WCollapsible initiallyOpenCollapsible;
-	private WCollapsible initiallyCollapsedCollapsible;
-	private CollapsibleGroup group;
-	private WCollapsibleToggle toggle;
+	@Test
+	public void testConstructorSetGroup() {
+		WCollapsibleToggle toggle = new WCollapsibleToggle();
+		toggle.setIdName("myToggle");
+		CollapsibleGroup group = new CollapsibleGroup();
+		group.setCollapsibleToggle(toggle);
+		Assert.assertSame(toggle, group.getCollapsibleToggle());
+		Assert.assertEquals("myToggle", group.getGroupName());
+	}
 
-	@Before
-	public void setUp() {
-		panel = new WPanel();
+	@Test
+	public void testConstructorBooleanDoesNothing() {
+		WCollapsibleToggle toggle = new WCollapsibleToggle(true);
+		CollapsibleGroup group = new CollapsibleGroup();
+		group.setCollapsibleToggle(toggle);
+		Assert.assertSame(toggle, group.getCollapsibleToggle());
+		Assert.assertEquals(toggle.getId(), group.getGroupName());
+	}
 
+	@Test
+	public void testConstructorWithGroup() {
+		CollapsibleGroup group = new CollapsibleGroup();
+		WCollapsibleToggle toggle = new WCollapsibleToggle(group);
+		Assert.assertSame(toggle, group.getCollapsibleToggle());
+	}
+
+	@Test
+	public void testGetGroup() {
+		CollapsibleGroup group = new CollapsibleGroup();
+		WCollapsibleToggle toggle = new WCollapsibleToggle(group);
+		Assert.assertSame(group, toggle.getGroup());
+	}
+
+	@Test
+	public void testGetGroupNoGroup() {
+		WCollapsibleToggle toggle = new WCollapsibleToggle();
+		Assert.assertNull(toggle.getGroup());
+	}
+
+	@Test
+	public void testGetGroupName() {
+		CollapsibleGroup group = new CollapsibleGroup();
+		WCollapsibleToggle toggle = new WCollapsibleToggle(group);
+		String expected = "expected";
+		toggle.setIdName(expected);
+		Assert.assertEquals(expected, toggle.getGroupName());
+	}
+	@Test
+	public void testGetGroupNameNoGroup() {
+		WCollapsibleToggle toggle = new WCollapsibleToggle();
+		String expected = "expected";
+		toggle.setIdName(expected);
+		Assert.assertEquals(expected, toggle.getGroupName());
+	}
+
+	// pointless test to make sure no-one re-introduces server mode.
+	@Test
+	public void testClientSideAlwaysTrue() {
+		WCollapsibleToggle toggle = new WCollapsibleToggle();
+		Assert.assertTrue(toggle.isClientSideToggleable());
 		toggle = new WCollapsibleToggle(false);
-		panel.add(toggle);
-
-		initiallyOpenCollapsible = new WCollapsible(new WText("1"), "1");
-		initiallyCollapsedCollapsible = new WCollapsible(new WText("2"), "2");
-		panel.add(initiallyOpenCollapsible);
-
-		initiallyOpenCollapsible.setCollapsed(false);
-		initiallyCollapsedCollapsible.setCollapsed(true);
-
-		group = new CollapsibleGroup();
-		group.addCollapsible(initiallyOpenCollapsible);
-		group.addCollapsible(initiallyCollapsedCollapsible);
-
-		UIContext uic = createUIContext();
-		uic.setUI(panel);
-		setActiveContext(uic);
-
-		panel.add(initiallyCollapsedCollapsible);
-	}
-
-	@Test
-	public void testExpandAllNoGroup() {
-		expandAll();
-
-		Assert.assertFalse("Open collapsible should have stayed open", initiallyOpenCollapsible.
-				isCollapsed());
-		Assert.assertFalse("Collapsed collapsible should have opened",
-				initiallyCollapsedCollapsible.isCollapsed());
-	}
-
-	@Test
-	public void testCollapseAllNoGroup() {
-		collapseAll();
-
-		Assert.assertTrue("Open collapsible should have collapsed", initiallyOpenCollapsible.
-				isCollapsed());
-		Assert.assertTrue("Collapsed collapsible should have stayed collapsed",
-				initiallyCollapsedCollapsible.isCollapsed());
-	}
-
-	@Test
-	public void testCollapseAllWithGroup() {
-		toggle.setGroup(group);
-		collapseAll();
-
-		Assert.assertTrue("Open collapsible should have collapsed", initiallyOpenCollapsible.
-				isCollapsed());
-		Assert.assertTrue("Collapsed collapsible should have stayed collapsed",
-				initiallyCollapsedCollapsible.isCollapsed());
-	}
-
-	@Test
-	public void testExpandAllWithGroup() {
-		toggle.setGroup(group);
-		expandAll();
-
-		Assert.assertFalse("Open collapsible should have stayed open", initiallyOpenCollapsible.
-				isCollapsed());
-		Assert.assertFalse("Collapsed collapsible should have opened",
-				initiallyCollapsedCollapsible.isCollapsed());
-	}
-
-	/**
-	 * Runs the "Collapse all" button's action.
-	 */
-	private void collapseAll() {
-		MockRequest request = new MockRequest();
-		request.setParameter(toggle.getId(), "collapse");
-		panel.serviceRequest(request);
-	}
-
-	/**
-	 * Runs the "Expand all" button's action.
-	 */
-	private void expandAll() {
-		MockRequest request = new MockRequest();
-		request.setParameter(toggle.getId(), "expand");
-		panel.serviceRequest(request);
+		Assert.assertTrue(toggle.isClientSideToggleable());
+		toggle = new WCollapsibleToggle(true);
+		Assert.assertTrue(toggle.isClientSideToggleable());
 	}
 }

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WCollapsibleToggleRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WCollapsibleToggleRenderer_Test.java
@@ -35,6 +35,6 @@ public class WCollapsibleToggleRenderer_Test extends AbstractWebXmlRendererTestC
 		// Server-side
 		toggle = new WCollapsibleToggle(false);
 		assertSchemaMatch(toggle);
-		assertXpathEvaluatesTo("true", "//ui:collapsibletoggle/@roundTrip", toggle);
+		assertXpathNotExists("//ui:collapsibletoggle/@roundTrip", toggle);
 	}
 }

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/table/SimpleSelectableTableExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/table/SimpleSelectableTableExample.java
@@ -13,6 +13,7 @@ import com.github.bordertech.wcomponents.WTable.ActionConstraint;
 import com.github.bordertech.wcomponents.WTable.SelectMode;
 import com.github.bordertech.wcomponents.WTableColumn;
 import com.github.bordertech.wcomponents.WText;
+import com.github.bordertech.wcomponents.examples.common.ExplanatoryText;
 
 /**
  * This example demonstrates a simple {@link WTable} that is bean bound and has row selection.
@@ -34,6 +35,13 @@ public class SimpleSelectableTableExample extends WPanel {
 	 * Create example.
 	 */
 	public SimpleSelectableTableExample() {
+		add(new ExplanatoryText("This example shows a simple selection mechanism. The table actions show some variations on how to set up constrained"
+				+ " actions. The delete and edit buttons do nothing in this example: they are merely there to show how to wire up different "
+				+ "constraint types.\n The select button shows how to add an error constrain to prevent the action unless at least one row is "
+				+ "selected. The delete button shows how to add an error constraint and a warning constraint to the same action to limit the action "
+				+ "to at least one row but warn the user if the action would be applied to more than one row. The edit button shows how to add an "
+				+ "error constraint to limit the action to exactly one selected row."));
+
 		add(table);
 		table.addColumn(new WTableColumn("First name", new WText()));
 		table.addColumn(new WTableColumn("Last name", new WText()));
@@ -56,6 +64,18 @@ public class SimpleSelectableTableExample extends WPanel {
 		// An action constraint is used so that a row must be selected before using the "Select" button
 		table.addActionConstraint(selectButton, new ActionConstraint(1, 0, true,
 				"One or more rows must be selected"));
+
+		WButton deleteWithWarningCondition = new WButton("Delete");
+		table.addAction(deleteWithWarningCondition);
+		// prevent the action if fewer than one row is selected.
+		table.addActionConstraint(deleteWithWarningCondition, new ActionConstraint(1, 0, true, "At least one row must be selected"));
+		// warn the user if more thanone row is selected but do not prevent the action unless the user bails.
+		table.addActionConstraint(deleteWithWarningCondition, new ActionConstraint(0, 1, false, "Are you sure you wish to delete these rows?"));
+
+		WButton editButton = new WButton("Edit");
+		table.addAction(editButton);
+		// prevent the action unless exactly one row is selected.
+		table.addActionConstraint(editButton, new ActionConstraint(1, 1, true, "Exactly one row must be selected"));
 
 		final WStyledText selectionText = new WStyledText();
 		selectionText.setWhitespaceMode(WStyledText.WhitespaceMode.PRESERVE);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WCollapsibleGroupExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WCollapsibleGroupExample.java
@@ -34,17 +34,17 @@ public class WCollapsibleGroupExample extends WPanel {
 		CollapsibleGroup group1 = new CollapsibleGroup();
 		CollapsibleGroup group2 = new CollapsibleGroup();
 
-		WCollapsibleToggle toggle1 = new WCollapsibleToggle(true, group1);
+		WCollapsibleToggle toggle1 = new WCollapsibleToggle(group1);
 		panel.add(new WText(
 				"Group one toggle controls will only toggle the state of those collapsibles marked as being in group 1."));
 		panel.add(toggle1);
 
-		WCollapsibleToggle toggle2 = new WCollapsibleToggle(true, group2);
+		WCollapsibleToggle toggle2 = new WCollapsibleToggle(group2);
 		panel.add(new WText(
 				"Group two toggle controls will only toggle the state of those collapsibles marked as being in group 2."));
 		panel.add(toggle2);
 
-		WCollapsibleToggle toggle3 = new WCollapsibleToggle(true);
+		WCollapsibleToggle toggle3 = new WCollapsibleToggle();
 		panel.
 				add(new WText(
 						"No group toggle controls should toggle every collapsible in the page."));

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/ajax/AjaxWCollapsibleExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/ajax/AjaxWCollapsibleExample.java
@@ -1,6 +1,7 @@
 package com.github.bordertech.wcomponents.examples.theme.ajax;
 
 import com.github.bordertech.wcomponents.CollapsibleGroup;
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.WCollapsible;
 import com.github.bordertech.wcomponents.WCollapsibleToggle;
 import com.github.bordertech.wcomponents.WContainer;
@@ -20,11 +21,8 @@ public class AjaxWCollapsibleExample extends WContainer {
 	 * Creates an AjaxWCollapsibleExample.
 	 */
 	public AjaxWCollapsibleExample() {
-		add(new WHeading(WHeading.MAJOR, "Client Side Toggle and Collapsibles with Ajax Content."));
-		add(new CollapsibleExample(true));
-
-		add(new WHeading(WHeading.MAJOR, "Server Side Toggle and Collapsibles with Ajax Content."));
-		add(new CollapsibleExample(false));
+		add(new WHeading(HeadingLevel.H2, "Collapsible Toggle and Collapsibles with Ajax Content."));
+		add(new CollapsibleExample());
 	}
 
 	/**
@@ -34,14 +32,11 @@ public class AjaxWCollapsibleExample extends WContainer {
 
 		/**
 		 * Creates a CollapsibleExample.
-		 *
-		 * @param clientSide true for client-side collapsible, false for server-side.
 		 */
-		private CollapsibleExample(final boolean clientSide) {
+		private CollapsibleExample() {
 
 			CollapsibleGroup group = new CollapsibleGroup();
-			WCollapsibleToggle wct = new WCollapsibleToggle(clientSide);
-			wct.setGroup(group);
+			WCollapsibleToggle wct = new WCollapsibleToggle(group);
 			add(wct);
 
 			WText component1 = new WText("Here is some text that is collapsible via ajax.");

--- a/wcomponents-theme/src/main/xslt/wc.common.collapsibleToggle.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.collapsibleToggle.xsl
@@ -24,9 +24,6 @@
 
 		<xsl:variable name="mode">
 			<xsl:choose>
-				<xsl:when test="@roundTrip"><!-- WCollapsibleToggle, to be removed. -->
-					<xsl:text>server</xsl:text>
-				</xsl:when>
 				<xsl:when test="@mode='dynamic' or @mode='lazy'">
 					<xsl:value-of select="@mode"/>
 				</xsl:when>
@@ -79,7 +76,7 @@
 			</li>
 			<li>
 				<xsl:call-template name="toggleElement">
-					<xsl:with-param name="mode" select="'client'"/><!-- collapse all is never ajaxy or lame -->
+					<xsl:with-param name="mode" select="'client'"/><!-- collapse all is never ajaxy -->
 					<xsl:with-param name="id" select="concat($id,'_collapse')"/>
 					<xsl:with-param name="for" select="$targetList"/>
 					<xsl:with-param name="name" select="$id"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.actions.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.actions.xsl
@@ -25,6 +25,10 @@
 		<xsl:value-of select="@minSelectedRows"/>
 		<xsl:text>","max":"</xsl:text>
 		<xsl:value-of select="@maxSelectedRows"/>
+		<xsl:text>","type":"</xsl:text>
+		<xsl:value-of select="@type"/>
+		<xsl:text>","message":"</xsl:text>
+		<xsl:value-of select="@message"/>
 		<xsl:text>"}</xsl:text>
 		<xsl:if test="position()!=last()">
 			<xsl:text>,</xsl:text>


### PR DESCRIPTION
* Re-instated table action warning behaviour. Fixes #618.
* Removed roundTrip WCollapsibleToggle. Fixes #598.
* Updated some examples.