### PR TITLE
Menu negative margin

### DIFF
--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WSectionExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WSectionExample.java
@@ -5,10 +5,12 @@ import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WCheckBox;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WFieldLayout;
+import com.github.bordertech.wcomponents.WMenu;
 import com.github.bordertech.wcomponents.WPanel;
 import com.github.bordertech.wcomponents.WSection;
 import com.github.bordertech.wcomponents.WSection.SectionMode;
 import com.github.bordertech.wcomponents.WText;
+import com.github.bordertech.wcomponents.examples.common.ExplanatoryText;
 import com.github.bordertech.wcomponents.examples.menu.MenuBarExample;
 import com.github.bordertech.wcomponents.subordinate.Equal;
 import com.github.bordertech.wcomponents.subordinate.Hide;
@@ -91,6 +93,20 @@ public class WSectionExample extends WContainer {
 		control.addRule(new Rule(new Equal(chb, "true"), new Show(section), new Hide(section)));
 
 		add(new WButton("submit"));
+
+		section = new WSection("MenuBar in nested panel");
+		add(section);
+
+		WPanel nestedPanel = new WPanel();
+
+		section.getContent().add(nestedPanel);
+		mbEx = new MenuBarExample(selectedMenuText);
+		WMenu exMenu = mbEx.getMenu();
+		exMenu.addHtmlClass("wc-neg-margin");
+		nestedPanel.add(exMenu);
+		nestedPanel.add(new ExplanatoryText("Hello World from a nested panel"));
+
+		section.getContent().add(new ExplanatoryText("Hello World from the top panel"));
 	}
 
 }

--- a/wcomponents-theme/src/main/sass/_wc.ui.menu.negmargin.scss
+++ b/wcomponents-theme/src/main/sass/_wc.ui.menu.negmargin.scss
@@ -1,0 +1,36 @@
+@import 'mixins-common';
+
+// ####################################################################################################################
+// WARNING
+//
+// When a WMenu of Type.BAR is the first child of a WPanel of Type.CHROME or of Type.ACTION (ie a WPanel with exposed
+// title) _or_ is the first child of a WPanel child of WSection; **and** that WPanel does not have a Layout applied then
+// a negative margin is applied to make the menu "dock" to the header bar.
+// This class `.wc-neg-margin` can be used to force this same negative margin on WMenus of Type.BAR when it is not
+// feasible to have them in unnested WPanel's in the appropriate circimstance.
+//
+// WARNING
+//
+// This makes no attempt to determine the location of the menu, it just uses the section padding as a negative margin.
+// This means it will apply wherever it is used.
+// It is intended that this **only** be used when the menu is the first visible component in such a section as described
+// above but I am not going to enforce that.
+//
+// WARNING
+//
+// Well here is the **WARNING**: if you use this willy-nilly your UI _could_ look really silly!
+.wc-menu-type-bar.wc-neg-margin {
+	// the negative margin must be 0 - the padding of WSection content.
+	$neg-margin: -$wc-section-space-normal;
+	margin: $neg-margin $neg-margin $wc-section-space-normal;
+}
+
+@if ($wc-gap-reduce-when-narrow != -1) {
+	@include respond-phonelike {
+		.wc-menu-type-bar.wc-neg-margin {
+			$neg-margin: -$wc-section-space-reduced;
+			margin: $neg-margin $neg-margin $wc-section-space-reduced;
+		}
+	}
+}
+// ####################################################################################################################

--- a/wcomponents-theme/src/main/sass/wc.ui.menu.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.menu.scss
@@ -94,4 +94,5 @@
 	display: none;
 }
 
+@import 'wc.ui.menu.negmargin';
 @import 'wc.ui.menu.color';


### PR DESCRIPTION
Added class `wc-neg-margin` which, if applied to a WMenu of `Type.BAR`
will give it a negative margin on the top, left and right which will
cause it to dock to a WSection header or the title bar of WPanel types
`CHROME` and `ACTION`.

Resolves #916