### PR TITLE
Toggle button css

### DIFF
--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WToggleButtonExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WToggleButtonExample.java
@@ -73,34 +73,34 @@ public class WToggleButtonExample extends WPanel {
 		add(container);
 
 		add(new ExplanatoryText("Toggle button exposing WCheckBox properties with labels."));
-		WFieldLayout layout = new WFieldLayout(WFieldLayout.LAYOUT_STACKED);
+		WFieldLayout layout = new WFieldLayout();
 		add(layout);
 
 
 		// the regular (check-boxy) parts of WToggleButton.
 
-		layout.addField("Normal Check box", new WToggleButton());
-		layout.addField("Checked Check box", new WToggleButton(true));
+		layout.addField("Normal toggle button", new WToggleButton());
+		layout.addField("Checked toggle button", new WToggleButton(true));
 
 		toggle = new WToggleButton();
 		toggle.setDisabled(true);
-		layout.addField("Disabled check box", toggle);
+		layout.addField("Disabled toggle button", toggle);
 
 		toggle = new WToggleButton(true);
 		toggle.setDisabled(true);
-		layout.addField("Disabled checked check box", toggle);
+		layout.addField("Disabled checked toggle button", toggle);
 
 		toggle = new WToggleButton();
 		toggle.setMandatory(true);
-		layout.addField("Mandatory check box", toggle);
+		layout.addField("Mandatory toggle button", toggle);
 
 		toggle = new WToggleButton();
 		toggle.setReadOnly(true);
-		layout.addField("Read only unchecked check box", toggle);
+		layout.addField("Read only unchecked toggle button", toggle);
 
 		toggle = new WToggleButton(true);
 		toggle.setReadOnly(true);
-		layout.addField("Read only checked check box", toggle);
+		layout.addField("Read only checked toggle button", toggle);
 
 
 

--- a/wcomponents-theme/src/main/sass/_invite.scss
+++ b/wcomponents-theme/src/main/sass/_invite.scss
@@ -2,6 +2,7 @@
 
 %wc-invite {
 	cursor: pointer;
+	outline: 0;
 
 	&:hover,
 	&:focus {

--- a/wcomponents-theme/src/main/sass/wc.ui.calendar.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.calendar.color.scss
@@ -25,8 +25,8 @@
 	color: $wc-ui-color-global-fg;
 
 	&[aria-pressed='true'] { // selected date
-		background-color: $wc-ui-color-highlight-bg;
-		color: $wc-ui-color-highlight-fg;
+		background-color: $wc-ui-color-selected-bg;
+		color: $wc-ui-color-selected-fg;
 	}
 }
 

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.color.scss
@@ -25,6 +25,6 @@
 
 // selected elements
 .wc-menuitem[aria-checked='true'] {
-	background-color: $wc-ui-color-highlight-bg;
-	color: $wc-ui-color-highlight-fg;
+	background-color: $wc-ui-color-selected-bg;
+	color: $wc-ui-color-selected-fg;
 }

--- a/wcomponents-theme/src/main/sass/wc.ui.togglebutton.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.togglebutton.scss
@@ -1,13 +1,13 @@
 /* wc.ui.togglebutton.scss */
+// toggle button styles based on https://codepen.io/mallendeo/pen/eLIiG
 @import 'mixins-common';
 
 .wc-togglebutton {
 	@include border;
 	background-color: $wc-ui-color-highlight-bg;
 	border-radius: $wc-togglebutton-slider-width;
-	cursor: pointer;
 	height: $wc-togglebutton-slider-width;
-	outline: 0;
+	// outline: 0;
 	position: relative;
 	transition: $wc-togglebutton-transition;
 	user-select: none;
@@ -26,33 +26,24 @@
 		width: 50%;
 	}
 
-	&:hover:after {
-		will-change: padding;
-	}
-
-	&:active:after {
-		padding-right: 0.8em;
-	}
-
-	&.wc_ro:active:after {
-		padding-right: 0;
-	}
-
-	&:before {
-		display: none;
-	}
-
 	&.wc_ro_sel,
 	&[aria-checked='true'] {
-		background-color: $wc-ui-color-togglebutton-selected;
-
 		&:after {
 			left: calc(50% - $wc-togglebutton-double-border-width);
 		}
+	}
 
-		&[disabled] {
-			background-color: $wc-ui-color-disabled-bg;
+	&[aria-checked='true'] {
+		background-color: $wc-ui-color-togglebutton-selected;
+
+		// invite ???
+		&:focus {
+			background-color: $wc-ui-color-invite-bg;
 		}
+	}
+
+	&[disabled] {
+		background-color: $wc-ui-color-disabled-bg;
 	}
 
 	&.wc_ro {

--- a/wcomponents-theme/src/main/xslt/wc.ui.togglebutton.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.togglebutton.xsl
@@ -31,7 +31,7 @@
 					<xsl:call-template name="commonControlAttributes">
 						<xsl:with-param name="isError" select="$isError"/>
 						<xsl:with-param name="myLabel" select="$myLabel[1]"/>
-						<xsl:with-param name="class" select="'wc-nobutton'"/>
+						<xsl:with-param name="class" select="'wc-nobutton wc-invite'"/>
 					</xsl:call-template>
 					<!-- Fortunately commonControlAttributes will only output a value attribute if
 						the XML element has a value attribute; so we can add the ui:checkbox value


### PR DESCRIPTION
* Some fixes to the toggle button Sass to remove unnecessary rules and
attach the common `wc-invite` class. Fixed up the example.
* Made some changes to selected components to improve consistency of
appearance.