### PR TITLE
Handlebars form processing

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/loading.js
+++ b/wcomponents-theme/src/main/js/wc/ui/loading.js
@@ -36,13 +36,12 @@ define(["wc/dom/initialise", "wc/ui/modalShim", "wc/timers"],
 		 * @private
 		 */
 		function clearLoadingShim() {
+			var container;
 			try {
 				Array.prototype.forEach.call(document.getElementsByTagName("form"), function(form) {
-					form.style.visibility ="";
-					form.removeAttribute("style");
-					form.removeAttribute("aria-busy");
+					form.removeAttribute("hidden");
 				});
-				var container = document.getElementById("wc-ui-loading");
+				container = document.getElementById("wc-ui-loading");
 				if (container && container.parentNode) {
 					container.parentNode.removeChild(container);
 				}

--- a/wcomponents-theme/src/main/xslt/wc.ui.application.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.application.xsl
@@ -13,7 +13,7 @@
 		<xsl:variable name="baseAjaxUrl">
 			<xsl:value-of select="@ajaxUrl"/>
 		</xsl:variable>
-		<form action="{@applicationUrl}" method="POST" id="{@id}" data-wc-datalisturl="{$baseAjaxUrl}" novalidate="novalidate" style="visibility:hidden" aria-busy="true">
+		<form action="{@applicationUrl}" method="POST" id="{@id}" data-wc-datalisturl="{$baseAjaxUrl}" novalidate="novalidate" hidden="hidden">
 			<xsl:attribute name="data-wc-ajaxurl">
 				<xsl:value-of select="$baseAjaxUrl"/>
 				<xsl:if test="ui:param">


### PR DESCRIPTION
Changed the way unprocessed forms are hidden from setting visibility to
setting hidden.

Using hidden reduces reflow overhead in all modern browsers whereas
setting visibility still reserves space for the elements and therefore
may have reflow implications.

It is safe to use hidden because this is used _only_ on page load and
there is nothing to flow yet.