### PR TITLE
Sass compression errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ## Bug Fixes
 * Fixed a bug which prevented `WField`'s `inputWidth` setting from rendering correctly #854.
 * Fixed a bug in rendering of `WPartialDateField` and polyfilled `WDateField` #852.
+* Fixed UI bugs in WMenus #866, #867.
+* Fixed a Sass bug which caused ListLayouts with layout FLAT to lose intra-component space #869.
 
 ## Enhancements
 * Added a mechanism to add and remove multiple HTML class attribute values to a component #856.

--- a/wcomponents-theme/build-i18n.xml
+++ b/wcomponents-theme/build-i18n.xml
@@ -23,9 +23,9 @@
 			<fileset dir="${i18n.build.target.dir}" includes="*.json"/>
 		</copy>
 	</target>
-	
+
 	<target name="buildJsonBundles">
-		<property name="propertiesToJson.js" value="${basedir}/propertiesToJson.js" />
+		<property name="propertiesToJson.js" value="${component.rootdir}/propertiesToJson.js" />
 		<property name="default.locale.properties" location="${i18n.build.target.dir}/${default.i18n.locale}.properties"/>
 		<property name="default.locale.json" location="${i18n.build.target.dir}/${default.i18n.locale}.json"/>
 		<buildProps destfile="${default.locale.properties}"/>
@@ -110,7 +110,7 @@
 			</sequential>
 		</for>
 	</target>
-	
+
 	<!--
 		Builds a properties file from the source files in the core and implementation directories.
 		This is largely for backwards compatibility.

--- a/wcomponents-theme/src/main/sass/wc.ui.mediaPlayer.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.mediaPlayer.scss
@@ -6,7 +6,7 @@
 .wc-track {
 	display: inline-block;
 
-	+ & {
+	& + & {
 		margin-left: $wc-gap-normal;
 	}
 }


### PR DESCRIPTION
Fixes an error in the Sass for `.wc-src` and `.wc-track` (both used by
WAudio/WVideo) which had an unfortunatel flow-on effect which broke the
CSS for flat listlayouts after CSS compression. Fixes #869