### PR TITLE
Sass error

### DIFF
--- a/wcomponents-theme/src/main/sass/_wc.ui.panel.chrome.scss
+++ b/wcomponents-theme/src/main/sass/_wc.ui.panel.chrome.scss
@@ -4,7 +4,7 @@
 
 @import 'mixins-common';
 @if ($wc-ui-color-section-heading-bg != -1) {
-	.wc-panel-type-chrome h1 { // there can be only one!
+	.wc-panel-type-chrome > h1 {
 		background-color: $wc-ui-color-section-heading-bg;
 		color: $wc-ui-color-section-heading-fg;
 	}


### PR DESCRIPTION
WPanel Type CHROME header colours should have used a child selector.