### PR TITLE
Subordinate rule proccessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## API Changes
 
 ## Bug Fixes
+* Fixed a bug in `com.github.bordertech.wcomponents.subordinate.AbstractCompare` which resulted in Subordinate controls returning an incorrect value if the control was in a read-only state #780.
 * Fixed a newly introduced bug which caused textareas to fail to accept newlines in IE11 #785.
 * Fixed several IE CSS issues.
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/subordinate/AbstractCompare.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/subordinate/AbstractCompare.java
@@ -88,7 +88,7 @@ public abstract class AbstractCompare extends AbstractCondition {
 	@Override
 	protected boolean execute() {
 		// Disabled triggers are always false
-		if ((trigger instanceof Disableable) && ((Disableable) trigger).isDisabled()) {
+		if ((trigger instanceof Disableable) && ((Disableable) trigger).isDisabled()  && !(trigger instanceof Input && ((Input) trigger).isReadOnly())) {
 			return false;
 		}
 
@@ -107,7 +107,7 @@ public abstract class AbstractCompare extends AbstractCondition {
 	@Override
 	protected boolean execute(final Request request) {
 		// Disabled triggers are always false
-		if ((trigger instanceof Disableable) && ((Disableable) trigger).isDisabled()) {
+		if ((trigger instanceof Disableable) && ((Disableable) trigger).isDisabled() && !(trigger instanceof Input && ((Input) trigger).isReadOnly())) {
 			return false;
 		}
 

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/subordinate/AbstractCompare_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/subordinate/AbstractCompare_Test.java
@@ -130,6 +130,32 @@ public class AbstractCompare_Test {
 				"Compare of equal disabled trigger and value should be false with request",
 				compare.execute(new MockRequest()));
 	}
+	@Test
+	public void testExecuteReadOnlyAndDisabled() {
+		String value = "test";
+
+		MyInput trigger = new MyInput();
+		trigger.setData(value);
+
+		// Setup Compare to be "true"
+		AbstractCompare compare = new MyCompare(trigger, value);
+		Assert.assertTrue("Compare of equal trigger and value should be true", compare.execute());
+		Assert.assertTrue("Compare of equal trigger and value should be true with request",
+				compare.execute(new MockRequest()));
+
+		// Disabled trigger should make the compare false
+		trigger.setDisabled(true);
+		Assert.assertFalse("Compare of equal disabled trigger and value should be false", compare.
+				execute());
+		Assert.assertFalse(
+				"Compare of equal disabled trigger and value should be false with request",
+				compare.execute(new MockRequest()));
+		trigger.setReadOnly(true);
+		Assert.assertTrue("Compare of equal disabled and read only trigger and value should be true", compare.execute());
+		Assert.assertTrue("Compare of equal disabled and read only trigger and value should be true with request",
+				compare.execute(new MockRequest()));
+
+	}
 
 	@Test
 	public void testExecuteTriggerWithListOfValues() {


### PR DESCRIPTION
Updated comparison execution such that disabled is only assumed false
if the control is not also disabled. Fixes #780.

@jonathanaustin PTAL