### PR TITLE
Tab element XSLT

### DIFF
--- a/wcomponents-theme/src/main/xslt/wc.ui.tab.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.tab.xsl
@@ -88,7 +88,7 @@
 
 			<xsl:call-template name="accessKey"/>
 			<xsl:apply-templates select="ui:decoratedlabel">
-				<xsl:with-param name="output" select="'span'"/>
+				<xsl:with-param name="output" select="'div'"/>
 			</xsl:apply-templates>
 		</div>
 		<xsl:if test="$type='accordion'">


### PR DESCRIPTION
Fixed a bug in WTab in which the tab label was not transformed to the
correct element.