### PR TITLE
Bug fixes

### DIFF
--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/HtmlClassPropertiesExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/HtmlClassPropertiesExample.java
@@ -4,8 +4,8 @@ import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WHeading;
 import com.github.bordertech.wcomponents.WPanel;
-import com.github.bordertech.wcomponents.WStyledText;
 import com.github.bordertech.wcomponents.WText;
+import com.github.bordertech.wcomponents.examples.common.ExplanatoryText;
 import com.github.bordertech.wcomponents.util.HtmlClassProperties;
 import com.github.bordertech.wcomponents.util.HtmlIconUtil;
 
@@ -194,25 +194,22 @@ public class HtmlClassPropertiesExample extends WPanel {
 		button.setHtmlClass(HtmlClassProperties.ICON_CANCEL_AFTER);
 		add(button);
 
+		add(new WHeading(HeadingLevel.H3, "Menu icons"));
+		button = new WButton("\u200b"); // \u200b is a zero-width space.
+		button.setToolTip("Menu");
+		button.setHtmlClass(HtmlClassProperties.ICON_MENU);
+		add(button);
+		button = new WButton("Menu");
+		button.setHtmlClass(HtmlClassProperties.ICON_MENU_BEFORE);
+		add(button);
+		button = new WButton("Menu");
+		button.setHtmlClass(HtmlClassProperties.ICON_MENU_AFTER);
+		add(button);
 
 		add(new WHeading(HeadingLevel.H2, "Non-standard icons"));
-		add(new WHeading(HeadingLevel.H3, "Before text content"));
-		WStyledText text = new WStyledText("Fort Awesome");
-		add(text);
-		text.setHtmlClass(HtmlClassProperties.ICON_BEFORE.toString() + " fa-fort-awesome");
-		add(new WHeading(HeadingLevel.H3, "After text content"));
-		text = new WStyledText("Fort Awesome");
-		add(text);
-		text.setHtmlClass(HtmlClassProperties.ICON_AFTER.toString() + " fa-fort-awesome");
-		add(new WHeading(HeadingLevel.H3, "As content"));
-		text = new WStyledText("\u200b");
-		add(text);
-		text.setHtmlClass(HtmlClassProperties.ICON.toString() + " fa-fort-awesome");
-
-
+		add(new ExplanatoryText("This example shows how to add a Font Awesome icon not in the set exposed by HtmlClassProperties."));
 		// using the icon helpers
 		String cogIcon = "fa-cog";
-		add(new WHeading(HeadingLevel.H3, "Cog icons"));
 		button = new WButton("\u200b"); // \u200b is a zero-width space.
 		button.setToolTip("Settings");
 		button.setHtmlClass(HtmlIconUtil.getIconClasses(cogIcon));

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/subordinate/SubordinateControlOptionsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/subordinate/SubordinateControlOptionsExample.java
@@ -236,6 +236,11 @@ public class SubordinateControlOptionsExample extends WContainer {
 	private final WCheckBox cbDisableTrigger = new WCheckBox();
 
 	/**
+	 * Client side disable/enable trigger.
+	 */
+	private final WCheckBox cbClientDisableTrigger = new WCheckBox();
+
+	/**
 	 * Readonly trigger.
 	 */
 	private final WCheckBox cbReadOnlyTrigger = new WCheckBox();
@@ -497,6 +502,8 @@ public class SubordinateControlOptionsExample extends WContainer {
 		triggerConfigSet.add(triggerConfigLayout);
 		triggerConfigLayout.addField("Disable Trigger", cbDisableTrigger);
 		triggerConfigLayout.addField("ReadOnly Trigger", cbReadOnlyTrigger);
+
+		triggerConfigLayout.addField("client disable trigger", cbClientDisableTrigger);
 		triggerConfigLayout.setLabelWidth(LABEL_WIDTH);
 
 		// Build Panel for Control/Target
@@ -657,6 +664,10 @@ public class SubordinateControlOptionsExample extends WContainer {
 			targetCollapsible.getDecoratedLabel().setTail(new WText(control.toString()));
 		}
 
+		control = new WSubordinateControl();
+		rule = new Rule(new Equal(cbClientDisableTrigger, true), new Disable((SubordinateTarget) trigger), new Enable((SubordinateTarget) trigger));
+		control.addRule(rule);
+		buildControlPanel.add(control);
 	}
 
 	/**
@@ -756,7 +767,6 @@ public class SubordinateControlOptionsExample extends WContainer {
 			default:
 				throw new SystemException("Trigger type not valid");
 		}
-
 		layout.addField(label, trigger);
 	}
 

--- a/wcomponents-theme/src/main/js/wc/ui/dateField.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dateField.js
@@ -1075,7 +1075,12 @@ define(["wc/has",
 				return false;
 			};
 
-
+			/**
+			 * Is a particular field a native date input?
+			 *
+			 * @param {Element} dateField a date field container.
+			 * @returns {Boolean}
+			 */
 			this.isLameDateField = function(dateField) {
 				if (hasNative) {
 					return false;

--- a/wcomponents-theme/src/main/js/wc/ui/subordinate.js
+++ b/wcomponents-theme/src/main/js/wc/ui/subordinate.js
@@ -612,6 +612,8 @@ define(["wc/dom/tag",
 						}
 						shed.subscribe(shed.actions.SELECT, shedObserver);
 						shed.subscribe(shed.actions.DESELECT, shedObserver);
+						shed.subscribe(shed.actions.ENABLE, shedObserver);
+						shed.subscribe(shed.actions.DISABLE, shedObserver);
 						console.log("Subordinate rules exist: added listeners");
 					}
 				});

--- a/wcomponents-theme/src/main/js/wc/ui/validation/dateField.js
+++ b/wcomponents-theme/src/main/js/wc/ui/validation/dateField.js
@@ -160,20 +160,20 @@ define(["wc/date/interchange",
 				}
 				Array.prototype.forEach.call(candidates, function(next) {
 					var textBox;
-					if (dateField.isNativeInput(next)) {
+					if (dateField.isLameDateField(next)) {
+						if (!next.getAttribute("aria-required")) {
+							return;
+						}
+						if (!dateField.getValue(next)) {
+							incomplete.push(next);
+						}
+					}
+					else {
 						textBox = dateField.getTextBox(next);
 						if (!textBox.getAttribute("required")) {
 							return;
 						}
 						if (!textBox.value) {
-							incomplete.push(next);
-						}
-					}
-					else {
-						if (!next.getAttribute("aria-required")) {
-							return;
-						}
-						if (!dateField.getValue(next)) {
 							incomplete.push(next);
 						}
 					}

--- a/wcomponents-theme/src/main/sass/wc.ui.table.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.scss
@@ -176,7 +176,7 @@ caption {
 	}
 
 	> .wc_table_colauto { // The first col after the last auto generated col is the first data col and cannot have a left border
-		border-left: 0 none;
+		@include border($pos: left, $width: 0);
 	}
 }
 

--- a/wcomponents-theme/src/main/xslt/wc.common.n.className.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.n.className.xsl
@@ -26,7 +26,7 @@
 		<xsl:if test="@class">
 			<xsl:value-of select="concat(' ', @class)"/>
 		</xsl:if>
-		<xsl:apply-templates select="ui:margin"/>
+		<xsl:apply-templates select="ui:margin" mode="class" />
 	</xsl:template>
 	
 	<xsl:template name="makeCommonClass">

--- a/wcomponents-theme/src/main/xslt/wc.ui.margin.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.margin.xsl
@@ -16,7 +16,7 @@
 		</xsl:if>
 	</xsl:template>
 	
-	<xsl:template match="ui:margin">
+	<xsl:template match="ui:margin" mode="class">
 		<xsl:choose>
 			<xsl:when test="@all">
 				<xsl:call-template name="margin">
@@ -53,64 +53,5 @@
 		</xsl:choose>
 	</xsl:template>
 	
-	<!--
-		Transform for ui:margin which is a common sub-element of layout components. It 
-		is used to place a margin on 1..4 sides of a component. Uses CSS margin 
-		shorthand notation and outputs nothing if all margins are 0.
-		
-		This is the old template to make margin into an inline style. Not very responsive. Does not help enforce
-		a common spacing style.
-	-->
-	<!--<xsl:template match="ui:margin">
-		<xsl:param name="style"/>
-		<xsl:variable name="margin">
-			<xsl:choose>
-				<xsl:when test="@all">
-					<xsl:call-template name="pxWithUnit">
-						<xsl:with-param name="gap" select="@all"/>
-					</xsl:call-template>
-				</xsl:when>
-				<xsl:otherwise>
-					<!-\- Note to JAVA peeps (web peeps, here is how to suck eggs)
-						the order of entries for a margin short form CSS rule is 
-							north east south west
-					-\->
-					<xsl:call-template name="pxWithUnit">
-						<xsl:with-param name="gap" select="@north"/>
-					</xsl:call-template>
-					<xsl:value-of select="' '"/>
-					<xsl:call-template name="pxWithUnit">
-						<xsl:with-param name="gap" select="@east"/>
-					</xsl:call-template>
-					<xsl:value-of select="' '"/>
-					<xsl:call-template name="pxWithUnit">
-						<xsl:with-param name="gap" select="@south"/>
-					</xsl:call-template>
-					<xsl:value-of select="' '"/>
-					<xsl:call-template name="pxWithUnit">
-						<xsl:with-param name="gap" select="@west"/>
-					</xsl:call-template>
-				</xsl:otherwise>
-			</xsl:choose>
-		</xsl:variable>
-		<xsl:if test="$margin != '' or $style != ''">
-			<xsl:attribute name="style">
-				<xsl:if test="$margin != ''">
-					<xsl:value-of select="concat('margin:',$margin,';')"/>
-				</xsl:if>
-				<xsl:if test="$style != ''">
-					<xsl:value-of select="$style"/>
-				</xsl:if>
-			</xsl:attribute>
-		</xsl:if>
-	</xsl:template>
-	
-	<xsl:template name="pxWithUnit">
-		<xsl:param name="gap" select="'0'"/>
-		<xsl:value-of select="$gap"/>
-		
-		<xsl:if test="$gap !='0'">
-			<xsl:text>px</xsl:text>
-		</xsl:if>
-	</xsl:template>-->
+	<xsl:template match="ui:margin"/>
 </xsl:stylesheet>


### PR DESCRIPTION
* Updated ui/validation/datefield to fix error calling incorrect public method in ui/datefield. Fixes #757
* Updated subordinate to run rules on disable/enable. Fixes #758.
* Updated how `ui:margin` gets converted to class attribute values to prevent accidentally applying `ui:margin` as a child element. This also removes the need to explicitly exclude `self::ui:margin` from `apply-templates`. Ensures a bug like #755 is not accidentally resurrected.
* Updated HtmlClassPropertiesExample to include ICON_MENU.