### PR TITLE
Input fields with User Text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 * Fixed a bug which prevented a control which opens a WDialog from running a server Action #875.
 * Fixed a bug which caused image editor to fail if multiple files were attached at once #876.
 * Fixed a bug which prevented timeout warnings from rendering a session elapsed message correctly #890.
-* Fixed a bug where WTree was adding an open item request to expanded rows #762.
+* Fixed a bug where `WTree` was adding an open item request to expanded rows #762.
+* Fixed a bug where `resetData()` was not handled correctly in `WNumberField`, `WDateField`
+  and `WPartialDateField` #896.
 
 ## Enhancements
 * Added a mechanism to add and remove multiple HTML class attribute values to a component #856.
@@ -18,6 +20,7 @@
 * Added a lot of Sass configuration options to `_common.scss` along with additional commentary #689.
 * Projects can override a new method `getUiVersionKey()` in `WApplication` if different versions of the same Application
   need to be registered by `UIRegistry` #894.
+* New constructors in `WPartialDateField` to allow a padding character to be passed in #573.
  
 # Release 1.2.4
 ## Bug Fixes

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WDateField.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WDateField.java
@@ -63,7 +63,6 @@ public class WDateField extends AbstractInput implements AjaxTrigger, AjaxTarget
 	public void setData(final Object data) {
 		// This override is necessary to maintain other internal state
 		DateFieldModel model = getOrCreateComponentModel();
-
 		try {
 			super.setData(convertDate(data));
 			model.text = null;
@@ -385,6 +384,17 @@ public class WDateField extends AbstractInput implements AjaxTrigger, AjaxTarget
 		 * The maximum date value to allow.
 		 */
 		private Date maxDate;
+
+		/**
+		 * Maintain internal state.
+		 */
+		@Override
+		public void resetData() {
+			super.resetData();
+			DateFieldModel shared = (DateFieldModel) getSharedModel();
+			this.text = shared.text;
+			this.validDate = shared.validDate;
+		}
 
 	}
 }

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WNumberField.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WNumberField.java
@@ -508,5 +508,16 @@ public class WNumberField extends AbstractInput implements AjaxTrigger, AjaxTarg
 		 */
 		private boolean validNumber = true;
 
+		/**
+		 * Maintain internal state.
+		 */
+		@Override
+		public void resetData() {
+			super.resetData();
+			NumberFieldModel shared = (NumberFieldModel) getSharedModel();
+			this.text = shared.text;
+			this.validNumber = shared.validNumber;
+		}
+
 	}
 }

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WDateField_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WDateField_Test.java
@@ -806,8 +806,62 @@ public class WDateField_Test extends AbstractWComponentTestCase {
 		WDateField dateField = processDoHandleRequestWithValidDate();
 		Assert.assertEquals("Incorrect text", REQUEST_VALID_USER_TEXT, dateField.getText());
 
-		dateField.setData(new Date());
-		Assert.assertEquals("Text should have been cleared", null, dateField.getText());
+		// Valid value
+		Date value = new Date();
+		dateField.setData(value);
+		Assert.assertNull("Text should have been cleared", dateField.getText());
+		Assert.assertEquals("Data should have value set", value, dateField.getData());
+		Assert.assertTrue("Should be valid", dateField.isParseable());
+
+		// Invalid value
+		dateField.setData(REQUEST_BAD_USER_TEXT);
+		Assert.assertEquals("Text should have bad date text", REQUEST_BAD_USER_TEXT, dateField.getText());
+		Assert.assertEquals("Data should have bad date text", REQUEST_BAD_USER_TEXT, dateField.getData());
+		Assert.assertFalse("Should be invalid", dateField.isParseable());
+	}
+
+	@Test
+	public void testResetData() {
+		WDateField dateField = new WDateField();
+
+		setActiveContext(createUIContext());
+		dateField.setLocked(true);
+
+		// Has valid value
+		Date value = new Date();
+		dateField.setData(value);
+		// Reset Data
+		dateField.resetData();
+		Assert.assertNull("With reset Text should have been cleared", dateField.getText());
+		Assert.assertNull("With reset Data should be null", dateField.getData());
+		Assert.assertTrue("With reset should be valid", dateField.isParseable());
+
+		// Invalid value
+		dateField.setData(REQUEST_BAD_USER_TEXT);
+		// Reset Data
+		dateField.resetData();
+		Assert.assertNull("With reset Text should have been cleared for invalid value", dateField.getText());
+		Assert.assertNull("With reset Data should be null for invalid value", dateField.getData());
+		Assert.assertTrue("With reset should be valid for invalid value", dateField.isParseable());
+	}
+
+	@Test
+	public void testResetDataWithInvalidDefault() {
+
+		WDateField dateField = new WDateField();
+		dateField.setData(REQUEST_BAD_USER_TEXT);
+
+		setActiveContext(createUIContext());
+		dateField.setLocked(true);
+
+		// Has valid value
+		Date value = new Date();
+		dateField.setData(value);
+		// Reset Data (should go back to invalid)
+		dateField.resetData();
+		Assert.assertEquals("Text should have bad date text", REQUEST_BAD_USER_TEXT, dateField.getText());
+		Assert.assertEquals("Data should have bad date text", REQUEST_BAD_USER_TEXT, dateField.getData());
+		Assert.assertFalse("Should be invalid", dateField.isParseable());
 	}
 
 	/**

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WNumberField_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WNumberField_Test.java
@@ -693,8 +693,62 @@ public class WNumberField_Test extends AbstractWComponentTestCase {
 		WNumberField numberField = processDoHandleRequestWithValidNumber();
 		Assert.assertEquals("Incorrect text", REQUEST_VALID_NUMBER_TEXT, numberField.getText());
 
-		numberField.setData(BigDecimal.valueOf(1));
-		Assert.assertEquals("Text should have been cleared", null, numberField.getText());
+		// Valid value
+		BigDecimal value = BigDecimal.valueOf(1);
+		numberField.setData(value);
+		Assert.assertNull("Text should have been cleared", numberField.getText());
+		Assert.assertEquals("Data should have value set", value, numberField.getData());
+		Assert.assertTrue("Should be valid", numberField.isValidNumber());
+
+		// Invalid value
+		numberField.setData(REQUEST_BAD_NUMBER_TEXT);
+		Assert.assertEquals("Text should have bad number text", REQUEST_BAD_NUMBER_TEXT, numberField.getText());
+		Assert.assertEquals("Data should have bad number text", REQUEST_BAD_NUMBER_TEXT, numberField.getData());
+		Assert.assertFalse("Should be invalid", numberField.isValidNumber());
+	}
+
+	@Test
+	public void testResetData() {
+		WNumberField numberField = new WNumberField();
+
+		setActiveContext(createUIContext());
+		numberField.setLocked(true);
+
+		// Has valid value
+		BigDecimal value = BigDecimal.valueOf(1);
+		numberField.setData(value);
+		// Reset Data
+		numberField.resetData();
+		Assert.assertNull("With reset Text should have been cleared", numberField.getText());
+		Assert.assertNull("With reset Data should be null", numberField.getData());
+		Assert.assertTrue("With reset should be valid", numberField.isValidNumber());
+
+		// Invalid value
+		numberField.setData(REQUEST_BAD_NUMBER_TEXT);
+		// Reset Data
+		numberField.resetData();
+		Assert.assertNull("With reset Text should have been cleared for invalid value", numberField.getText());
+		Assert.assertNull("With reset Data should be null for invalid value", numberField.getData());
+		Assert.assertTrue("With reset should be valid for invalid value", numberField.isValidNumber());
+	}
+
+	@Test
+	public void testResetDataWithInvalidDefault() {
+
+		WNumberField numberField = new WNumberField();
+		numberField.setData(REQUEST_BAD_NUMBER_TEXT);
+
+		setActiveContext(createUIContext());
+		numberField.setLocked(true);
+
+		// Has valid value
+		BigDecimal value = BigDecimal.valueOf(1);
+		numberField.setData(value);
+		// Reset Data (should go back to invalid)
+		numberField.resetData();
+		Assert.assertEquals("Text should have bad number text", REQUEST_BAD_NUMBER_TEXT, numberField.getText());
+		Assert.assertEquals("Data should have bad number text", REQUEST_BAD_NUMBER_TEXT, numberField.getData());
+		Assert.assertFalse("Should be invalid", numberField.isValidNumber());
 	}
 
 	/**

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WPartialDateField_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WPartialDateField_Test.java
@@ -212,6 +212,24 @@ public class WPartialDateField_Test extends AbstractWComponentTestCase {
 
 	}
 
+	@Test
+	public void testConstructorWithDefaultPadding() {
+		WPartialDateField partial = new WPartialDateField();
+		Assert.assertEquals("Incorrect default padding char", ' ', partial.getPaddingChar());
+	}
+
+	@Test
+	public void testConstructorWithCustomPadding() {
+		WPartialDateField partial = new WPartialDateField('X');
+		Assert.assertEquals("Incorrect custom padding char", 'X', partial.getPaddingChar());
+	}
+
+	@Test
+	public void testConstructorWithDateAndCustomPadding() {
+		WPartialDateField partial = new WPartialDateField(null, null, null, 'X');
+		Assert.assertEquals("Incorrect custom padding char", 'X', partial.getPaddingChar());
+	}
+
 	/**
 	 * test setPartialDate - with Integer inputs.
 	 */
@@ -428,6 +446,73 @@ public class WPartialDateField_Test extends AbstractWComponentTestCase {
 		dateField = processDoHandleRequestWithBadDate(); // Put a value in User Text and make sure it gets cleared
 		dateField.setDate(new Date());
 		Assert.assertNull("User text should be null when a valid date is set", dateField.getText());
+	}
+
+	@Test
+	public void testSetData() {
+
+		WPartialDateField dateField = new WPartialDateField();
+
+		setActiveContext(createUIContext());
+		dateField.setLocked(true);
+
+		// Valid value
+		String value = REQUEST_VALID_DATE_TEXT;
+		dateField.setData(value);
+		Assert.assertNull("Text should have been cleared", dateField.getText());
+		Assert.assertEquals("Data should have value set", value, dateField.getData());
+		Assert.assertTrue("Should be valid", dateField.isValidDate());
+
+		// Invalid value
+		dateField.setData(REQUEST_BAD_USER_TEXT);
+		Assert.assertEquals("Text should have bad date text", REQUEST_BAD_USER_TEXT, dateField.getText());
+		Assert.assertEquals("Data should have bad date text", REQUEST_BAD_USER_TEXT, dateField.getData());
+		Assert.assertFalse("Should be invalid", dateField.isValidDate());
+	}
+
+	@Test
+	public void testResetData() {
+
+		WPartialDateField dateField = new WPartialDateField();
+
+		setActiveContext(createUIContext());
+		dateField.setLocked(true);
+
+		// Has valid value
+		Date value = new Date();
+		dateField.setData(value);
+		// Reset Data
+		dateField.resetData();
+		Assert.assertNull("With reset Text should have been cleared", dateField.getText());
+		Assert.assertNull("With reset Data should be null", dateField.getData());
+		Assert.assertTrue("With reset should be valid", dateField.isValidDate());
+
+		// Invalid value
+		dateField.setData(REQUEST_BAD_USER_TEXT);
+		// Reset Data
+		dateField.resetData();
+		Assert.assertNull("With reset Text should have been cleared for invalid value", dateField.getText());
+		Assert.assertNull("With reset Data should be null for invalid value", dateField.getData());
+		Assert.assertTrue("With reset should be valid for invalid value", dateField.isValidDate());
+	}
+
+	@Test
+	public void testResetDataWithInvalidDefault() {
+
+		WPartialDateField dateField = new WPartialDateField();
+		dateField.setData(REQUEST_BAD_USER_TEXT);
+
+		setActiveContext(createUIContext());
+		dateField.setLocked(true);
+
+		// Has valid value
+		Date value = new Date();
+		dateField.setData(value);
+		// Reset Data (should go back to invalid)
+		dateField.resetData();
+		Assert.assertEquals("Text should have bad date text", REQUEST_BAD_USER_TEXT, dateField.getText());
+		Assert.assertEquals("Data should have bad date text", REQUEST_BAD_USER_TEXT, dateField.getData());
+		Assert.assertFalse("Should be invalid", dateField.isValidDate());
 	}
 
 	@Test

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WPartialDateFieldExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WPartialDateFieldExample.java
@@ -35,8 +35,6 @@ public class WPartialDateFieldExample extends WContainer {
 	 */
 	public WPartialDateFieldExample() {
 
-
-
 		// First block with button Panel
 		WPanel wrapper = new WPanel();
 		add(wrapper);
@@ -134,7 +132,7 @@ public class WPartialDateFieldExample extends WContainer {
 		copyBtn.setAction(new Action() {
 			@Override
 			public void execute(final ActionEvent event) {
-				text.setText(dateField.getText());
+				text.setText(dateField.getValueAsString());
 			}
 		});
 


### PR DESCRIPTION
`WNumberField`, `WDateField` and `WPartialDateField` change to handle `setData()` and `resetData()` correctly.

Addresses #573 #896.