### PR TITLE
Deprecated media queries

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/menu/tree.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/tree.js
@@ -418,7 +418,7 @@ define(["wc/ui/menu/core",
 			/**
 			 * Write the state of WTree.
 			 *
-			 * @param {Element} the WTree root element
+			 * @param {Element} next the WTree root element
 			 * @param {Element} toContainer the state container
 			 */
 			this.writeMenuState = function(next, toContainer) {

--- a/wcomponents-theme/src/main/sass/_mixins-respond.scss
+++ b/wcomponents-theme/src/main/sass/_mixins-respond.scss
@@ -11,88 +11,6 @@ $wc-large-screen: 1921px !default;//bigger than 1080p
 // guess what this is for!
 $wc-bigger-than-small-screen: $wc-small-screen + 1px;
 
-// NOTE: This  does not work with Vaadin Sass-compiler. See separate mixins below.
-@mixin respond($size, $test: max-width) {
-	@if($size == phone) { //should cover most modern phones and some smaller/older tablets
-		@media only screen  and (min-device-width : 320px) and (max-device-width : 736px) {
-			@content;
-		}
-	}
-	@else if($size == phonelike) {
-		@media only screen  and (max-width : 736px) {
-			@content;
-		}
-	}
-	@else if($size == mobile) { // most things from small phones to ipad size tablets
-		@media only screen  and (min-device-width : 320px) and (max-device-width : 1034px) {
-			@content;
-		}
-	}
-	@else if($size == small) {
-		@media only screen and (#{$test}: $wc-small-screen) {
-			@content;
-		}
-	}
-	@else if($size == 'not-small') {
-		@media only screen and (min-width: $wc-bigger-than-small-screen) {
-			@content;
-		}
-	}
-	@else if($size == medium) {
-		@media only screen and (#{$test}: $wc-medium-screen) {
-			@content;
-		}
-	}
-	@else if($size == large) {
-		@media only screen and (#{$test}: $wc-large-screen) {
-			@content;
-		}
-	}
-	@else if($size == ip6) { //iphone 6plus
-		@media only screen  and (min-device-width : 375px) and (max-device-width : 667px) {
-			@content;
-		}
-	}
-	@else if($size == ip6p) { //iphone 6
-		@media only screen  and (min-device-width : 414px) and (max-device-width : 736px) {
-			@content;
-		}
-	}
-	@else if($size == ip5) { //iphone 5/5s/5c
-		@media only screen  and (min-device-width : 320px) and (max-device-width : 568px) {
-			@content;
-		}
-	}
-	@else if($size == ip4) { //iphone 4/4s
-		@media only screen  and (min-device-width : 320px) and (max-device-width : 480px) {
-			@content;
-		}
-	}
-	@else if($size == ipad) { //most ipads
-		@media only screen  and (min-device-width : 768px) and (max-device-width : 1024px) {
-			@content;
-		}
-	}
-	@else {
-		@media only screen and (#{$test}: $size) { // primitive but should allow a bit of customization.
-			@content;
-		}
-	}
-}
-// END of mixin broken by Vaadin Sass-Compiler/
-
-@mixin respond-phone {
-	@media only screen and (max-device-width: 773px) {
-		@content;
-	}
-}
-
-@mixin respond-not-phone {
-	@media only screen and (min-device-width: 774px) {
-		@content;
-	}
-}
-
 @mixin respond-phonelike {
 	@media only screen and (max-width : 773px) {
 		@content;
@@ -117,26 +35,30 @@ $wc-bigger-than-small-screen: $wc-small-screen + 1px;
 	}
 }
 
-@mixin respond-med-screen {
-	@media only screen and (max-width: 1280px) {
+@mixin respond-bigger-screen {
+	@media only screen and (min-width: 1281px) {
 		@content;
 	}
 }
 
-@mixin respond-large-screen {
-	@media only screen and (min-width: 1921px) {
+// TODO Do we want to add some pixel density tests for phones/tablets?
+// (-webkit-min-device-pixel-ratio: 2), /* Webkit-based browsers */
+// (min--moz-device-pixel-ratio: 2),    /* Older Firefox browsers (prior to Firefox 16) */
+// (min-resolution: 2dppx),             /* The standard way */
+// (min-resolution: 192dpi)             /* dppx fallback */
+
+@mixin respond-medium-density {
+	@media only screen and (-webkit-min-device-pixel-ratio: 1.5),
+	only screen and (min-resolution: 1.5dppx),
+	only screen and (min-resolution: 144dpi) {
 		@content;
 	}
 }
 
-@mixin respond-med-device {
-	@media only screen and (min-device-width: 1025px) {
-		@content;
-	}
-}
-
-@mixin respond-large-device {
-	@media only screen and (min-device-width: 1921px) {
+@mixin respond-high-density {
+	@media only screen and (-webkit-min-device-pixel-ratio: 2),
+	only screen and (min-resolution: 2dppx),
+	only screen and (min-resolution: 192dpi) {
 		@content;
 	}
 }

--- a/wcomponents-theme/src/main/sass/wc.common.page.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.page.scss
@@ -10,7 +10,7 @@ html {
 body {
 	@include tight-box;
 	font-family: $wc-default-font;
-	font-size: $wc-default-font-size;
+	font-size: $wc-desktop-font-size;
 	height: 100%; // body to fill viewport for event propagation.
 }
 
@@ -69,19 +69,19 @@ pre {
 	display: none !important;
 }
 
+@include respond-medium-density {
+	body {
+		font-size: $wc-default-font-size;
+	}
+}
+
 @include viewport {
 	user-zoom: zoom;
 	width: extend-to-zoom;
 	zoom: 1;
 }
 
-@include respond-med-device {
-	body {
-		font-size: $wc-desktop-font-size;
-	}
-}
-
-@include respond-large-device {
+@include respond-bigger-screen {
 	body {
 		font-size: $wc-bigscreen-font-size;
 	}


### PR DESCRIPTION
Removed deprecated media queries from responsive design mixins in Sass. Fixes #745.