### PR TITLE
Common color classes

### DIFF
--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WStyledTextFontAwesomeExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WStyledTextFontAwesomeExample.java
@@ -9,6 +9,7 @@ import com.github.bordertech.wcomponents.WTemplate;
 import com.github.bordertech.wcomponents.WText;
 import com.github.bordertech.wcomponents.layout.FlowLayout;
 import com.github.bordertech.wcomponents.template.TemplateRendererFactory;
+import com.github.bordertech.wcomponents.util.HtmlClassProperties;
 
 /**
  * An example showing how to use {@link WStyledText} to create icons using
@@ -124,5 +125,20 @@ public class WStyledTextFontAwesomeExample extends WPanel {
 		text = new WStyledText(" ");
 		text.setHtmlClass("fa fa-ban fa-stack-2x text-ban");
 		template.addTaggedComponent("upper", text);
+
+		add(new WHeading(HeadingLevel.H2, "Coloured icons"));
+		text = new WStyledText("Information");
+		text.setHtmlClass(HtmlClassProperties.ICON_INFO_BEFORE.toString() + " wc-cinfo");
+		add(text);
+		text = new WStyledText("Success");
+		text.setHtmlClass(HtmlClassProperties.ICON_SUCCESS_BEFORE.toString() + " wc-csuccess");
+		add(text);
+		text = new WStyledText("Warning");
+		text.setHtmlClass(HtmlClassProperties.ICON_WARN_BEFORE.toString() + " wc-cwarning");
+		add(text);
+		text = new WStyledText("Error");
+		text.setHtmlClass(HtmlClassProperties.ICON_ERROR_BEFORE.toString() + " wc-cerror");
+		add(text);
+
 	}
 }

--- a/wcomponents-theme/src/main/sass/wc.common.color.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.color.scss
@@ -1,0 +1,21 @@
+/* wc.common.color.scss */
+// These are colour classes. Colour classes are _very_ dangerous. Therefore we do not
+// supply any which act on actual elements. These colours will, therefore only act on the
+// pseudo element used to generate an icon. Extend these as you feel fit.
+@import 'mixins-common';
+
+.wc-cerror::before {
+	color: $wc-ui-color-error-fg;
+}
+
+.wc-cwarning::before {
+	color: $wc-ui-color-warning-fg;
+}
+
+.wc-cinfo::before {
+	color: $wc-ui-color-info-fg;
+}
+
+.wc-csuccess::before {
+	color: $wc-ui-color-success-fg;
+}


### PR DESCRIPTION
We have had a few requests to expose theme colours as part of the CSS
API. I am somewhat loathe to do this as it may undermine efforts to
manage consistent branding and accessibility. As a
meet-somewhere-my-side-of-the-middle compromise I have created classes
which may be used to set colours in a theme by extension and which, by
default, colour the :before pseudo element to allow for simple coloured
icons.

These classes reflect the message states:
* `wc-csuccess`
* `wc-cinfo`
* `wc-cwarning`
* `wc-cerror`