### PR TITLE
Multiple HTML Classes 856

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 ## API Changes
 
 ## Bug Fixes
-* Fixed bug in XSLT of inline errors #847
-* Fixed bug in i18n of timeout warnings #846
-
+* Fixed a bug which prevented `WField`'s `inputWidth` setting from rendering correctly #854.
+* Fixed a bug in rendering of `WPartialDateField` and polyfilled `WDateField` #852.
 
 ## Enhancements
+* Added a mechanism to add and remove multiple HTML class attribute values to a component #856.
+
+# Release 1.2.4
+## Bug Fixes
+* Fixed bug in XSLT of inline errors #847
+* Fixed bug in i18n of timeout warnings #846
 
 # Release 1.2.3
 ## API Changes

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWComponent.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWComponent.java
@@ -19,9 +19,9 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.logging.Log;
@@ -1695,9 +1695,9 @@ public abstract class AbstractWComponent implements WComponent {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public HashSet getHtmlClassList() {
+	public Set getHtmlClasses() {
 		ComponentModel model = getComponentModel();
-		return model.getHtmlClassList();
+		return model.getHtmlClasses();
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWComponent.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWComponent.java
@@ -19,6 +19,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -1650,8 +1651,7 @@ public abstract class AbstractWComponent implements WComponent {
 	 */
 	@Override
 	public void setHtmlClass(final String text) {
-		ComponentModel model = getOrCreateComponentModel();
-		model.setHtmlClass(text);
+		getOrCreateComponentModel().setHtmlClass(text);
 	}
 
 	/**
@@ -1659,26 +1659,16 @@ public abstract class AbstractWComponent implements WComponent {
 	 */
 	@Override
 	public void setHtmlClass(final HtmlClassProperties className) {
-		ComponentModel model = getOrCreateComponentModel();
-		model.setHtmlClass(className);
+		getOrCreateComponentModel().setHtmlClass(className);
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void appendHtmlClass(final String className) {
-		if (Util.empty(className)) {
-			return;
-		}
-		String htmlClass = getHtmlClass();
-		if (null == htmlClass) {
-			setHtmlClass(className);
-		} else {
-			StringBuilder newHtmlClass = new StringBuilder(htmlClass);
-			newHtmlClass.append(" ");
-			newHtmlClass.append(className);
-			setHtmlClass(newHtmlClass.toString());
+	public void addHtmlClass(final String className) {
+		if (!Util.empty(className)) {
+			getOrCreateComponentModel().addHtmlClass(className);
 		}
 	}
 
@@ -1686,15 +1676,9 @@ public abstract class AbstractWComponent implements WComponent {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void appendHtmlClass(final HtmlClassProperties className) {
-		String htmlClass = getHtmlClass();
-		if (null == htmlClass) {
-			setHtmlClass(className);
-		} else {
-			StringBuilder newHtmlClass = new StringBuilder(htmlClass);
-			newHtmlClass.append(" ");
-			newHtmlClass.append(className.toString());
-			setHtmlClass(newHtmlClass.toString());
+	public void addHtmlClass(final HtmlClassProperties className) {
+		if (null != className) {
+			getOrCreateComponentModel().addHtmlClass(className);
 		}
 	}
 
@@ -1705,6 +1689,31 @@ public abstract class AbstractWComponent implements WComponent {
 	public String getHtmlClass() {
 		ComponentModel model = getComponentModel();
 		return I18nUtilities.format(null, model.getHtmlClass());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public HashSet getHtmlClassList() {
+		ComponentModel model = getComponentModel();
+		return model.getHtmlClassList();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void removeHtmlClass(final String className) {
+		getOrCreateComponentModel().removeHtmlClass(className);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void removeHtmlClass(final HtmlClassProperties className) {
+		getOrCreateComponentModel().removeHtmlClass(className);
 	}
 
 	// ================================

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/ComponentModel.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/ComponentModel.java
@@ -182,7 +182,7 @@ public class ComponentModel implements WebModel, Externalizable {
 	/**
 	 * Adds extra value to the HTML class of the output component.
 	 */
-	private HashSet<String> htmlClassList;
+	private Set<String> htmlClasses;
 
 	/**
 	 * General placeholder for subclasses of WComponent to place model attributes. This is mostly for convenience so
@@ -542,13 +542,13 @@ public class ComponentModel implements WebModel, Externalizable {
 	 * @return the HTML class list as a single space separated String.
 	 */
 	protected Serializable getHtmlClass() {
-		if (this.htmlClassList == null || this.htmlClassList.isEmpty()) {
+		if (this.htmlClasses == null || this.htmlClasses.isEmpty()) {
 			return null;
 		}
 		int i = 0;
 		StringBuilder result = new StringBuilder();
 
-		for (String c : this.htmlClassList) {
+		for (String c : this.htmlClasses) {
 			if (i++ > 0) {
 				result.append(" ");
 			}
@@ -562,10 +562,10 @@ public class ComponentModel implements WebModel, Externalizable {
 	 */
 	protected void setHtmlClass(final String text) {
 		if (text == null) {
-			this.htmlClassList = null;
+			this.htmlClasses = null;
 		} else {
-			this.htmlClassList = new HashSet<>();
-			this.htmlClassList.add(text);
+			this.htmlClasses = new HashSet<>();
+			this.htmlClasses.add(text);
 		}
 	}
 
@@ -574,7 +574,7 @@ public class ComponentModel implements WebModel, Externalizable {
 	 */
 	protected void setHtmlClass(final HtmlClassProperties className) {
 		if (null == className) {
-			this.htmlClassList = null;
+			this.htmlClasses = null;
 		} else {
 			setHtmlClass(className.toString());
 		}
@@ -585,10 +585,10 @@ public class ComponentModel implements WebModel, Externalizable {
 	 */
 	protected void addHtmlClass(final String text) {
 		if (!Util.empty(text)) {
-			if (this.htmlClassList == null) {
-				this.htmlClassList = new HashSet<>();
+			if (this.htmlClasses == null) {
+				this.htmlClasses = new HashSet<>();
 			}
-			this.htmlClassList.add(text);
+			this.htmlClasses.add(text);
 		}
 	}
 
@@ -604,8 +604,8 @@ public class ComponentModel implements WebModel, Externalizable {
 	/**
 	 * @return the set of HTML classes to add to the current component.
 	 */
-	protected HashSet getHtmlClassList() {
-		return this.htmlClassList;
+	protected Set getHtmlClasses() {
+		return this.htmlClasses;
 	}
 
 	/**
@@ -613,8 +613,8 @@ public class ComponentModel implements WebModel, Externalizable {
 	 * @param className the value to remove
 	 */
 	protected void removeHtmlClass(final String className) {
-		if (!(this.htmlClassList == null || Util.empty(className))) {
-			this.htmlClassList.remove(className);
+		if (this.htmlClasses != null && !Util.empty(className)) {
+			this.htmlClasses.remove(className);
 		}
 	}
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/ComponentModel.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/ComponentModel.java
@@ -182,7 +182,7 @@ public class ComponentModel implements WebModel, Externalizable {
 	/**
 	 * Adds extra value to the HTML class of the output component.
 	 */
-	private Serializable htmlClass;
+	private HashSet<String> htmlClassList;
 
 	/**
 	 * General placeholder for subclasses of WComponent to place model attributes. This is mostly for convenience so
@@ -537,25 +537,95 @@ public class ComponentModel implements WebModel, Externalizable {
 		this.accessibleText = I18nUtilities.asMessage(text, args);
 	}
 
+
 	/**
-	 * @return Returns the HTML class.
+	 * @return the HTML class list as a single space separated String.
 	 */
 	protected Serializable getHtmlClass() {
-		return htmlClass;
+		if (this.htmlClassList == null || this.htmlClassList.isEmpty()) {
+			return null;
+		}
+		int i = 0;
+		StringBuilder result = new StringBuilder();
+
+		for (String c : this.htmlClassList) {
+			if (i++ > 0) {
+				result.append(" ");
+			}
+			result.append(c);
+		}
+		return result.toString();
 	}
 
 	/**
 	 * @param text The HTML class name text to set.
 	 */
 	protected void setHtmlClass(final String text) {
-		this.htmlClass = text;
+		if (text == null) {
+			this.htmlClassList = null;
+		} else {
+			this.htmlClassList = new HashSet<>();
+			this.htmlClassList.add(text);
+		}
 	}
 
 	/**
 	 * @param className The HTML class name to set.
 	 */
 	protected void setHtmlClass(final HtmlClassProperties className) {
-		this.htmlClass = className.toString();
+		if (null == className) {
+			this.htmlClassList = null;
+		} else {
+			setHtmlClass(className.toString());
+		}
+	}
+
+	/**
+	 * @param text The HTML class name text to set.
+	 */
+	protected void addHtmlClass(final String text) {
+		if (!Util.empty(text)) {
+			if (this.htmlClassList == null) {
+				this.htmlClassList = new HashSet<>();
+			}
+			this.htmlClassList.add(text);
+		}
+	}
+
+	/**
+	 * @param className The HTML class name to set.
+	 */
+	protected void addHtmlClass(final HtmlClassProperties className) {
+		if (null != className) {
+			addHtmlClass(className.toString());
+		}
+	}
+
+	/**
+	 * @return the set of HTML classes to add to the current component.
+	 */
+	protected HashSet getHtmlClassList() {
+		return this.htmlClassList;
+	}
+
+	/**
+	 * Remove a value from the HTML class name list.
+	 * @param className the value to remove
+	 */
+	protected void removeHtmlClass(final String className) {
+		if (!(this.htmlClassList == null || Util.empty(className))) {
+			this.htmlClassList.remove(className);
+		}
+	}
+
+	/**
+	 * Remove a value from the HTML class name list.
+	 * @param className the property representing the value to remove
+	 */
+	protected void removeHtmlClass(final HtmlClassProperties className) {
+		if (className != null) {
+			removeHtmlClass(className.toString());
+		}
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WComponent.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WComponent.java
@@ -5,6 +5,7 @@ import com.github.bordertech.wcomponents.validation.Diagnostic;
 import com.github.bordertech.wcomponents.validation.ValidatingAction;
 import java.io.Serializable;
 import java.text.MessageFormat;
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -511,25 +512,42 @@ public interface WComponent extends WebComponent {
 	void setHtmlClass(final HtmlClassProperties className);
 
 	/**
-	 * Append value to an existing HTML class name.
+	 * Append value to the HTML class name for this component.
 	 * @param className the HTML class attribute's value to add to the component
 	 */
-	void appendHtmlClass(final String className);
+	void addHtmlClass(final String className);
 
 	/**
-	 * Append a value to an existing HTML class name for this component from a set of preset values.
+	 * Append a value to the HTML class name for this component from a set of preset values.
 	 *
 	 * @param className the HTML class attribute's value to add to the component derived from the utility enum
 	 */
-	void appendHtmlClass(final HtmlClassProperties className);
+	void addHtmlClass(final HtmlClassProperties className);
 
 	/**
 	 * Returns the HTML class name string to apply to a component. Some values in the HTML class name attribute are
 	 * determined in the theme and are used for core functionality and styling. This method will only return class name
 	 * values which are added in the application, it has no knowledge of theme's class names.
 	 *
-	 * @return the value to add to the HTML class attribute of the output component.
+	 * @return the value to add to the HTML class attribute of the output component
 	 */
 	String getHtmlClass();
+
+	/**
+	 * @return the HTML class list HashSet for this component
+	 */
+	HashSet getHtmlClassList();
+
+	/**
+	 * Remove a value from the set of HTML class name values added to the current component.
+	 * @param className the value to remove
+	 */
+	void removeHtmlClass(final String className);
+
+	/**
+	 * Remove a value from the set of HTML class name values added to the current component.
+	 * @param className the property representing the value to remove
+	 */
+	void removeHtmlClass(final HtmlClassProperties className);
 
 }

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WComponent.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WComponent.java
@@ -5,8 +5,8 @@ import com.github.bordertech.wcomponents.validation.Diagnostic;
 import com.github.bordertech.wcomponents.validation.ValidatingAction;
 import java.io.Serializable;
 import java.text.MessageFormat;
-import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * The WComponent interface.
@@ -536,7 +536,7 @@ public interface WComponent extends WebComponent {
 	/**
 	 * @return the HTML class list HashSet for this component
 	 */
-	HashSet getHtmlClassList();
+	Set getHtmlClasses();
 
 	/**
 	 * Remove a value from the set of HTML class name values added to the current component.

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/AbstractWComponent_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/AbstractWComponent_Test.java
@@ -12,6 +12,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import junit.framework.Assert;
 import org.junit.Test;
 
@@ -1146,7 +1147,7 @@ public class AbstractWComponent_Test extends AbstractWComponentTestCase {
 		expected.add(additionalClass);
 		comp.setHtmlClass(initialClass);
 		comp.addHtmlClass(additionalClass);
-		Assert.assertEquals("HTML class should have been appended with a space separator", expected, comp.getHtmlClassList());
+		Assert.assertEquals("HTML class should have been appended with a space separator", expected, comp.getHtmlClasses());
 	}
 
 	@Test
@@ -1168,7 +1169,7 @@ public class AbstractWComponent_Test extends AbstractWComponentTestCase {
 		expected.add(additionalClass.toString());
 		comp.setHtmlClass(initialClass);
 		comp.addHtmlClass(additionalClass);
-		Assert.assertEquals("HTML class should have been appended with a space separator", expected, comp.getHtmlClassList());
+		Assert.assertEquals("HTML class should have been appended with a space separator", expected, comp.getHtmlClasses());
 	}
 
 	@Test
@@ -1183,7 +1184,7 @@ public class AbstractWComponent_Test extends AbstractWComponentTestCase {
 	@Test
 	public void testGetHtmlClassListDefaultState() {
 		AbstractWComponent comp = new SimpleComponent();
-		Assert.assertNull(comp.getHtmlClassList());
+		Assert.assertNull(comp.getHtmlClasses());
 	}
 
 	@Test
@@ -1196,7 +1197,7 @@ public class AbstractWComponent_Test extends AbstractWComponentTestCase {
 		expected.add(classValue2);
 		comp.setHtmlClass(classValue);
 		comp.addHtmlClass(classValue2);
-		HashSet<String> result = comp.getHtmlClassList();
+		Set<String> result = comp.getHtmlClasses();
 		Assert.assertEquals(expected.size(), result.size());
 		for (String c : expected) {
 			Assert.assertTrue(result.contains(new String(c)));

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/AbstractWComponent_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/AbstractWComponent_Test.java
@@ -10,6 +10,7 @@ import java.io.PrintWriter;
 import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import junit.framework.Assert;
 import org.junit.Test;
@@ -1136,45 +1137,109 @@ public class AbstractWComponent_Test extends AbstractWComponentTestCase {
 	}
 
 	@Test
-	public void testAppendHtmlClass() {
+	public void testAddHtmlClass() {
 		AbstractWComponent comp = new SimpleComponent();
 		String initialClass = "foo";
 		String additionalClass = "bar";
-		String expected = initialClass + " " + additionalClass;
+		HashSet<String> expected = new HashSet<>();
+		expected.add(initialClass);
+		expected.add(additionalClass);
 		comp.setHtmlClass(initialClass);
-		comp.appendHtmlClass(additionalClass);
-		Assert.assertEquals("HTML class should have been appended with a space separator", expected, comp.getHtmlClass());
+		comp.addHtmlClass(additionalClass);
+		Assert.assertEquals("HTML class should have been appended with a space separator", expected, comp.getHtmlClassList());
 	}
 
 	@Test
-	public void testAppendHtmlClassWithNoInitialClass() {
+	public void testAddHtmlClassWithNoInitialClass() {
 		AbstractWComponent comp = new SimpleComponent();
 		String additionalClass = "bar";
 		String expected = additionalClass;
-		comp.appendHtmlClass(additionalClass);
+		comp.addHtmlClass(additionalClass);
 		Assert.assertEquals("HTML class should have been appended without a space separator", expected, comp.getHtmlClass());
 	}
 
 	@Test
-	public void testAppendHtmlClassUsingHtmlClassProperties() {
+	public void testAddHtmlClassUsingHtmlClassProperties() {
 		AbstractWComponent comp = new SimpleComponent();
 		String initialClass = "foo";
 		HtmlClassProperties additionalClass = HtmlClassProperties.RESPOND;
-		StringBuilder expected = new StringBuilder(initialClass);
-		expected.append(" ");
-		expected.append(additionalClass.toString());
+		HashSet<String> expected = new HashSet<>();
+		expected.add(initialClass);
+		expected.add(additionalClass.toString());
 		comp.setHtmlClass(initialClass);
-		comp.appendHtmlClass(additionalClass);
-		Assert.assertEquals("HTML class should have been appended with a space separator", expected.toString(), comp.getHtmlClass());
+		comp.addHtmlClass(additionalClass);
+		Assert.assertEquals("HTML class should have been appended with a space separator", expected, comp.getHtmlClassList());
 	}
 
 	@Test
-	public void testAppendHtmlClassWithNoInitialClassUsingHtmlClassProperties() {
+	public void testAddHtmlClassWithNoInitialClassUsingHtmlClassProperties() {
 		AbstractWComponent comp = new SimpleComponent();
 		HtmlClassProperties additionalClass = HtmlClassProperties.RESPOND;
 		String expected = additionalClass.toString();
-		comp.appendHtmlClass(additionalClass);
+		comp.addHtmlClass(additionalClass);
 		Assert.assertEquals("HTML class should have been appended without a space separator", expected, comp.getHtmlClass());
+	}
+
+	@Test
+	public void testGetHtmlClassListDefaultState() {
+		AbstractWComponent comp = new SimpleComponent();
+		Assert.assertNull(comp.getHtmlClassList());
+	}
+
+	@Test
+	public void testGetHtmlClassList() {
+		AbstractWComponent comp = new SimpleComponent();
+		String classValue = "foo";
+		String classValue2 = "bar";
+		HashSet<String> expected = new HashSet<>();
+		expected.add(classValue);
+		expected.add(classValue2);
+		comp.setHtmlClass(classValue);
+		comp.addHtmlClass(classValue2);
+		HashSet<String> result = comp.getHtmlClassList();
+		Assert.assertEquals(expected.size(), result.size());
+		for (String c : expected) {
+			Assert.assertTrue(result.contains(new String(c)));
+		}
+	}
+
+	@Test
+	public void testRemoveHtmlClassString() {
+		AbstractWComponent comp = new SimpleComponent();
+		comp.setHtmlClass("foo");
+		comp.removeHtmlClass("foo");
+		Assert.assertNull(comp.getHtmlClass());
+	}
+
+	@Test
+	public void testRemoveHtmlClassProperty() {
+		AbstractWComponent comp = new SimpleComponent();
+		comp.setHtmlClass(HtmlClassProperties.ICON);
+		comp.removeHtmlClass(HtmlClassProperties.ICON);
+		Assert.assertNull(comp.getHtmlClass());
+	}
+
+	@Test
+	public void testRemoveHtmlClassMixed() {
+		AbstractWComponent comp = new SimpleComponent();
+		comp.setHtmlClass(HtmlClassProperties.ICON);
+		comp.removeHtmlClass(HtmlClassProperties.ICON.toString());
+		Assert.assertNull(comp.getHtmlClass());
+	}
+
+	@Test
+	public void testRemoveHtmlClassStringNoMatch() {
+		AbstractWComponent comp = new SimpleComponent();
+		comp.setHtmlClass("foo");
+		comp.removeHtmlClass("bar");
+		Assert.assertEquals("foo", comp.getHtmlClass());
+	}
+
+	@Test
+	public void testRemoveHtmlClassStringNull() {
+		AbstractWComponent comp = new SimpleComponent();
+		comp.removeHtmlClass("bar");
+		Assert.assertNull(comp.getHtmlClass());
 	}
 
 	/**


### PR DESCRIPTION
* COnverted Serializable HtmlClassName to a HashSet<String>.
* Added methods addHtmlClass(String), addHtmlClass(HtmlClassProperties), removeHtmlClass(String) and
removeHtmlClass(HtmlClassProperties)

Fixes #856.

@jonathanaustin PTAL