### PR TITLE
Fix calendar day of week headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed a flaw which could result in dialogs sometimes running partly off screen (#940).
 * Fixed an issue which could result in a WTableAction trigger button becoming enabled if disabled row(s) were selected. This is part of #943.
 * Fixed an issue where a dialog trigger button's action could be erroneously fired by a dialog re-opening on page load #945.
+* Fixed missing "day of week column headers" in calendar date picker (#942).
 
 ## Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fixed missing "day of week column headers" in calendar date picker (#942).
 
 ## Enhancements
+* Allow TinyMCE global configuration to be overriden without a theme rebuild.
 
 # Release 1.2.9
 

--- a/wcomponents-theme/src/main/js/wc/loader/style.js
+++ b/wcomponents-theme/src/main/js/wc/loader/style.js
@@ -147,20 +147,6 @@ define(["wc/has", "wc/config", "wc/fixes"], /** @param has @param wcconfig @igno
 			 */
 			ext,
 			/**
-			 * The id of the main CSS link element produced in the XSLT. The browser specific CSS is added after this.
-			 * @var
-			 * @type {String}
-			 * @private
-			 */
-			mainCss = document.getElementById("wc_css_screen"),
-			/**
-			 * The DOM node immediately following the main CSS link element produced in the XSLT.
-			 * @var
-			 * @type {Node}
-			 * @private
-			 */
-			sibling = mainCss ? mainCss.nextSibling : null,
-			/**
 			 * The common file name used to build the CSS files with an additional DOT suffix.
 			 * The individual 'extension' extends this.;
 			 * @var
@@ -181,7 +167,7 @@ define(["wc/has", "wc/config", "wc/fixes"], /** @param has @param wcconfig @igno
 		 */
 		function addLinkElement(url, media) {
 			var head = document.head || document.getElementsByTagName("head")[0],
-				el;
+				el, sibling, mainCss;
 			if (!head) { // you gotta be kidding me ...
 				return;
 			}
@@ -191,7 +177,8 @@ define(["wc/has", "wc/config", "wc/fixes"], /** @param has @param wcconfig @igno
 				// really care if we add the link more than once but it is better to not do so.
 				return;
 			}
-
+			mainCss = instance.getMainCss();
+			sibling = mainCss ? mainCss.nextSibling : null;
 			el = document.createElement("link");
 			el.type = "text/css";
 			el.setAttribute("rel", "stylesheet");
@@ -348,6 +335,19 @@ define(["wc/has", "wc/config", "wc/fixes"], /** @param has @param wcconfig @igno
 		}
 
 		/**
+		 * Get the main CSS link element produced in the XSLT. The browser specific CSS is added after this.
+		 * @param {boolean} urlOnly If true returns only the URL of the main CSS.
+		 * @returns {Element|String} The main CSS.
+		 */
+		this.getMainCss = function(urlOnly) {
+			var mainCss = document.getElementById("wc_css_screen");
+			if (mainCss && urlOnly) {
+				return mainCss.getAttribute("href");
+			}
+			return mainCss;
+		};
+
+		/**
 		 * Write link elements for all required CSS files. Should only be called from ui:root XSLT. To add CSS from a
 		 * module use {@link module:wc/loader/style.add}.
 		 *
@@ -408,7 +408,8 @@ define(["wc/has", "wc/config", "wc/fixes"], /** @param has @param wcconfig @igno
 			}
 		};
 	}
-	return /** @alias module:wc/loader/style */ new StyleLoader();
+	var instance = new StyleLoader();
+	return /** @alias module:wc/loader/style */ instance;
 
 
 	/**

--- a/wcomponents-theme/src/main/js/wc/ui/calendar.js
+++ b/wcomponents-theme/src/main/js/wc/ui/calendar.js
@@ -501,12 +501,6 @@ function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthNam
 				template = getEmptyCalendar();
 
 			calendarProps = {
-				firstChar: function() {
-					/* Template helper, first character of text. */
-					return function(text, render) {
-						return render(text)[0];
-					};
-				},
 				dayName: dayName.get(true),
 				monthName: monthName.get(),
 				fullYear: _today.getFullYear(),
@@ -1168,6 +1162,21 @@ function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthNam
 	}
 
 	var /** @alias module:wc/ui/calendar */ instance = new Calendar();
+
+	/**
+	 * Registers a handlebars helper that takes a dayname and returns the shortest possible meaningful
+	 * abbreviation for use when building a month-view calendar as each "day of week" column header.
+	 * For example in English this suffices: M, T, W, T, F, S, S (even though S and S are theoretically
+	 * ambiguous we can tell by their relative position what they are, same with T and T).
+	 * As long as there is no language where every day of the week starts with the same letter we're golden.
+	 */
+	handlebars.registerHelper("dayColHeader", function(text) {
+		if (text && text.length) {
+			return text[0];
+		}
+		return text;
+	});
+
 	initialise.register(instance);
 	return instance;
 });

--- a/wcomponents-theme/src/main/js/wc/ui/rtf.js
+++ b/wcomponents-theme/src/main/js/wc/ui/rtf.js
@@ -8,10 +8,12 @@
  * @module
  * @requires module:wc/dom/initialise
  * @requires module:wc/config
+ * @requires module:wc/loader/style
+ * @requires module:wc/mixin
  * @requires external:tinyMCE
  */
-define(["wc/dom/initialise", "wc/config", "tinyMCE"],
-	function(initialise, wcconfig, tinyMCE) {
+define(["wc/dom/initialise", "wc/config", "wc/loader/style", "wc/mixin", "tinyMCE"],
+	function(initialise, wcconfig, styleLoader, mixin, tinyMCE) {
 		"use strict";
 
 		/**
@@ -23,15 +25,18 @@ define(["wc/dom/initialise", "wc/config", "tinyMCE"],
 		 */
 		function processNow(idArr) {
 			var id,
-				initObj = {},
+				initObj = {
+					content_css: styleLoader.getMainCss(true),
+					plugins: "autolink link image lists print preview paste"
+				},
 				config = wcconfig.get("wc/ui/rtf"),
 				setupFunc = function (editor) {
 					editor.on("change", function () {
 						editor.save();
 					});
 				};
-			if (config) {
-				initObj = config.initObj || {};
+			if (config && config.initObj) {
+				mixin(config.initObj, initObj);  // config values overwrite defaults coded here.
 			}
 
 			while ((id = idArr.shift())) {

--- a/wcomponents-theme/src/main/resource/wc.ui.dateField.calendar.html
+++ b/wcomponents-theme/src/main/resource/wc.ui.dateField.calendar.html
@@ -21,7 +21,7 @@
 		<tr>
 			{{#dayName}}
 			<th>
-				<abbr title="{{.}}">{{#firstChar}}{{.}}{{/firstChar}}</abbr>
+				<abbr title="{{.}}">{{dayColHeader .}}</abbr>
 			</th>
 			{{/dayName}}
 		</tr>

--- a/wcomponents-theme/src/main/xslt/wc.ui.root.n.tinyMCEConfig.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.root.n.tinyMCEConfig.xsl
@@ -6,11 +6,5 @@
 		Sample tinyMCE configuration 
 		**** NOTE: your config MUST start with a comma. ****
 	-->
-	<xsl:template name="tinyMCEConfig">,
-	"wc/ui/rtf": {
-		"initObj": {
-			content_css: "<xsl:value-of select="$cssFilePath"/>",
-			plugins: 'autolink link image lists print preview paste'
-		}
-	}</xsl:template>
+	<xsl:template name="tinyMCEConfig"></xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Closes #942 

Allows TinyMCE to be configured without theme rebuild (and moved some defaults from XSLT to JS).