### PR TITLE
WButton client only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 * Fixed a bug in rendering of `WPartialDateField` and polyfilled `WDateField` #852.
 * Fixed UI bugs in WMenus #866, #867.
 * Fixed a Sass bug which caused ListLayouts with layout FLAT to lose intra-component space #869.
+* Fixed a bug which prevented a control which opens a WDialog from running a server Action #875.
 
 ## Enhancements
 * Added a mechanism to add and remove multiple HTML class attribute values to a component #856.
+* Added a mechanism to mark a WButton as having an action only in the client #878.
 
 # Release 1.2.4
 ## Bug Fixes

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WButton.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WButton.java
@@ -501,6 +501,28 @@ public class WButton extends WBeanComponent implements Container, Disableable, A
 	}
 
 	/**
+	 * @return {@code true} if the button fires a client side command without causing a submit action. This is not necessarily incompatible with being
+	 * an AjaxTrigger.
+	 */
+	public boolean isClientCommandOnly() {
+		return getComponentModel().client;
+	}
+
+	/**
+	 * Sets whether this button should fire a client command without submitting the form. What this actually does is indicates to the client that the
+	 * button element is not a submit button so a form submit will not be triggered when the button is pressed.  If the button is also an AjaxTrigger
+	 * then the Ajax request will still fire unless the custom command specifically prevents this.
+	 *
+	 * <p>If this is true then interacting with the button on the client will not submit the form. A custom command will fire if one is attached to
+	 * the button through custom JavaScript.</p>
+	 *
+	 * @param client indicates if the current button is to trigger a client action without a submit
+	 */
+	public void setClientCommandOnly(final boolean client) {
+		getOrCreateComponentModel().client = client;
+	}
+
+	/**
 	 * Indicates whether this button will trigger a WPopup when used.
 	 *
 	 * @return true if this button triggers a popup, false otherwise.
@@ -801,6 +823,11 @@ public class WButton extends WBeanComponent implements Container, Disableable, A
 		 * Act as a cancel control and warn the user of unsaved changes.
 		 */
 		private boolean cancel;
+
+		/**
+		 * Trigger a command in the client without firing a submit.
+		 */
+		private boolean client;
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WButtonRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WButtonRenderer.java
@@ -53,6 +53,7 @@ class WButtonRenderer extends AbstractWebXmlRenderer {
 		xml.appendOptionalAttribute("cancel", button.isCancel(), "true");
 		xml.appendOptionalAttribute("unsavedChanges", button.isUnsavedChanges(), "true");
 		xml.appendOptionalAttribute("msg", button.getMessage());
+		xml.appendOptionalAttribute("client", button.isClientCommandOnly(), "true");
 
 		if (imageUrl != null) {
 			xml.appendAttribute("imageUrl", imageUrl);

--- a/wcomponents-core/src/main/resources/schema/ui/v1/button.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/button.xsd
@@ -35,14 +35,19 @@
 			<xs:extension base="xs:string">
 				<xs:attributeGroup ref="ui:button.link.attributes"/>
 				<xs:attributeGroup ref="ui:button.menu.attributes"/>
-				<xs:attribute name="popup" type="xs:boolean">
+				<xs:attribute name="popup" type="xs:boolean" default="false">
 					<xs:annotation>
 						<xs:documentation>Indicates whether this button will trigger a WPopup. Required for WCAG2.0 level A compliance of WPopup.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
-				<xs:attribute name="unsavedChanges" type="xs:boolean">
+				<xs:attribute name="unsavedChanges" type="xs:boolean" default="false">
 					<xs:annotation>
 						<xs:documentation>If set and @cancel is true the user will receive a warning even if they have not made changes on the current screen.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="client" type="xs:boolean" default="false">
+					<xs:annotation>
+						<xs:documentation>If set "true" then the button is expected to trigger a purely client side process and will not submit to the server.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 			</xs:extension>

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WButton_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WButton_Test.java
@@ -595,6 +595,11 @@ public class WButton_Test extends AbstractWComponentTestCase {
 				getButtonValue(true, true, true, true, true, false));
 	}
 
+	@Test
+	public void testClientCommandOnlyAccessors() {
+		assertAccessorsCorrect(new WButton("client"), "clientCommandOnly", false, true, false);
+	}
+
 	/**
 	 * Returns the text for a button created with the given data.
 	 *

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WButtonRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WButtonRenderer_Test.java
@@ -59,6 +59,7 @@ public class WButtonRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertXpathNotExists("//ui:button[@ajax]", button);
 		assertXpathNotExists("//ui:button[@validates]", button);
 		assertXpathNotExists("//ui:button[@popup]", button);
+		assertXpathNotExists("//ui:button[@client]", button);
 	}
 
 	@Test
@@ -111,6 +112,9 @@ public class WButtonRenderer_Test extends AbstractWebXmlRendererTestCase {
 
 		button.setImagePosition(ImagePosition.WEST);
 		assertXpathEvaluatesTo("w", "//ui:button/@imagePosition", button);
+
+		button.setClientCommandOnly(true);
+		assertXpathEvaluatesTo("true", "//ui:button/@client", button);
 	}
 
 	@Test

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WButtonExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WButtonExample.java
@@ -5,6 +5,7 @@ import com.github.bordertech.wcomponents.ActionEvent;
 import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.MessageContainer;
 import com.github.bordertech.wcomponents.Request;
+import com.github.bordertech.wcomponents.WApplication;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WButton.ImagePosition;
 import com.github.bordertech.wcomponents.WContainer;
@@ -17,6 +18,7 @@ import com.github.bordertech.wcomponents.WMessages;
 import com.github.bordertech.wcomponents.WPanel;
 import com.github.bordertech.wcomponents.WText;
 import com.github.bordertech.wcomponents.WTextField;
+import com.github.bordertech.wcomponents.WebUtilities;
 import com.github.bordertech.wcomponents.examples.common.ExplanatoryText;
 import com.github.bordertech.wcomponents.layout.FlowLayout;
 import com.github.bordertech.wcomponents.util.HtmlClassProperties;
@@ -91,6 +93,8 @@ public class WButtonExample extends WPanel implements MessageContainer {
 
 		//disabled state
 		addDisabledExamples();
+
+		addClientOnlyExamples();
 
 		add(new WHorizontalRule());
 		addImageExamples();
@@ -195,6 +199,32 @@ public class WButtonExample extends WPanel implements MessageContainer {
 		iconButton = new WButton("Right icon with text content");
 		iconButton.setHtmlClass("wc-icon-after fa-hand-o-right");
 		add(iconButton);
+	}
+
+	/**
+	 * Examples showing use of client only buttons.
+	 */
+	private void addClientOnlyExamples() {
+		// client command button
+
+		add(new WHeading(HeadingLevel.H2, "Client command buttons"));
+		add(new ExplanatoryText("These examples show buttons which do not submit the form"));
+
+		//client command buttons witho a command
+		WButton nothingButton = new WButton("Do nothing");
+		add(nothingButton);
+		nothingButton.setClientCommandOnly(true);
+		nothingButton = new WButton("Do nothing link");
+		add(nothingButton);
+		nothingButton.setRenderAsLink(true);
+		nothingButton.setClientCommandOnly(true);
+
+		// client command buttons with command.
+		HelloButton helloButton = new HelloButton("Hello");
+		add(helloButton);
+		helloButton = new HelloButton("Hello link");
+		helloButton.setRenderAsLink(true);
+		add(helloButton);
 	}
 
 	/**
@@ -405,6 +435,37 @@ public class WButtonExample extends WPanel implements MessageContainer {
 
 			messages.info(((WButton) event.getActionObject()).getText() + MESSAGE);
 		}
+
+	}
+
+	/**
+	 * Simple extension of WButton to set as a client only button and add a class used in the example's alert script. We then add the script in the
+	 * first use.
+	 *
+	 */
+	private final class HelloButton extends WButton {
+		/**
+		 * Create a HelloButton with a particlar text label.
+		 * @param text the text to show on the button
+		 */
+		public HelloButton(final String text) {
+			super(text);
+			setClientCommandOnly(true);
+			setHtmlClass("hellobutton");
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		@Override
+		protected void preparePaintComponent(final Request request) {
+			if (!isInitialised()) {
+				WebUtilities.getAncestorOfClass(WApplication.class, this).addJsFile("/com/github/bordertech/wcomponents/examples/hellobutton.js");
+				setInitialised(true);
+			}
+			super.preparePaintComponent(request);
+		}
+
 
 	}
 }

--- a/wcomponents-examples/src/main/resources/com/github/bordertech/wcomponents/examples/hellobutton.js
+++ b/wcomponents-examples/src/main/resources/com/github/bordertech/wcomponents/examples/hellobutton.js
@@ -1,0 +1,21 @@
+require(["wc/compat/compat!"], function() {
+	require(["wc/dom/event", "wc/dom/classList", "wc/dom/initialise"], function(event, classList, initialise){
+		// This script exists _only_ as an example to show use of WButton setClientCommandOnly(boolean);
+
+		/**
+		 * If an element with class 'hellobutton' is clicked, pop up an alert dialog.
+		 * @param {module:wc/dom/event} $event the wrapped click event
+		 */
+		function clickEvent($event) {
+			var target = $event.target;
+
+			if (target && classList.contains(target, "hellobutton")) {
+				window.alert("hello");
+			}
+		}
+		// add an event manager subscription for the click handler
+		initialise.register({postInit: function(){
+			event.add(document.body, event.TYPE.click, clickEvent);
+		}});
+	});
+});

--- a/wcomponents-theme/src/main/xslt/wc.common.button.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.button.xsl
@@ -64,7 +64,7 @@
 
 			<xsl:attribute name="type">
 				<xsl:choose>
-					<xsl:when test="self::ui:printbutton">
+					<xsl:when test="self::ui:printbutton or @client=$t">
 						<xsl:text>button</xsl:text>
 					</xsl:when>
 					<xsl:otherwise>


### PR DESCRIPTION
Added a mechanism to mark a WButton as being client-side only. Fixes #878.