### PR TITLE
Fix dialog position, responsive UI updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed a bug in `com.github.bordertech.wcomponents.subordinate.AbstractCompare` which resulted in Subordinate controls returning an incorrect value if the control was in a read-only state #780.
 * Fixed a newly introduced bug which caused textareas to fail to accept newlines in IE11 #785.
 * Fixed several IE CSS issues.
+* Fixed bug which could result in dialogs being mis-positioned #805.
 
 ## Enhancements
 * Added mechanism to convert tabsets to accordions on small screens #783.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,17 @@
 ## API Changes
 
 ## Bug Fixes
+* Fixed bug which could result in dialogs being mis-positioned #805.
+
+## Enhancements
+* JavaScript API added a utility module to centralize determination of toggle points for responsive UI updates.
+
+# Release 1.2.2
+## Bug Fixes
 * Fixed a bug in `com.github.bordertech.wcomponents.subordinate.AbstractCompare` which resulted in Subordinate controls returning an incorrect value if the control was in a read-only state #780.
 * Fixed a newly introduced bug which caused textareas to fail to accept newlines in IE11 #785.
 * Fixed several IE CSS issues.
-* Fixed bug which could result in dialogs being mis-positioned #805.
+* Fixed a bug which caused the incorrect HTML className to be set using HtmlIconUtils to place a custom icon "AFTER" element content.
 
 ## Enhancements
 * Added mechanism to convert tabsets to accordions on small screens #783.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Bug Fixes
 * Fixed bug which could result in dialogs being mis-positioned #805.
+* Fixed bugs in keyboard driving combo boxes #808, #809.
 
 ## Enhancements
 * JavaScript API added a utility module to centralize determination of toggle points for responsive UI updates.

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WDialogExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WDialogExample.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.examples;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.MessageContainer;
 import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.WAjaxControl;
@@ -201,8 +202,7 @@ public class WDialogExample extends WPanel implements MessageContainer {
 		 * If not set explicitly, the title of a dialog is determined by the UI theme.
 		 * ALL dialogs must have a title, you probably DO NOT WANT the theme default!
 		 */
-		final WDialog dialogWithTitle = new WDialog(new ViewPersonList(), new WButton(
-				"Show dialog with specified title"));
+		final WDialog dialogWithTitle = new WDialog(new ViewPersonList(), new WButton("Show dialog with specified title"));
 		dialogWithTitle.setTitle("List of people");
 		/*
 		 * NOT RESIZEABLE
@@ -210,8 +210,7 @@ public class WDialogExample extends WPanel implements MessageContainer {
 		 * disabled: you usually don't want to do this as it may cause usability
 		 * problems.
 		 */
-		final WDialog fixedSizeDialog = new WDialog(new ViewPersonList(), new WButton(
-				"Show dialog which is not resizeable"));
+		final WDialog fixedSizeDialog = new WDialog(new ViewPersonList(), new WButton("Show dialog which is not resizeable"));
 		fixedSizeDialog.setResizable(false);
 		/*
 		 * NOT RESIZEABLE with fixed dimensions
@@ -219,8 +218,7 @@ public class WDialogExample extends WPanel implements MessageContainer {
 		 * disabled: you usually don't want to do this as it may cause usability
 		 * problems.
 		 */
-		final WDialog fixedSizeDialog2 = new WDialog(new ViewPersonList(), new WButton(
-				"Show dialog with size but not resizeable"));
+		final WDialog fixedSizeDialog2 = new WDialog(new ViewPersonList(), new WButton("Show dialog with size but not resizeable"));
 		fixedSizeDialog2.setResizable(false);
 		fixedSizeDialog2.setWidth(300);
 		fixedSizeDialog2.setHeight(150);
@@ -229,34 +227,30 @@ public class WDialogExample extends WPanel implements MessageContainer {
 		 * SET THE WIDTH of a dialog
 		 * If not set explicitly, the initial width of a dialog is determined by the UI theme.
 		 */
-		final WDialog dialogWithWidth = new WDialog(new ViewPersonList(), new WButton(
-				"Show dialog with specified width (300px)"));
+		final WDialog dialogWithWidth = new WDialog(new ViewPersonList(), new WButton("Show dialog with specified width (300px)"));
 		dialogWithWidth.setWidth(300);
 		/*
 		 * SET THE HEIGHT of a dialog
 		 * If not set explicitly, the initial width of a dialog is determined by the UI theme.
 		 */
-		final WDialog dialogWithHeight = new WDialog(new ViewPersonList(), new WButton(
-				"Show dialog with specified height (150px)"));
+		final WDialog dialogWithHeight = new WDialog(new ViewPersonList(), new WButton("Show dialog with specified height (150px)"));
 		dialogWithHeight.setHeight(150);
 		/*
 		 * SET THE HEIGHT of a dialog
 		 * If not set explicitly, the initial width of a dialog is determined by the UI theme.
 		 */
-		final WDialog dialogWithHeight2 = new WDialog(new ViewPersonList(), new WButton(
-				"Show enormous dialog"));
-		dialogWithHeight2.setHeight(850);
-		dialogWithHeight2.setWidth(1000);
+		final WDialog dialogWithHeight2 = new WDialog(new WText("1500px x 1000px"), new WButton("Show enormous dialog"));
+		dialogWithHeight2.setHeight(1000);
+		dialogWithHeight2.setWidth(1500);
 		/*
 		 * Make Modal
 		 * If not set explicitly, the initial width of a dialog is determined by the UI theme.
 		 */
-		final WDialog dialogWithMode = new WDialog(new ViewPersonList(), new WButton(
-				"Show dialog with mode set to MODAL"));
+		final WDialog dialogWithMode = new WDialog(new ViewPersonList(), new WButton("Show modal dialog"));
 		dialogWithMode.setMode(WDialog.MODAL);
 
 		// Layout
-		add(new WHeading(WHeading.MAJOR,
+		add(new WHeading(HeadingLevel.H2,
 				"Dialogs which display use of various properties one at a time"));
 		add(dialogWithTitle);
 		add(fixedSizeDialog);
@@ -283,8 +277,7 @@ public class WDialogExample extends WPanel implements MessageContainer {
 		add(modalDialogRT);
 		add(nonModalDialogRT);
 
-		WDialog fileUploadDialog = new WDialog(new WMultiFileWidgetAjaxExample(), new WButton(
-				"Upload"));
+		WDialog fileUploadDialog = new WDialog(new WMultiFileWidgetAjaxExample(), new WButton("Upload"));
 		fileUploadDialog.setMode(WDialog.MODAL);
 		fileUploadDialog.setWidth(600);
 		add(fileUploadDialog);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WSuggestionsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WSuggestionsExample.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.examples;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.WAjaxControl;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WEmailField;
 import com.github.bordertech.wcomponents.WFieldLayout;
@@ -21,33 +22,61 @@ import java.util.List;
 public class WSuggestionsExample extends WContainer {
 
 	/**
+	 * Ajax target.
+	 */
+	private final WTextField resultField = new WTextField();
+
+	/**
 	 * Construct example.
 	 */
 	public WSuggestionsExample() {
 		WFieldLayout layout = new WFieldLayout();
 		layout.setLabelWidth(25);
 
+		resultField.setReadOnly(true);
+
 		add(layout);
 
 		WSuggestions suggestions = new WSuggestions("icao");
 		add(suggestions);
-		WTextField text = new WTextField();
-		text.setSuggestions(suggestions);
-		layout.addField("Cached list", text);
+		final WTextField text1 = new WTextField();
+		text1.setSuggestions(suggestions);
+		text1.setActionOnChange(new Action() {
+			@Override
+			public void execute(final ActionEvent event) {
+				resultField.setText(text1.getValueAsString());
+			}
+		});
+		add(new WAjaxControl(text1, resultField));
+		layout.addField("Cached list", text1);
 
 		// Static suggestions
 		suggestions = new WSuggestions(Arrays.asList("foo1", "foo2", "foo3", "ofoo"));
 		add(suggestions);
-		text = new WTextField();
-		text.setSuggestions(suggestions);
-		layout.addField("Static", text);
+		final WTextField text2 = new WTextField();
+		text2.setSuggestions(suggestions);
+		text2.setActionOnChange(new Action() {
+			@Override
+			public void execute(final ActionEvent event) {
+				resultField.setText(text2.getValueAsString());
+			}
+		});
+		add(new WAjaxControl(text2, resultField));
+		layout.addField("Static", text2);
 
 		// Dynamic suggestions
 		suggestions = new WSuggestions();
 		add(suggestions);
-		text = new WTextField();
-		text.setSuggestions(suggestions);
-		layout.addField("Dynamic", text);
+		final WTextField text3 = new WTextField();
+		text3.setSuggestions(suggestions);
+		text3.setActionOnChange(new Action() {
+			@Override
+			public void execute(final ActionEvent event) {
+				resultField.setText(text3.getValueAsString());
+			}
+		});
+		add(new WAjaxControl(text3, resultField));
+		layout.addField("Dynamic as ajax trigger", text3);
 		suggestions.setRefreshAction(new AjaxAction(""));
 
 		// Dynamic phone number suggestions
@@ -70,10 +99,20 @@ public class WSuggestionsExample extends WContainer {
 		suggestions = new WSuggestions();
 		suggestions.setAutocomplete(WSuggestions.Autocomplete.LIST);
 		add(suggestions);
-		text = new WTextField();
-		text.setSuggestions(suggestions);
-		layout.addField("Force selection from list", text);
+		final WTextField text5 = new WTextField();
+		text5.setSuggestions(suggestions);
+		layout.addField("Force selection from list", text5);
 		suggestions.setRefreshAction(new AjaxAction(""));
+//		text5.setActionOnChange(new Action() {
+//			@Override
+//			public void execute(final ActionEvent event) {
+//				resultField.setText(text5.getValueAsString());
+//			}
+//		});
+//		add(new WAjaxControl(text5, resultField));
+
+
+		layout.addField("Output", resultField);
 	}
 
 	/**

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WSuggestionsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WSuggestionsExample.java
@@ -2,7 +2,6 @@ package com.github.bordertech.wcomponents.examples;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
-import com.github.bordertech.wcomponents.WCheckBox;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WEmailField;
 import com.github.bordertech.wcomponents.WFieldLayout;

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/ajax/AjaxReplaceControllerExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/ajax/AjaxReplaceControllerExample.java
@@ -18,6 +18,7 @@ import com.github.bordertech.wcomponents.WPanel;
 import com.github.bordertech.wcomponents.WRadioButtonSelect;
 import com.github.bordertech.wcomponents.WShuffler;
 import com.github.bordertech.wcomponents.WSingleSelect;
+import com.github.bordertech.wcomponents.WSuggestions;
 import com.github.bordertech.wcomponents.WTextField;
 import java.util.Arrays;
 
@@ -166,6 +167,19 @@ public class AjaxReplaceControllerExample extends WPanel {
 		// the text field really just needs to be read only
 		textField.setReadOnly(true);
 
+		WSuggestions suggestions = new WSuggestions("icao");
+		add(suggestions);
+		final WTextField controller11 = new WTextField();
+		controller11.setSuggestions(suggestions);
+		controller11.setActionOnChange(new Action() {
+			@Override
+			public void execute(final ActionEvent event) {
+				textField.setText("WSuggestions/WTextField: " + controller11.getValueAsString());
+			}
+		});
+		// add the ajax control for the controller
+		add(new WAjaxControl(controller11, textField));
+
 		// the second ajax control is a button
 		ajaxButton.setAction(new Action() {
 			@Override
@@ -177,7 +191,8 @@ public class AjaxReplaceControllerExample extends WPanel {
 		add(new WAjaxControl(ajaxButton,
 				new AjaxTarget[]{controller, controller2, controller3, controller4,
 					controller5, controller6, controller7, controller8,
-					controller9, controller10}));
+					controller9, controller10, controller11}));
+
 
 		// do the layout
 		final WFieldLayout layout = new WFieldLayout();
@@ -192,6 +207,7 @@ public class AjaxReplaceControllerExample extends WPanel {
 		layout.addField("Make a selection", controller8);
 		layout.addField("Enter some text", controller9);
 		layout.addField("Enter a date", controller10);
+		layout.addField("Cached list", controller11);
 		layout.addField("Output", textField);
 		layout.addField((WLabel) null, ajaxButton);
 

--- a/wcomponents-theme/src/main/js/wc/dom/getFilteredGroup.js
+++ b/wcomponents-theme/src/main/js/wc/dom/getFilteredGroup.js
@@ -74,6 +74,7 @@ define(["wc/dom/group", "wc/dom/shed"],
 				filter,
 				ignoreInnerGroups,
 				asObject,
+				shedAttributeOnly = false,
 				mask = getFilteredGroup.FILTERS,
 				filterFunc = function(element) {
 					var _result = true,
@@ -90,7 +91,7 @@ define(["wc/dom/group", "wc/dom/shed"],
 						flags = filter & nextMask;  // extract the relevant flags from the provided filter
 						if (flags && flags !== nextMask) {  // if one flag is set (but not BOTH flags)
 							reverse = !!(flags & negative);  // do we need to reverse the results from SHED?
-							_result = reverse ^ shed[SHED_FILTERS[Math.floor(i / 2)]](element);
+							_result = reverse ^ shed[SHED_FILTERS[Math.floor(i / 2)]](element, shedAttributeOnly);
 						}
 					}
 					return !!_result;  // XOR returns a bitmask not === true
@@ -102,6 +103,7 @@ define(["wc/dom/group", "wc/dom/shed"],
 					asObject = config.asObject;
 					filter = config.filter || mask.selected;
 					ignoreInnerGroups = config.ignoreInnerGroups;
+					shedAttributeOnly = !! config.shedAttributeOnly;
 				}
 				else {
 					filter = mask.selected;
@@ -164,6 +166,8 @@ define(["wc/dom/group", "wc/dom/shed"],
 		 *    {@link module:wc/dom/getFilteredGroup.FILTERS} If not provided the mask will default to "selected". Note
 		 *    that setting BOTH flags for a given property (e.g. hidden + visible) is the same as setting NEITHER of the
 		 *    flags so don't bother.
+		 * @property {boolean} shedAttributeOnly If true use only the simple attribute test in shedFilters (at present
+		 *    this applies only to isHidden).
 		 */
 
 		/**

--- a/wcomponents-theme/src/main/js/wc/ui/comboBox.js
+++ b/wcomponents-theme/src/main/js/wc/ui/comboBox.js
@@ -132,7 +132,7 @@ define(["wc/has",
 			 */
 			function clearList(combo) {
 				var listbox = getListBox(combo), options;
-				if (listbox && (options = getFilteredGroup(listbox))) {
+				if (listbox && (options = getFilteredGroup(listbox, {containerWd: LISTBOX, itemWd: OPTION, shedAttributeOnly: true}))) {
 					options.forEach(function(next) {
 						shed.deselect(next, true);  // do not publish they are already hidden and are not important for anything else.
 						next.tabIndex = 0;
@@ -318,6 +318,10 @@ define(["wc/has",
 				}
 			}
 
+			function getAvailableOptions(listbox) {
+				return getFilteredGroup(listbox, {filter: (getFilteredGroup.FILTERS.visible|getFilteredGroup.FILTERS.enabled), containerWd: LISTBOX, itemWd: OPTION, shedAttributeOnly: true});
+			}
+
 			/**
 			 * Given an option in a listbox and a printable character, find the next option (if any) which starts
 			 * with that character.
@@ -332,7 +336,7 @@ define(["wc/has",
 			 * @returns {Element} The next available option which starts with keyName (if any), or undefined.
 			 */
 			function getTextTarget(listbox, start, keyName) {
-				var options = getFilteredGroup(listbox),
+				var options = getAvailableOptions(listbox),
 					result,
 					startIdx = options.indexOf(start), i, next, txt;
 
@@ -810,7 +814,7 @@ define(["wc/has",
 					return;
 				}
 
-				candidates = getFilteredGroup(listbox, {filter: getFilteredGroup.FILTERS.visible, containerWd: LISTBOX, itemWd: OPTION});
+				candidates = getAvailableOptions(listbox);
 
 				if (candidates && candidates.length) {
 					if (candidates.some(function (next) {

--- a/wcomponents-theme/src/main/js/wc/ui/dialog.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dialog.js
@@ -219,17 +219,24 @@ define(["wc/dom/classList",
 			}
 
 			function saveDialogDimensions(element, regObj) {
+				var unitless;
 				if (element.style.width) {
 					regObj["width"] = element.style.width.replace(UNIT, "");
 				}
 				if (element.style.height) {
 					regObj["height"] = element.style.height.replace(UNIT, "");
 				}
-				if (element.style.left) {
-					regObj["left"] = element.style.left.replace(UNIT, "");
+				if ((unitless = element.style.left)) {
+					unitless = Math.round(parseFloat(unitless));
+					if (unitless >= 0 ) {
+						regObj["left"] = unitless;
+					}
 				}
-				if (element.style.top) {
-					regObj["top"] = element.style.top.replace(UNIT, "");
+				if ((unitless = element.style.top)) {
+					unitless = Math.round(parseFloat(unitless));
+					if (unitless >= 0 ) {
+						regObj["top"] = unitless;
+					}
 				}
 			}
 

--- a/wcomponents-theme/src/main/js/wc/ui/dialogFrame.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dialogFrame.js
@@ -28,8 +28,8 @@
  * @requires module:wc/ui/positionable
  * @requires module:wc/ui/draggable
  * @requires module:wc/dom/role
- * @requires module:wc/dom/getViewportSize
  * @requires external:Moustache
+ * @requires module:wc/ui/viewportUtils
  */
 
 define(["wc/dom/event",
@@ -49,11 +49,14 @@ define(["wc/dom/event",
 		"wc/ui/positionable",
 		"wc/ui/draggable",
 		"wc/dom/role",
-		"wc/dom/getViewportSize",
-		"Mustache"],
-	/** @param event @param focus @param initialise @param shed @param tag @param uid @param Widget @param i18n @param loader @param processResponse @param modalShim @param timers @param has @param resizeable @param positionable @param draggable @param $role @param getViewportSize @param Mustache @ignore */
+		"Mustache",
+		"wc/ui/viewportUtils"],
+	/** @param event @param focus @param initialise @param shed @param tag @param uid @param Widget @param i18n
+	 * @param loader @param processResponse @param modalShim @param timers @param has @param resizeable
+	 * @param positionable @param draggable @param $role @param Mustache @param viewportUtils
+	 * @ignore */
 	function(event, focus, initialise, shed, tag, uid, Widget, i18n, loader, processResponse,
-		modalShim, timers, has, resizeable, positionable, draggable, $role, getViewportSize, Mustache) {
+		modalShim, timers, has, resizeable, positionable, draggable, $role, Mustache, viewportUtils) {
 		"use strict";
 
 		/**
@@ -88,9 +91,7 @@ define(["wc/dom/event",
 					NO_FORM: "Cannot find a form to which to attach the dialog",
 					UNKNOWN: "Failed to open dialog: readon unknown"
 				},
-				resizeTimeout,
-				/** The pixel cpount at which we make all dialog frames "full screen" */
-				FULL_SCREEN_POINT = 1000;
+				resizeTimeout;
 
 			TITLE_WD.descendFrom(HEADER_WD);
 			DIALOG_CONTENT_WRAPPER.descendFrom(DIALOG, true);
@@ -119,7 +120,7 @@ define(["wc/dom/event",
 			 * @returns {Boolean} true is move/resize are supportable.
 			 */
 			function canMoveResize() {
-				return getViewportSize().width > FULL_SCREEN_POINT;
+				return !viewportUtils.isSmallScreen();
 			}
 
 			/**
@@ -325,10 +326,8 @@ define(["wc/dom/event",
 				var control;
 
 				setUpMoveResizeControls(dialog);
-				if ((control = MAX_BUTTON.findDescendant(dialog)) && !shed.isHidden(control)) {
-					if (obj.max) {
-						shed.select(control);
-					}
+				if (obj.max && (control = MAX_BUTTON.findDescendant(dialog))) {
+					shed.select(control);
 				}
 			}
 
@@ -391,7 +390,7 @@ define(["wc/dom/event",
 				try {
 					if (obj) {
 						// set the initial position. If the position (top, left) is set in the config object we do not need to calculate position.
-						if (!(obj.top || obj.left || obj.top === 0 || obj.left === 0)) {
+						if (!((obj.top || obj.top === 0) && (obj.left || obj.left === 0))) {
 							if (canMoveResize()) {
 								resizeable.disableAnimation(dialog);
 								disabledAnimations = true;

--- a/wcomponents-theme/src/main/js/wc/ui/menu/bar.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/bar.js
@@ -1,28 +1,3 @@
-/**
- * Menu controller extension for WMenu of type BAR and type FLYOUT. These are menus which are horizontal at the top
- * level and if they have submenus they are transient fly-out artifacts.
- *
- * @see {@link http://www.w3.org/TR/wai-aria-practices/#menu}
- *
- * @module
- * @extends module:wc/ui/menu/core
- *
- * @requires module:wc/ui/menu/core
- * @requires module:wc/array/toArray
- * @requires module:wc/dom/event
- * @requires module:wc/dom/keyWalker
- * @requires module:wc/dom/shed
- * @requires module:wc/dom/Widget
- * @requires module:wc/dom/initialise
- * @requires module:wc/dom/uid
- * @requires module:wc/dom/getViewportSize
- * @requires module:wc/i18n/i18n
- * @requires module:wc/dom/classList
- * @requires module:wc/timers
- * @requires module:wc/loader/resource
- * @requires module:wc/ui/ajax/processResponse
- * @requires module:wc/ui/menu/menuItem
- */
 define(["wc/ui/menu/core",
 	"wc/array/toArray",
 	"wc/dom/event" ,
@@ -31,16 +6,18 @@ define(["wc/ui/menu/core",
 	"wc/dom/Widget",
 	"wc/dom/initialise",
 	"wc/dom/uid",
-	"wc/dom/getViewportSize",
 	"wc/i18n/i18n",
 	"wc/dom/classList",
 	"wc/timers",
 	"wc/ui/ajax/processResponse",
 	"wc/loader/resource",
 	"Mustache",
+	"wc/ui/viewportUtils",
 	"wc/ui/menu/menuItem"],
-	/** @param abstractMenu @param toArray @param event @param keyWalker @param shed @param Widget @param initialise @param uid @param getViewportSize @param i18n@param classList @param timers @param processResponse @param loader @param Mustache @ignore */
-	function(abstractMenu, toArray, event, keyWalker, shed, Widget, initialise, uid, getViewportSize, i18n, classList, timers, processResponse, loader, Mustache) {
+	/** @param abstractMenu @param toArray @param event @param keyWalker @param shed @param Widget @param initialise
+	 * @param uid @param i18n@param classList @param timers @param processResponse @param loader @param Mustache
+	 * @param viewportUtils @ignore */
+	function(abstractMenu, toArray, event, keyWalker, shed, Widget, initialise, uid, i18n, classList, timers, processResponse, loader, Mustache, viewportUtils) {
 		"use strict";
 
 		/* Unused dependencies:
@@ -63,8 +40,7 @@ define(["wc/ui/menu/core",
 				submenuTemplate,
 				closeButtonTemplate,
 				DECORATED_LABEL,
-				RESPONSIVE_MENU,
-				HAMBURGER_TOGGLE_POINT = 773; // from Sass see mixin respond-phone-like
+				RESPONSIVE_MENU;
 
 			/**
 			 * The descriptors for this menu type.
@@ -385,8 +361,7 @@ define(["wc/ui/menu/core",
 			 * @param {Element} el The element which may be a menu, submenu or something containing a menu.
 			 */
 			function toggleIconMenus(el) {
-				var candidates, element = el || document.body,
-					vps;
+				var candidates, element = el || document.body;
 				if (instance.isSubMenu(element)) {
 					return;
 				}
@@ -407,8 +382,8 @@ define(["wc/ui/menu/core",
 					return next.childNodes.length > 1;
 				});
 
-				if (candidates.length && (vps = getViewportSize())) {
-					if (vps.width <= HAMBURGER_TOGGLE_POINT) {
+				if (candidates.length) {
+					if (viewportUtils.isPhoneLike()) {
 						candidates.forEach(makeIconified);
 					}
 					else {
@@ -426,7 +401,32 @@ define(["wc/ui/menu/core",
 			};
 		}
 
-		var /** @alias module:wc/ui/menu/bar */ instance;
+		/**
+		 * Menu controller extension for WMenu of type BAR and type FLYOUT. These are menus which are horizontal at the top
+		 * level and if they have submenus they are transient fly-out artifacts.
+		 *
+		 * @see {@link http://www.w3.org/TR/wai-aria-practices/#menu}
+		 *
+		 * @module
+		 * @extends module:wc/ui/menu/core
+		 *
+		 * @requires module:wc/ui/menu/core
+		 * @requires module:wc/array/toArray
+		 * @requires module:wc/dom/event
+		 * @requires module:wc/dom/keyWalker
+		 * @requires module:wc/dom/shed
+		 * @requires module:wc/dom/Widget
+		 * @requires module:wc/dom/initialise
+		 * @requires module:wc/dom/uid
+		 * @requires module:wc/i18n/i18n
+		 * @requires module:wc/dom/classList
+		 * @requires module:wc/timers
+		 * @requires module:wc/ui/ajax/processResponse
+		 * @requires module:wc/loader/resource
+		 * @requires:external:Mustache
+		 * @requires module:wc/ui/viewportUtils
+		 */
+		var instance;
 		Menubar.prototype = abstractMenu;
 		instance = new Menubar();
 		instance.constructor = Menubar;

--- a/wcomponents-theme/src/main/js/wc/ui/menu/core.js
+++ b/wcomponents-theme/src/main/js/wc/ui/menu/core.js
@@ -10,7 +10,6 @@
  * @requires module:wc/dom/focus
  * @requires module:wc/dom/formUpdateManager
  * @requires module:wc/dom/getFilteredGroup
- * @requires module:wc/dom/getViewportSize
  * @requires module:wc/dom/keyWalker
  * @requires module:wc/dom/shed
  * @requires module:wc/dom/viewportCollision
@@ -21,6 +20,7 @@
  * @requires module:wc/i18n/i18n
  * @requires module:wc/dom/getBox
  * @requires module:wc/array/toArray
+ * @requires module:wc/ui/viewportUtils
  *
  * @see {@link module:wc/ui/menu/bar}
  * @see {@link module:wc/ui/menu/column}
@@ -32,7 +32,6 @@ define(["wc/dom/attribute",
 		"wc/dom/focus",
 		"wc/dom/formUpdateManager",
 		"wc/dom/getFilteredGroup",
-		"wc/dom/getViewportSize",
 		"wc/dom/keyWalker",
 		"wc/dom/shed",
 		"wc/dom/viewportCollision",
@@ -42,10 +41,14 @@ define(["wc/dom/attribute",
 		"wc/timers",
 		"wc/i18n/i18n",
 		"wc/dom/getBox",
-		"wc/array/toArray"
+		"wc/array/toArray",
+		"wc/ui/viewportUtils"
 	],
-	/** @param attribute @param classList @param event @param focus @param formUpdateManager @param getFilteredGroup @param getViewportSize @param keyWalker @param shed @param viewportCollision @param Widget @param key @param processResponse @param timers @param i18n @param getBox @param toArray @ignore */
-	function(attribute, classList, event, focus, formUpdateManager, getFilteredGroup, getViewportSize, keyWalker, shed, viewportCollision, Widget, key, processResponse, timers, i18n, getBox, toArray) {
+	/** @param attribute @param classList @param event @param focus @param formUpdateManager @param getFilteredGroup
+	 * @param keyWalker @param shed @param viewportCollision @param Widget @param key
+	 * @param processResponse @param timers @param i18n @param getBox @param toArray @param viewportUtils @ignore */
+	function(attribute, classList, event, focus, formUpdateManager, getFilteredGroup, keyWalker, shed,
+		viewportCollision, Widget, key, processResponse, timers, i18n, getBox, toArray, viewportUtils) {
 		"use strict";
 
 		/* NOTE: Many functions in this module are private but accept an instance of a subclass as an argument. These
@@ -104,8 +107,7 @@ define(["wc/dom/attribute",
 				KeyEvent.DOM_VK_DOWN,
 				KeyEvent.DOM_VK_LEFT,
 				KeyEvent.DOM_VK_RIGHT
-			],
-			FULL_SCREEN_TOGGLE_POINT = 773;
+			];
 
 		/**
 		 * Sets up {@link module:wc/dom/Widget} descriptors for parts of a menu which do not vary between subclasses.
@@ -227,11 +229,6 @@ define(["wc/dom/attribute",
 			return result;
 		}
 
-		function canActivateOnHover() {
-			var vps = getViewportSize();
-			return !(vps && vps.width <= FULL_SCREEN_TOGGLE_POINT);
-		}
-
 		/**
 		 * Mouse over handler. Sets up hover effects when the menu is transoent and not displayed on a mobile device.
 		 * This handler is only bound if required when a menu first receives focus and is bound directly to the menu
@@ -259,7 +256,7 @@ define(["wc/dom/attribute",
 				}
 
 				this._focusItem(item, root);
-				if (activateOnHover === root.id && canActivateOnHover()) {
+				if (activateOnHover === root.id && viewportUtils.isPhoneLike()) {
 					// current menu is active menu
 					if (this._isOpener(item)) {
 						item = this._getBranch(item);

--- a/wcomponents-theme/src/main/js/wc/ui/tabset.js
+++ b/wcomponents-theme/src/main/js/wc/ui/tabset.js
@@ -13,7 +13,7 @@
  * @requires module:wc/ajax/setLoading
  * @requires module:wc/dom/focus
  * @requires module:wc/dom/classList
- * @requires module:wc/dom/getViewportSize
+ * @requires module:wc/ui/viewportUtils
  * @requires module:wc/ui/ajax/processResponse
  * @requires module:wc/dom/event
  * @requires module:wc/timers
@@ -30,12 +30,12 @@ define(["wc/array/toArray",
 	"wc/ajax/setLoading",
 	"wc/dom/focus",
 	"wc/dom/classList",
-	"wc/dom/getViewportSize",
+	"wc/ui/viewportUtils",
 	"wc/ui/ajax/processResponse",
 	"wc/dom/event",
 	"wc/timers"],
 	function(toArray, ariaAnalog, formUpdateManager, getFilteredGroup, initialise, shed, Widget, containerload,
-		setLoading, focus, classList, getViewportSize, processResponse, event, timers) {
+		setLoading, focus, classList, viewportUtils, processResponse, event, timers) {
 		"use strict";
 
 		/**
@@ -78,8 +78,6 @@ define(["wc/array/toArray",
 				 * @private
 				 */
 				lastTabId,
-
-				TOGGLE_POINT = 1001, // from Sass see mixin respond-not-small
 				CONVERTED = "data-wc-converted",
 				MULTISELECT = "aria-multiselectable",
 				TRUE = "true",
@@ -729,8 +727,7 @@ define(["wc/array/toArray",
 			 */
 			function toggleToFromAccordions(container) {
 				var candidates,
-					element = container || document.body,
-					vps;
+					element = container || document.body;
 
 				if (TABSET.isOneOfMe(element)) {
 					candidates = [element];
@@ -743,13 +740,11 @@ define(["wc/array/toArray",
 					return;
 				}
 
-				if ((vps = getViewportSize())) {
-					if (vps.width < TOGGLE_POINT) {
-						candidates.forEach(tabsetToAccordion);
-					}
-					else {
-						candidates.forEach(AccordionToTabset);
-					}
+				if (viewportUtils.isSmallScreen()) {
+					candidates.forEach(tabsetToAccordion);
+				}
+				else {
+					candidates.forEach(AccordionToTabset);
 				}
 			}
 

--- a/wcomponents-theme/src/main/js/wc/ui/viewportUtils.js
+++ b/wcomponents-theme/src/main/js/wc/ui/viewportUtils.js
@@ -1,0 +1,153 @@
+define(["wc/dom/getViewportSize", "wc/config"], function (getViewportSize, wcconfig) {
+	"use strict";
+
+	/**
+	 * Create a viewport utils singleton.
+	 * @constructor
+	 * @private
+	 * @alias module:wc/ui/viewportUtils~VpUtils
+	 */
+	function VpUtils() {
+
+		var conf = wcconfig.get("wc/ui/viewportUtils"),
+			// For device limits in Sass see _common.scss.
+			// The size of the largest device considered a phone: currently 773px of a Nexus 6.
+			phoneLimit = 773,
+			// What is the upper limit of a small screen? This could be the 768 of a iPad in portrait orientation,
+			// the 1024 of an old-school monitor or an iPad in landscape orientation or something aribrary. The default
+			// 1000 was chosen as we find some things are quite usable on a tablet in landscape but are less usable in
+			// portrait. We prefer to use min/max-width as a media query rather than orientation for a variety of
+			// reasons.
+			smallScreenLimit = 1000,
+			// A large screen is bigger than 1080p.
+			largeScreenLimit = 1981,
+			medDefinition = 1.5,
+			highDefinition = 2,
+			pixelRatio = window.devicePixelRation || 1;
+
+		if (conf) {
+			phoneLimit = conf.phone || phoneLimit;
+			smallScreenLimit = conf.small || smallScreenLimit;
+			largeScreenLimit = conf.large || largeScreenLimit;
+		}
+
+		/**
+		 * Determine if the current viewport is smaller or larger than a given limit.
+		 *
+		 * @function
+		 * @private
+		 * @param {int} limit The limit to test
+		 * @param {boolean} [gtr] if true then we want to know if the viewport is at least as big as limit, otherwise
+		 *   is the viewport no bigger than limit
+		 * @returns {Boolean} true if the viewport is no bigger than limit (or at least as big as limit if gtr is true).
+		 */
+		function testViewportSize(limit, gtr) {
+			var vps = getViewportSize();
+			if (vps) {
+				if (gtr) {
+					return vps.width >= limit;
+				}
+				return vps.width <= limit;
+			}
+			return false;
+		}
+
+		/**
+		 * Is the width of the current viewport similar to that of a mobile phone?
+		 *
+		 * @function
+		 * @public
+		 * @alias module:wc/ui/viewportUtils.isPhoneLike
+		 * @returns {Boolean} true if the viewport width is no bigger than the configured limit for a phone.
+		 */
+		this.isPhoneLike = function() {
+			return testViewportSize(phoneLimit);
+		};
+
+
+		/**
+		 * Is the width of the current viewport "small"?
+		 *
+		 * @function
+		 * @public
+		 * @alias module:wc/ui/viewportUtils.isSmallScreen
+		 * @returns {Boolean} true if the viewport width is no bigger than the configured limit for a small screen.
+		 */
+		this.isSmallScreen = function() {
+			return testViewportSize(smallScreenLimit);
+		};
+
+
+		/**
+		 * Is the width of the current viewport at least that of a large monitor?
+		 *
+		 * @function
+		 * @public
+		 * @alias module:wc/ui/viewportUtils.isLargeScreen
+		 * @returns {Boolean} true if the viewport width is at least that of the configured limit for a big screen.
+		 */
+		this.isLargeScreen = function() {
+			return testViewportSize(largeScreenLimit, true);
+		};
+
+		/**
+		 * Is the current screen a high definition screen?
+		 *
+		 * @function
+		 * @public
+		 * @alias module:wc/ui/viewportUtils.isHighDef
+		 * @returns {Boolean} true if the current screen device is a high definition screen.
+		 */
+		this.isHighDef = function () {
+			return pixelRatio >= highDefinition;
+		};
+
+		/**
+		 * Is the current screen a moderate definition screen? For example Samsung Galaxy 5, 6.
+		 *
+		 * @function
+		 * @public
+		 * @alias module:wc/ui/viewportUtils.isModerateDefinition
+		 * @returns {Boolean} true if the current screen device is a medium definition screen.
+		 */
+		this.isModerateDefinition = function () {
+			return pixelRatio >= medDefinition && pixelRatio < highDefinition;
+		};
+
+		/**
+		 * Is the current screen definition medium def or better?
+		 *
+		 * @function
+		 * @public
+		 * @alias module:wc/ui/viewportUtils.isHigherDefinition
+		 * @returns {Boolean} true if the current screen device is a medium definition screen or better.
+		 */
+		this.isHigherDefinition = function () {
+			return pixelRatio >= medDefinition;
+		};
+
+		/**
+		 * Is the current screen definition "normal" i.e. 1 or not able to be determined.
+		 *
+		 * @function
+		 * @public
+		 * @alias module:wc/ui/viewportUtils.isStandardDefinition
+		 * @returns {Boolean} true if the current screen device is standard definition.
+		 */
+		this.isStandardDefinition = function () {
+			return !pixelRatio || pixelRatio === 1;
+		};
+	}
+
+	/**
+	 * Provides utility methods regarding the current state of the viewport for use in synchronising responsive UI
+	 * manipulation with CSS media queries.
+	 *
+	 * @module wc/ui/viewportUtils
+	 * @requires module:wc/dom/getViewportSize
+	 * @requires module:wc/config
+	 */
+	return new VpUtils();
+});
+
+

--- a/wcomponents-theme/src/main/sass/_mixins-respond.scss
+++ b/wcomponents-theme/src/main/sass/_mixins-respond.scss
@@ -1,15 +1,7 @@
 // Skeleton responsive design mixin. Gives what we need by default but feel free to add to it with other responsive
 // design mixins as required.
 
-//how big is a small screen?
-$wc-small-screen: 1000px !default;
-//and a common/medium screen?
-$wc-medium-screen: 1280px !default;
-//how about a BIG screen?
-$wc-large-screen: 1921px !default;//bigger than 1080p
-
-// guess what this is for!
-$wc-bigger-than-small-screen: $wc-small-screen + 1px;
+// NOTE: If you change any of these take a look at the configuration of wc/ui/viewportUtils.
 
 @mixin respond-phonelike {
 	@media only screen and (max-width : 773px) {
@@ -40,12 +32,6 @@ $wc-bigger-than-small-screen: $wc-small-screen + 1px;
 		@content;
 	}
 }
-
-// TODO Do we want to add some pixel density tests for phones/tablets?
-// (-webkit-min-device-pixel-ratio: 2), /* Webkit-based browsers */
-// (min--moz-device-pixel-ratio: 2),    /* Older Firefox browsers (prior to Firefox 16) */
-// (min-resolution: 2dppx),             /* The standard way */
-// (min-resolution: 192dpi)             /* dppx fallback */
 
 @mixin respond-medium-density {
 	@media only screen and (-webkit-min-device-pixel-ratio: 1.5),


### PR DESCRIPTION
* Updated dialogFrame.js to fix positioning bug. Found another issue in `wc/ui/dialog` which could result in an incorrect position being preserved between opening (negative left or top). Updated example to test fix. Fixes #805.
* Resize event driven UI manipulation saw a scattering of toggle points so I created a utility module to manage them all. Should be easier to keep in sync with the Sass this way.