### PR TITLE
Address table selection/Action issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Fixed `WTree` AJAX expansion #934, QC158631.
 * Fixed `WFieldSet` to handle `WRepeaters` correctly when Mandatory is set #936 QC158462.
 * Fixed a flaw in client code of `WSelectToggle` which could cause unexpected results if the target component(s) included a `WTable` with **single** row selection #938.
+* Fixed a flaw which could result in dialogs sometimes running partly off screen (#940).
+* Fixed an issue which could result in a WTableAction trigger button becoming enabled if disabled row(s) were selected. This is part of #943.
 
 ## Enhancements
 

--- a/wcomponents-theme/src/main/js/wc/ui/table/action.js
+++ b/wcomponents-theme/src/main/js/wc/ui/table/action.js
@@ -45,6 +45,8 @@ define(["wc/dom/event",
 				var min,
 					max,
 					table,
+					// todo: this filter can be deleted once we drop WDataTable as rows will no longer be able to be disabled
+					filter = getFilteredGroup.FILTERS.enabled | getFilteredGroup.FILTERS.selected,
 					selected = 0;
 
 				if ((table = ACTION_TABLE.findAncestor(button))) {
@@ -55,7 +57,7 @@ define(["wc/dom/event",
 						return true;
 					}
 
-					selected = (getFilteredGroup(ROW_CONTAINER.findDescendant(table))).length;
+					selected = (getFilteredGroup(ROW_CONTAINER.findDescendant(table), {filter: filter})).length;
 
 					if ((min && selected < parseInt(min, 10)) || (max && selected > parseInt(max, 10))) {
 						return false;


### PR DESCRIPTION
Fixes bug which caused WDataTable actions to be enabled if disabled rows were selected. Part of #943