### PR TITLE
Shed hidden update

### DIFF
--- a/wcomponents-theme/src/main/js/wc/dom/ariaAnalog.js
+++ b/wcomponents-theme/src/main/js/wc/dom/ariaAnalog.js
@@ -567,7 +567,6 @@ define(["wc/has",
 						filter: function(el) {
 							/* the group filter EXCLUDES elements return true*/
 							var result = NodeFilter.FILTER_ACCEPT;
-							// return shed.isDisabled(el) || shed.isHidden(el);
 							if (shed.isDisabled(el) || shed.isHidden(el)) {
 								result = NodeFilter.FILTER_REJECT;
 							}

--- a/wcomponents-theme/src/main/js/wc/dom/focus.js
+++ b/wcomponents-theme/src/main/js/wc/dom/focus.js
@@ -305,7 +305,7 @@ define(["wc/array/toArray",
 					 * unless the radio button is the first radio button in a group and none of the group's
 					 * radio buttons are checked.
 					 */
-					if (shed.isDisabled(element) || shed.isHidden(element) || element.type === "hidden" || getStyle(element, "visibility", false, true) === "hidden") {
+					if (shed.isDisabled(element) || shed.isHidden(element)) {
 						result = REJECT;
 					}
 					else if (tagName === tag.INPUT && element.type === "radio" && !shed.isSelected(element)) {

--- a/wcomponents-theme/src/main/js/wc/dom/getFilteredGroup.js
+++ b/wcomponents-theme/src/main/js/wc/dom/getFilteredGroup.js
@@ -12,7 +12,7 @@ define(["wc/dom/group", "wc/dom/shed"],
 			/** @constant {String[]} FILTERS The properties which may be used to filter a group. @private */
 			FILTERS = ["selected", "deselected", "disabled", "enabled", "hidden", "visible", "expanded", "collapsed"],
 			/** @constant {String[]} SHED_FILTERS {@link module:wc/dom.shed} functions which may be used to filter a group. @private */
-			SHED_FILTERS = ["isSelected", "isDisabled", "isNotVisible", "isExpanded"];
+			SHED_FILTERS = ["isSelected", "isDisabled", "isHidden", "isExpanded"];
 
 		/**
 		 * Build an object defining states as bit masks from a string array.

--- a/wcomponents-theme/src/main/js/wc/ui/SubordinateAction.js
+++ b/wcomponents-theme/src/main/js/wc/ui/SubordinateAction.js
@@ -279,16 +279,6 @@ define(["wc/ui/fx", "wc/dom/shed", "wc/has"],
 				return (type === "checkbox" || type === "radio");
 			}
 
-//			function isVisible(element)
-//			{
-//				return !shed.isHidden(element);
-//			}
-//
-//			function isEnabled(element)
-//			{
-//				return !shed.isDisabled(element);
-//			}
-
 			/**
 			* doInGroup is a helper for {@link module:wc/ui/SubordinateAction~hideInGroup} and
 			* {@link module:wc/ui/SubordinateAction~showInGroup}.

--- a/wcomponents-theme/src/main/js/wc/ui/calendar.js
+++ b/wcomponents-theme/src/main/js/wc/ui/calendar.js
@@ -365,7 +365,7 @@ function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthNam
 				input;
 
 			// touching = null;
-			if (cal && !shed.isHidden(cal)) {
+			if (cal && !shed.isHidden(cal, true)) {
 				// focus the dateField if required
 				if (!ignoreFocusReset && (input = getInputForCalendar(cal))) {
 					refocusId = input.id;
@@ -1026,7 +1026,7 @@ function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthNam
 			var input, box,
 				cal = element || getCal(),
 				fixed;
-			if (cal && !shed.isHidden(cal)) {
+			if (cal && !shed.isHidden(cal, true)) {
 				fixed = (window.getComputedStyle && window.getComputedStyle(cal).position === "fixed");
 				if (fixed) {
 					input = getInputForCalendar(cal);
@@ -1114,7 +1114,7 @@ function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthNam
 				element, cal;
 			DATE_FIELD = DATE_FIELD || dateField.getWidget();
 
-			if (DATE_FIELD && target && (cal = getCal()) && !shed.isHidden(cal)) {
+			if (DATE_FIELD && target && (cal = getCal()) && !shed.isHidden(cal, true)) {
 				element = DATE_FIELD.findAncestor(target);
 
 				if (!element || (element !== DATE_FIELD.findAncestor(getCal()))) { // second: focused a different date field

--- a/wcomponents-theme/src/main/js/wc/ui/comboBox.js
+++ b/wcomponents-theme/src/main/js/wc/ui/comboBox.js
@@ -806,7 +806,7 @@ define(["wc/has",
 				}
 
 				listbox = getListBox(element);
-				if (!listbox || shed.isHidden(listbox)) { // listbox should always be available.
+				if (!listbox || shed.isHidden(listbox, true)) { // listbox should always be available.
 					return;
 				}
 

--- a/wcomponents-theme/src/main/js/wc/ui/dialog.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dialog.js
@@ -121,7 +121,7 @@ define(["wc/dom/classList",
 					return false;
 				}
 
-				if (dialog && !shed.isHidden(dialog)) {
+				if (dialog && !shed.isHidden(dialog, true)) {
 					content = dialogFrame.getContent();
 					if (!content) {
 						console.error("Found open dialog but not its content");

--- a/wcomponents-theme/src/main/js/wc/ui/dialogFrame.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dialogFrame.js
@@ -164,7 +164,7 @@ define(["wc/dom/event",
 					form, formId;
 
 				if (dialog) {
-					if (shed.isHidden(dialog)) {
+					if (shed.isHidden(dialog, true)) {
 						return Promise.resolve(openDlgHelper(dto));
 					}
 					return Promise.reject(REJECT.ALREADY_OPEN);
@@ -193,7 +193,7 @@ define(["wc/dom/event",
 			function openDlgHelper(dto) {
 				var dialog = instance.getDialog();
 
-				if (dialog && shed.isHidden(dialog)) {
+				if (dialog && shed.isHidden(dialog, true)) {
 					if (dto && dto.openerId) {
 						openerId = dto.openerId;
 					}
@@ -488,7 +488,7 @@ define(["wc/dom/event",
 				else if (docFragment.getElementById && docFragment.getElementById(DIALOG_ID)) {
 					removeShim = true;
 				}
-				if (removeShim && (dialog = instance.getDialog()) && !shed.isHidden(dialog)) {
+				if (removeShim && (dialog = instance.getDialog()) && !shed.isHidden(dialog, true)) {
 					modalShim.clearShim(dialog);
 				}
 			}
@@ -506,7 +506,7 @@ define(["wc/dom/event",
 				if (element && (content = instance.getContent()) && content.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_CONTAINED_BY) {
 					dialog = instance.getDialog();
 					// if we are refreshing inside the dialog we may need to reposition
-					if (!shed.isHidden(dialog)) {  // it damn well better not be
+					if (!shed.isHidden(dialog, true)) {  // it damn well better not be
 						if (!(dialog.style.width && dialog.style.height)) {
 							// we have not got a fixed or user-created size so we will resize automatically
 							instance.reposition();
@@ -574,7 +574,7 @@ define(["wc/dom/event",
 			 */
 			this.close = function() {
 				var dialog = this.getDialog();
-				if (dialog && !shed.isHidden(dialog)) {
+				if (dialog && !shed.isHidden(dialog, true)) {
 					shed.hide(dialog);
 					return true;
 				}
@@ -651,7 +651,7 @@ define(["wc/dom/event",
 				var dialog;
 				if (!$event.defaultPrevented && CLOSE_WD.findAncestor($event.target)) {
 					dialog = document.getElementById(DIALOG_ID);
-					if (dialog && !shed.isHidden(dialog)) {
+					if (dialog && !shed.isHidden(dialog, true)) {
 						instance.close();
 						$event.preventDefault();
 					}
@@ -706,7 +706,7 @@ define(["wc/dom/event",
 					dialog,
 					result = false,
 					keyCode = $event.keyCode;
-				if (!$event.defaultPrevented && (dialog = document.getElementById(DIALOG_ID)) && !shed.isHidden(dialog)) {
+				if (!$event.defaultPrevented && (dialog = document.getElementById(DIALOG_ID)) && !shed.isHidden(dialog, true)) {
 					switch (keyCode) {
 						case KeyEvent.DOM_VK_ESCAPE:
 							result = instance.close();
@@ -737,7 +737,7 @@ define(["wc/dom/event",
 			function resizeEventHelper() {
 				var dialog = document.getElementById(DIALOG_ID);
 
-				if (!dialog || shed.isHidden(dialog)) {
+				if (!dialog || shed.isHidden(dialog, true)) {
 					return;
 				}
 				setUnsetDimensionsPosition(dialog);

--- a/wcomponents-theme/src/main/js/wc/ui/getVisibleText.js
+++ b/wcomponents-theme/src/main/js/wc/ui/getVisibleText.js
@@ -17,8 +17,8 @@ define(["wc/dom/Widget",
 		var HINT;
 
 		/**
-		 * Funny old treewlker filter: ee want to get all the nodes we can remove from element so we SKIP anything which
-		 * is not considered invisible.
+		 * Funny old treewalker filter: we want to get all the nodes we can remove from element so we ACCEPT anything
+		 * which is disabled or hidden.
 		 *
 		 * @function
 		 * @private
@@ -26,12 +26,7 @@ define(["wc/dom/Widget",
 		 * @returns {Number} NodeFilter.FILTER_ACCEPT if the node is hidden (and can therefore be removed).
 		 */
 		function treeWalkerFilter(element) {
-			if (shed.isDisabled(element) ||
-					shed.isHidden(element) ||
-					element.type === "hidden" ||
-					getStyle(element, "visibility", false, true) === "hidden" ||
-					getStyle(element, "display", false, true) === "none" ||
-					(element.offsetWidth === 0 && element.offsetHeight === 0)) {
+			if (shed.isDisabled(element) || shed.isHidden(element)) {
 				return NodeFilter.FILTER_ACCEPT;
 			}
 

--- a/wcomponents-theme/src/main/js/wc/ui/label.js
+++ b/wcomponents-theme/src/main/js/wc/ui/label.js
@@ -168,7 +168,7 @@ define(["wc/dom/classList",
 				}
 				newLabellingElement.id = label.id;
 
-				if (shed.isHidden(element)) {
+				if (shed.isHidden(element, true)) {
 					shed.hide(newLabellingElement, true);  // nothing depends on the hidden state of a label and we are replicating a load-time state.
 				}
 				if (classList.contains(label, CLASS_OFF)) {
@@ -204,7 +204,7 @@ define(["wc/dom/classList",
 						shed.optional(element);
 					}
 
-					if (shed.isHidden(element)) {
+					if (shed.isHidden(element, true)) {
 						shed.hide(element);
 					}
 					else {

--- a/wcomponents-theme/src/main/js/wc/ui/menu/core.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/core.js
@@ -281,7 +281,7 @@ define(["wc/dom/attribute",
 		AbstractMenu.prototype._textMatchFilter = function(textNode) {
 			var parent = textNode.parentNode;
 
-			if (shed.isNotVisible(textNode, parent) || shed.hasDisabledAncestor(textNode, parent) || getFixedWidgets().OFFSCREEN.findAncestor(parent)) {
+			if (shed.isHidden(textNode) || shed.hasDisabledAncestor(textNode, parent) || getFixedWidgets().OFFSCREEN.findAncestor(parent)) {
 				return NodeFilter.FILTER_REJECT;
 			}
 			if (textNode.nodeValue) {

--- a/wcomponents-theme/src/main/js/wc/ui/modalShim.js
+++ b/wcomponents-theme/src/main/js/wc/ui/modalShim.js
@@ -156,7 +156,7 @@ define(["wc/dom/attribute", "wc/dom/uid", "wc/dom/classList", "wc/dom/event", "w
 				var shimElement, key, aKeyElement;
 				try {
 					shimElement = document.getElementById(MODAL_BACKGROUND_ID);
-					if (shimElement && !shed.isHidden(shimElement)) {
+					if (shimElement && !shed.isHidden(shimElement, true)) {
 						addRemoveEvents();
 						shimElement.className = "";
 						for (key in accessKeyMap) {

--- a/wcomponents-theme/src/main/js/wc/ui/resizeable.js
+++ b/wcomponents-theme/src/main/js/wc/ui/resizeable.js
@@ -504,7 +504,7 @@ define(["wc/dom/attribute",
 			 */
 			function bootstrap(element) {
 				var body = document.body;
-				if (!(attribute.get(element, BS) || shed.isHidden(element) || shed.hasHiddenAncestor(element))) {
+				if (!(attribute.get(element, BS) || shed.isHidden(element))) {
 					attribute.set(element, BS, true);
 					event.add(element, event.TYPE.mousedown, mousedownEvent);
 					event.add(element, event.TYPE.keydown, keydownEvent);

--- a/wcomponents-theme/src/main/js/wc/ui/selectboxSearch.js
+++ b/wcomponents-theme/src/main/js/wc/ui/selectboxSearch.js
@@ -139,7 +139,7 @@ define(["wc/string/escapeRe",
 						textContent.set(search, val + character);
 						val = textContent.get(search);
 						if (val.length) {
-							if (shed.isHidden(search)) {
+							if (shed.isHidden(search, true)) {
 								element.parentNode.insertBefore(search, element);
 								shed.show(search);
 							}
@@ -360,7 +360,7 @@ define(["wc/string/escapeRe",
 			function closeSearch(element) {
 				var search = getSearchElement();
 				textContent.set(search, "");
-				if (!shed.isHidden(search)) {
+				if (!shed.isHidden(search, true)) {
 					hideSearch(search);
 					if (fireOnchange && element) {
 						// programatically changing the select will not fire change so we gots to do it ourselves

--- a/wcomponents-theme/src/main/js/wc/ui/textArea.js
+++ b/wcomponents-theme/src/main/js/wc/ui/textArea.js
@@ -63,14 +63,14 @@ define(["wc/dom/attribute",
 
 			function hideCounter(element) {
 				var counter;
-				if ((counter = instance.getCounter(element)) && !shed.isHidden(counter)) {
+				if ((counter = instance.getCounter(element)) && !shed.isHidden(counter, true)) {
 					shed.hide(counter, true);
 				}
 			}
 
 			function showCounter(element) {
 				var counter;
-				if ((counter = instance.getCounter(element)) && shed.isHidden(counter)) {
+				if ((counter = instance.getCounter(element)) && shed.isHidden(counter, true)) {
 					shed.show(counter, true);
 				}
 			}

--- a/wcomponents-theme/src/main/js/wc/ui/timeoutWarn.js
+++ b/wcomponents-theme/src/main/js/wc/ui/timeoutWarn.js
@@ -52,7 +52,7 @@ define(["lib/sprintf", "wc/xml/xslTransform", "wc/dom/event", "wc/dom/Widget", "
 			 * @param {Element} element The warning container.
 			 */
 			function closeWarning(element) {
-				if (element && !shed.isHidden(element)) {
+				if (element && !shed.isHidden(element, true)) {
 					event.remove(document.body, event.TYPE.keydown, keyDownEvent);
 					event.remove(element, event.TYPE.click, clickEvent);
 					shed.hide(element);
@@ -162,7 +162,7 @@ define(["lib/sprintf", "wc/xml/xslTransform", "wc/dom/event", "wc/dom/Widget", "
 						body = i18n.get("${wc.ui.timeoutWarn.message.expired.body}");
 						container.appendChild(errorDf);
 						container.innerHTML = sprintf.sprintf(container.innerHTML, header, body);
-						if (shed.isHidden(container)) {
+						if (shed.isHidden(container, true)) {
 							showDialog(container);  // re-show it if the warning was closed by the user
 						}
 						console.info("expired shown at", new Date());

--- a/wcomponents-theme/src/main/js/wc/ui/validation/validationManager.js
+++ b/wcomponents-theme/src/main/js/wc/ui/validation/validationManager.js
@@ -15,7 +15,6 @@
  * @requires module:wc/i18n/i18n
  */
 define(["wc/dom/classList",
-		"wc/dom/getBox",
 		"wc/has",
 		"wc/dom/initialise",
 		"wc/dom/shed",
@@ -23,8 +22,8 @@ define(["wc/dom/classList",
 		"wc/dom/Widget",
 		"wc/Observer",
 		"wc/i18n/i18n"],
-	/** @param classList @param getBox @param has @param initialise @param shed @param tag @param Widget @param Observer @param i18n @ignore*/
-	function(classList, getBox, has, initialise, shed, tag, Widget, Observer, i18n) {
+	/** @param classList @param has @param initialise @param shed @param tag @param Widget @param Observer @param i18n @ignore*/
+	function(classList, has, initialise, shed, tag, Widget, Observer, i18n) {
 		"use strict";
 
 		/**
@@ -180,20 +179,6 @@ define(["wc/dom/classList",
 			}
 
 			/**
-			 * Tests if the current element is actually visible.
-			 * NOTE: this is only guranteed to work for bounded elements such as INPUT, TEXTAREA etc but is close enough
-			 * for our purposes for other elements since when an element is hidden its descendants have no dimensions.
-			 * @function
-			 * @private
-			 * @param {Element} element The HTML element to test.
-			 * @returns {Boolean} true if the element is associated with a success message.
-			 */
-			function isNotVisible(element) {
-				var box = getBox(element);
-				return !(box.width && box.height);
-			}
-
-			/**
 			 * Remove a link to a component which was in an error state when the page was loaded (using
 			 * WValidationErrors) but which was subsequently corrected.
 			 * @function
@@ -286,8 +271,7 @@ define(["wc/dom/classList",
 			 */
 			this.isExempt = function(element) {
 				var result = false;
-				if ((element.tagName === tag.INPUT && element.type === "hidden") || shed.isDisabled(element) ||
-					(shed.isHidden(element) || isNotVisible(element))) {
+				if ((element.tagName === tag.INPUT && element.type === "hidden") || shed.isDisabled(element) || shed.isHidden(element)) {
 					result = true;
 				}
 				return result;

--- a/wcomponents-theme/src/main/sass/_mixins-common.scss
+++ b/wcomponents-theme/src/main/sass/_mixins-common.scss
@@ -175,9 +175,9 @@
 	// Require important to ensure we are really off screen
 	// scss-lint:disable ImportantRule
 	left: -9999px !important;
+	max-width: 10px !important; // not zero otherwise the item may appear 'hidden' to dom/shed
 	overflow: hidden !important;
 	position: absolute !important;
-	width: 0 !important;
 }
 
 /// Set an outline on an element. Outlines may be better than borders for transient effects.

--- a/wcomponents-theme/src/test/intern/wc.dom.shed.test.js
+++ b/wcomponents-theme/src/test/intern/wc.dom.shed.test.js
@@ -521,105 +521,49 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils!"],
 			testHasDisabledAncestorFalse: function() {
 				assert.isFalse(controller.hasDisabledAncestor(document.getElementById("radioButtonGroup4_1")));
 			},
-			testHasHiddenAncestor: function() {
-				assert.isTrue(controller.hasHiddenAncestor(document.getElementById("radioButtonGroup4_1")));
+			testIsHiddenByAncestor: function() {
+				var test = document.getElementById("visibletests1");
+				assert.isFalse(controller.isHidden(test));
 			},
-			testHasHiddenAncestorFalse: function() {
-				assert.isFalse(controller.hasHiddenAncestor(document.getElementById("radioButtonGroup3_1")));
-			},
-			testIsVisible: function() {
-				var parent = document.getElementById("visibletests"),
-					test = document.getElementById("visibletests1");
-				assert.isTrue(controller.isVisible(test));
-			},
-			testIsNotVisible: function() {
-				var parent = document.getElementById("visibletests"),
-					test = document.getElementById("visibletests1");
-				assert.isFalse(controller.isNotVisible(test));
-			},
-			testIsVisibleWithDisplay: function() {
+			testIsHiddenByAncestorWithDisplay: function() {
 				var parent = document.getElementById("visibletests"),
 					test = document.getElementById("visibletests1");
 				try {
 					parent.style.display = "none";
-					assert.isFalse(controller.isVisible(test));
+					assert.isTrue(controller.isHidden(test));
 				}
 				finally {
 					parent.style.display = "";
 				}
 			},
-			testIsVisibleWithVisibility: function() {
+			testIsHiddenByAncestorWithVisibility: function() {
 				var parent = document.getElementById("visibletests"),
 					test = document.getElementById("visibletests1");
 				try {
 					parent.style.visibility = "hidden";
-					assert.isFalse(controller.isVisible(test));
+					assert.isTrue(controller.isHidden(test));
 				}
 				finally {
 					parent.style.visibility = "";
 				}
 			},
-			testIsVisibleWithHidden: function() {
+			testIsHiddenByAncestorWithHidden: function() {
 				var parent = document.getElementById("visibletests"),
 					test = document.getElementById("visibletests1");
 				try {
 					parent.setAttribute("hidden", "hidden");
-					assert.isFalse(controller.isVisible(test));
+					assert.isTrue(controller.isHidden(test));
 				}
 				finally {
 					parent.removeAttribute("hidden");
 				}
 			},
-			testIsVisibleWithShedHide: function() {
+			testIsHiddenByAncestorWithShedHide: function() {
 				var parent = document.getElementById("visibletests"),
 					test = document.getElementById("visibletests1");
 				try {
 					controller.hide(parent);
-					assert.isFalse(controller.isVisible(test));
-				}
-				finally {
-					controller.show(parent);
-				}
-			},
-			testIsNotVisibleWithDisplay: function() {
-				var parent = document.getElementById("visibletests"),
-					test = document.getElementById("visibletests1");
-				try {
-					parent.style.display = "none";
-					assert.isTrue(controller.isNotVisible(test));
-				}
-				finally {
-					parent.style.display = "";
-				}
-			},
-			testIsNotVisibleWithVisibility: function() {
-				var parent = document.getElementById("visibletests"),
-					test = document.getElementById("visibletests1");
-				try {
-					parent.style.visibility = "hidden";
-					assert.isTrue(controller.isNotVisible(test));
-				}
-				finally {
-					parent.style.visibility = "";
-				}
-			},
-			testIsNotVisibleWithHidden: function() {
-				var parent = document.getElementById("visibletests"),
-					test = document.getElementById("visibletests1");
-				try {
-					parent.setAttribute("hidden", "hidden");
-					assert.isTrue(controller.isNotVisible(test));
-				}
-				finally {
-					parent.removeAttribute("hidden");
-				}
-			},
-			testIsNotVisibleWithShedHide: function() {
-				var parent = document.getElementById("visibletests"),
-					test = document.getElementById("visibletests1");
-				try {
-					controller.hide(parent);
-					assert.isTrue(controller.isNotVisible(test));
+					assert.isTrue(controller.isHidden(test));
 				}
 				finally {
 					controller.show(parent);


### PR DESCRIPTION
Fixed the nasty shed method names introduced in the last pull request.
shed.isHidden now has an optional boolean attribute which if true will
only look for the hidden/open attribute, otherwise it will test the
hidden/open attribute then other mechanisms which make an element
hidden.