### PR TITLE
Datalist as html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## API Changes
 
 ## Bug Fixes
+* Updated DataListInterceptor and ServletUtil to allow DataLists to be sent as HTML rather than XML (#747).
 
 ## Enhancements
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/servlet/ServletUtil.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/servlet/ServletUtil.java
@@ -386,7 +386,8 @@ public final class ServletUtil {
 		InterceptorComponent[] chain;
 
 		if (parameters.get(WServlet.DATA_LIST_PARAM_NAME) != null) { // Datalist
-			chain = new InterceptorComponent[]{new DataListInterceptor()};
+			chain = new InterceptorComponent[]{new TransformXMLInterceptor(),
+                                                           new DataListInterceptor()};
 
 		} else if (parameters.get(WServlet.AJAX_TRIGGER_PARAM_NAME) != null) { // AJAX
 			chain = new InterceptorComponent[]{

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/container/DataListInterceptor_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/container/DataListInterceptor_Test.java
@@ -7,7 +7,6 @@ import com.github.bordertech.wcomponents.servlet.WServlet;
 import com.github.bordertech.wcomponents.servlet.WebXmlRenderContext;
 import com.github.bordertech.wcomponents.util.Factory;
 import com.github.bordertech.wcomponents.util.LookupTable;
-import com.github.bordertech.wcomponents.util.NullWriter;
 import com.github.bordertech.wcomponents.util.mock.MockRequest;
 import com.github.bordertech.wcomponents.util.mock.MockResponse;
 import java.io.IOException;
@@ -42,7 +41,7 @@ public class DataListInterceptor_Test extends AbstractWebXmlRendererTestCase {
 		// Render phase
 		MockResponse response = new MockResponse();
 		interceptor.attachResponse(response);
-		interceptor.paint(new WebXmlRenderContext(new PrintWriter(new NullWriter()))); // interceptor renders directly to response
+		interceptor.paint(new WebXmlRenderContext(new PrintWriter(response.getWriter())));
 
 		String xml = response.getWriterOutput();
 
@@ -77,7 +76,7 @@ public class DataListInterceptor_Test extends AbstractWebXmlRendererTestCase {
 		// Render phase
 		MockResponse response = new MockResponse();
 		interceptor.attachResponse(response);
-		interceptor.paint(new WebXmlRenderContext(new PrintWriter(new NullWriter()))); // interceptor renders directly to response
+		interceptor.paint(new WebXmlRenderContext(new PrintWriter(response.getWriter())));
 
 		String xml = response.getWriterOutput();
 

--- a/wcomponents-theme/src/main/js/wc/ui/listLoader.js
+++ b/wcomponents-theme/src/main/js/wc/ui/listLoader.js
@@ -82,8 +82,13 @@ define(["wc/ajax/ajax",
 								promiseDone(groupLose, err);
 							},
 							callback: function(srcTree) {
-								var promise = xslTransform.transform({ xmlDoc: srcTree });
-								promise.then(promiseDone.bind(this, groupWin), this.onError);
+								if (srcTree === null && this.responseText) {
+									promiseDone(groupWin, xslTransform.htmlToDocumentFragment(this.responseText));
+								}
+								else {
+									var promise = xslTransform.transform({ xmlDoc: srcTree });
+									promise.then(promiseDone.bind(this, groupWin), this.onError);
+								}
 							},
 							cache: true,  // cache should be forever, cache is broken by changing URL (querystring)
 							responseType: ajax.responseType.XML


### PR DESCRIPTION
* Updated data list handling to send HTML rather than XML.
* Updated listLoader.js to handle both HTML and XML responses (though I
kept the request as `responseXML` - this could be reviewed).

Fixes #747