### PR TITLE
WPanel types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
 # Change log
 ## API Changes
 
+* Deprecated the following WPanel Types (part of #689, #639):
+  * Type.ACTION: deprecated in favour of WSection to remove API ambiguity.
+  * Type.BANNER: deprecated in favour of WSection as never implemented but JavaDoc points to WSection equivalence
+  * Type.BLOCK: deprecated in favour of Type.PLAIN and WSection as no longer serves any useful purpose
+  * Type.CHROME: deprecated in favour of WSection to remove API ambiguity.
+
 ## Bug Fixes
 
+* Applied a workaround for buggy implementation of placeholders in textareas in IE11 #911.
+
 ## Enhancements
+
+* Added CSS support for an additional class `wc-neg-margin` on WMenu Type.BAR to force the "docking" style if it is not possible to make the menubar the first child of a WPanel with no layout #916.
+* Updated JavaScript Widgets used to determine WDateField and WPartialDateField to remove some potential access errors when either of these components is in a read-only state #907.
 
 # Release 1.2.6
 ## API Changes

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WPanel.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WPanel.java
@@ -35,14 +35,17 @@ public class WPanel extends WContainer implements AjaxInternalTrigger, AjaxTarge
 		/**
 		 * An action panel is similar to CHROME but with a different appearance. It is intended to be used once per
 		 * screen to highlight the main area of activity.
+		 * @deprecated v1.2.7 use {@link WSection} instead
 		 */
 		ACTION,
 		/**
 		 * A titled panel which is similar to CHROME but with a fancier border.
+		 * @deprecated v1.2.7 use {@link WSection} instead
 		 */
 		BANNER,
 		/**
 		 * A 'block' type panel has padding around the edges.
+		 * @deprecated v1.2.7 use Type.PLAIN and {@link Margin} instead
 		 */
 		BLOCK,
 		/**
@@ -51,6 +54,7 @@ public class WPanel extends WContainer implements AjaxInternalTrigger, AjaxTarge
 		BOX,
 		/**
 		 * A panel with a title displayed in a border.
+		 * @deprecated v1.2.7 use {@link WSection} instead
 		 */
 		CHROME,
 		/**

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WPanelTypeExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WPanelTypeExample.java
@@ -17,7 +17,6 @@ import com.github.bordertech.wcomponents.WText;
 import com.github.bordertech.wcomponents.WTextField;
 import com.github.bordertech.wcomponents.examples.common.ExplanatoryText;
 import com.github.bordertech.wcomponents.examples.menu.MenuBarExample;
-import com.github.bordertech.wcomponents.layout.FlowLayout;
 import com.github.bordertech.wcomponents.layout.ListLayout;
 
 /**


### PR DESCRIPTION
Needed for V2 rationalisation to get rid of the WSection/WPanel overlap
problem.

* Deprecated unused Type.BANNER
* Deprecated useless Type.BLOCK
* Deprecated ambiguous Type.ACTION and Type.CHROME

Addresses parts of #689 and #639