### PR TITLE
Dialog position

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/dialogFrame.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dialogFrame.js
@@ -351,23 +351,27 @@ define(["wc/dom/event",
 			 * @private
 			 * @function
 			 * @param {Element} dialog The dialog container.
-			 * @param { module:wc/ui/dialogFrame~dto} obj The registry item that contains configuration data for this
-			 *   dialog.
+			 * @param {module:wc/ui/dialogFrame~dto} obj The registry item that contains configuration data for this dialog.
 			 */
 			function initDialogPosition(dialog, obj) {
-				var disabledAnimations;
+				var disabledAnimations, configObj;
 				try {
 					if (obj) {
+						configObj = {width: obj.width, height: obj.height, topOffsetPC: INITIAL_TOP_PROPORTION};
 						// set the initial position. If the position (top, left) is set in the config object we do not need to calculate position.
 						if (!((obj.top || obj.top === 0) && (obj.left || obj.left === 0))) {
 							if (canMoveResize()) {
 								resizeable.disableAnimation(dialog);
 								disabledAnimations = true;
-								positionable.setBySize(dialog, {width: obj.width, height: obj.height, topOffsetPC: INITIAL_TOP_PROPORTION});
+								positionable.setBySize(dialog, configObj);
 							}
 							else {
-								positionable.storePosBySize(dialog, {width: obj.width, height: obj.height, topOffsetPC: INITIAL_TOP_PROPORTION});
+								positionable.storePosBySize(dialog, configObj);
 							}
+						}
+						else if (canMoveResize()) {
+							// even if we have position we may have to re-position the dialog
+							positionable.bringIntoView(dialog, configObj);
 						}
 					}
 				}

--- a/wcomponents-theme/src/main/js/wc/ui/draggable.js
+++ b/wcomponents-theme/src/main/js/wc/ui/draggable.js
@@ -1,27 +1,3 @@
-/**
- * Provides functionality used to move a component around the screen. Components may be moved using a mouse or keyboard.
- *
- * @typedef {Object} module:wc/ui/draggable.config() Optional module configuration
- * @property {int} step The number of pixels to move the draggable element per key press.
- * @default 8
- *
- * @module
- * @requires module:wc/dom/attribute
- * @requires module:wc/dom/clearSelection
- * @requires module:wc/dom/event
- * @requires module:wc/dom/getEventOffset
- * @requires module:wc/dom/isAcceptableTarget
- * @requires module:wc/dom/getBox
- * @requires module:wc/dom/initialise
- * @requires module:wc/dom/shed
- * @requires module:wc/dom/uid
- * @requires module:wc/dom/Widget
- * @requires module:wc/has
- * @requires module:wc/ui/ajax/processResponse
- * @requires module:wc/ui/positionable
- * @requires module:wc/ui/resizeable
- * @requires module:wc/config
- */
 define(["wc/dom/attribute",
 		"wc/dom/clearSelection",
 		"wc/dom/event",
@@ -37,7 +13,6 @@ define(["wc/dom/attribute",
 		"wc/ui/positionable",
 		"wc/ui/resizeable",
 		"wc/config"],
-	/** @param attribute wc/dom/attribute @param classList wc/dom/classList @param clearSelection wc/dom/clearSelection @param event wc/dom/event @param getMouseEventOffset wc/dom/getEventOffset @param isAcceptableEventTarget wc/dom/isAcceptableTarget @param getBox wc/dom/getBox @param initialise wc/dom/initialise @param shed wc/dom/shed @param uid wc/dom/uid @param Widget wc/dom/Widget @param has wc/has @param processResponse wc/ui/ajax/processResponse @param positionable wc/ui/positionable @param wcconfig wc/config @ignore */
 	function(attribute, clearSelection, event, getMouseEventOffset, isAcceptableEventTarget, getBox, initialise, shed, uid, Widget, has, processResponse, positionable, resizeable, wcconfig) {
 		"use strict";
 
@@ -241,7 +216,6 @@ define(["wc/dom/attribute",
 						animationsDisabled = true;
 						positionable.clearZeros(element, true);
 						positionable.setPositionInView(element, left, top);
-						positionable.clearPositionBySize(id);
 					}
 				}
 				finally {
@@ -399,7 +373,31 @@ define(["wc/dom/attribute",
 			};
 		}
 
-		var /** @alias module:wc/ui/draggable */ instance = new Draggable();
+		/**
+		 * Provides functionality used to move a component around the screen. Components may be moved using a mouse or keyboard.
+		 *
+		 * @typedef {Object} module:wc/ui/draggable.config() Optional module configuration
+		 * @property {int} step The number of pixels to move the draggable element per key press.
+		 * @default 8
+		 *
+		 * @module
+		 * @requires module:wc/dom/attribute
+		 * @requires module:wc/dom/clearSelection
+		 * @requires module:wc/dom/event
+		 * @requires module:wc/dom/getEventOffset
+		 * @requires module:wc/dom/isAcceptableTarget
+		 * @requires module:wc/dom/getBox
+		 * @requires module:wc/dom/initialise
+		 * @requires module:wc/dom/shed
+		 * @requires module:wc/dom/uid
+		 * @requires module:wc/dom/Widget
+		 * @requires module:wc/has
+		 * @requires module:wc/ui/ajax/processResponse
+		 * @requires module:wc/ui/positionable
+		 * @requires module:wc/ui/resizeable
+		 * @requires module:wc/config
+		 */
+		var instance = new Draggable();
 		initialise.register(instance);
 		return instance;
 	});

--- a/wcomponents-theme/src/main/js/wc/ui/positionable.js
+++ b/wcomponents-theme/src/main/js/wc/ui/positionable.js
@@ -559,7 +559,6 @@ define(["wc/dom/attribute", "wc/dom/getViewportSize", "wc/dom/getBox", "wc/dom/g
 				}
 				if (box.top < 0) {
 					el.style.top = ZERO;
-					box = getBox(el);
 				}
 			};
 
@@ -652,6 +651,78 @@ define(["wc/dom/attribute", "wc/dom/getViewportSize", "wc/dom/getBox", "wc/dom/g
 				if (positionedBySize[id]) {
 					clearPositionBySizeKey(id);
 				}
+			};
+
+
+
+			/**
+			 * Re-set an elements position if it is currently partly or wholly out of view.
+			 *
+			 * @function module:wc/ui/positionable.bringIntoView
+			 * @public
+			 * @param {Element} el the element to reposition
+			 * @param {Object} [config] a configuration DTO
+			 * @param {number} [config.width] the width of the element
+			 * @param {number} [config.height] the height of the element
+			 * @param {number} [config.topOffsetPC] the proportion offset
+			 * @param {boolean} [config.animate] {@code true} if the element is animatable and we want to turn these off
+			 * @return {boolean} {@code true} if the element was repositioned.
+ 			 */
+			this.bringIntoView = function(el, config) {
+				var element,
+					vp,
+					box,
+					repositionNeeded,
+					disabledAnimations;
+
+				if (!el) {
+					return false;
+				}
+
+				element = (el.nodeType === Node.ELEMENT_NODE ? el : document.getElementById(el));
+
+				if (!element) {
+					return false;
+				}
+
+				if ((element.style.top && parseFloat(element.style.top) < 0) || (element.style.left && parseFloat(element.style.left) < 0)) {
+					// too far up or left from the cheap seats
+					repositionNeeded = true;
+				}
+				else {
+					box = getBox(element);
+
+					if (box.left < 0 || box.top < 0) {
+						// too far up or left
+						repositionNeeded = true;
+					}
+					else {
+						vp = getViewportSize(true);
+						if (box.right > vp.width || box.bottom > vp.height) {
+							// too far right or down
+							repositionNeeded = true;
+						}
+					}
+				}
+
+				if (repositionNeeded) {
+					try {
+						if (config && config.animate) {
+							resizeable.disableAnimation(element);
+							disabledAnimations = true;
+						}
+						instance.setBySize(element, config);
+						return true;
+					}
+					finally {
+						if (disabledAnimations) {
+							resizeable.restoreAnimation(element);
+						}
+					}
+
+				}
+
+				return false;
 			};
 		}
 

--- a/wcomponents-theme/src/main/js/wc/ui/positionable.js
+++ b/wcomponents-theme/src/main/js/wc/ui/positionable.js
@@ -450,8 +450,10 @@ define(["wc/dom/attribute", "wc/dom/getViewportSize", "wc/dom/getBox", "wc/dom/g
 				if (conf) {
 					width = conf.width;
 					height = conf.height;
-					topOffset = (conf.topOffsetPC !== undefined) ? conf.topOffsetPC : topOffset;  // if the top offset is not specified then position the element so that it is at the top of the relative component
-					leftOffset = (conf.leftOffsetPC !== undefined) ? conf.leftOffsetPC : leftOffset;  // if the left offset is not specified then position the element so that it is in the middle of the relative component
+					// if the top offset is not specified then position the element so that it is at the top of the relative component
+					topOffset = (conf.topOffsetPC !== undefined) ? conf.topOffsetPC : topOffset;
+					// if the left offset is not specified then position the element so that it is in the middle of the relative component
+					leftOffset = (conf.leftOffsetPC !== undefined) ? conf.leftOffsetPC : leftOffset;
 					relativeTo = conf.relativeTo;
 				}
 
@@ -460,7 +462,8 @@ define(["wc/dom/attribute", "wc/dom/getViewportSize", "wc/dom/getBox", "wc/dom/g
 				}
 				else {
 					relSize = getViewportSize(true);
-					func = "setPositionInView";  // when setting position relative to the viewport never let left or top be less than 0
+					// when setting position relative to the viewport never let left or top be less than 0
+					func = "setPositionInView";
 					if (!positionedBySize[id]) {
 						++positionedBySize.length;
 					}
@@ -565,10 +568,9 @@ define(["wc/dom/attribute", "wc/dom/getViewportSize", "wc/dom/getBox", "wc/dom/g
 			 * @function module:wc/ui/positionable.clearZeros
 			 * @public
 			 * @param {Element} element The element to reset.
-			 * @param {Boolean} [ignoreTopLeft] If true then do not reset top or left, just bottom and right. Why?
-			 *    because we sometimes need to keep these as they are used rather a lot elsewhere. Why not bottom and
-			 *    right? Because they are only set during collision detection or explicit pinning and are never part
-			 *    of the underlying component's default position model.
+			 * @param {Boolean} [ignoreTopLeft] If true then do not reset top or left, just bottom and right. Why? because we sometimes need to keep
+			 * these as they are used rather a lot elsewhere. Why not bottom and right? Because they are only set during collision detection or
+			 * explicit pinning and are never part of the underlying component's default position model.
 			 */
 			this.clearZeros = function(element, ignoreTopLeft) {
 				if (!ignoreTopLeft && element.style.top === ZERO) {
@@ -640,9 +642,7 @@ define(["wc/dom/attribute", "wc/dom/getViewportSize", "wc/dom/getBox", "wc/dom/g
 			};
 
 			/**
-			 * Allow any other module to clear an element from the position by size register. This is currently only
-			 * used by {@link module:wc/ui/draggable} to prevent a draggable component being repositioned by a resize
-			 * event if the user has positioned it explicitly.
+			 * Allow any other module to clear an element from the position by size register.
 			 *
 			 * @function module:wc/ui/positionable.clearPositionBySize
 			 * @public
@@ -682,30 +682,23 @@ define(["wc/dom/attribute", "wc/dom/getViewportSize", "wc/dom/getBox", "wc/dom/g
 		 * @typedef {Object} module:wc/ui/positionable~pinToConfig
 		 *
 		 * @property {bitmap} pos description a bitwise OR of {@link module:wc/ui/positionable#POS} options.
-		 * @property {Boolean} [outside] Where to pin the element in the relative element. If rue it gets pinned to
-		 *    the outside of the relative element, otherwise it gets pinned within the relative element.
-		 * @property {int} [vOffset] The vertical offset to apply to the pined element relative to the requested
-		 *    position.
-		 * @property {int} [hOffset] The horizontal offset to apply to the pined element relative to the requested
-		 *    position.
-		 */
-
-		/**
-		 * Configuration object used to set the position of an element relative to either another element or the
-		 * viewport. NOTE: if neither topOffsetPC nor leftOffsetPC are set then the element will attempt to
-		 * center itself relative to the relative element/viewport.
+		 * @property {Boolean} [outside] Where to pin the element in the relative element. If rue it gets pinned to the outside of the relative
+		 *    element, otherwise it gets pinned within the relative element.
+		 * @property {int} [vOffset] The vertical offset to apply to the pined element relative to the requested position.
+		 * @property {int} [hOffset] The horizontal offset to apply to the pined element relative to the requested position.
+		 *
+		 * Configuration object used to set the position of an element relative to either another element or the viewport. NOTE: if neither
+		 * `topOffsetPC` nor `leftOffsetPC` are set then the element will attempt to center itself relative to the relative element/viewport.
 		 *
 		 * @typedef {Object} module:wc/ui/positionable~setBySizeConfig
 		 *
 		 * @property {int} [width] The width of the element being positioned. If not set then this is calculated.
 		 * @property {int} [height] The height of the element being positioned. If not set then this is calculated.
-		 * @property {Element} [relativeTo] If set then position the element relative to this target, otherwise
-		 *    position it relative to the viewport.
-		 * @property {float} [topOffsetPC] If set then the element is positioned such that the top of the element is
-		 *    below the top of the relative element/viewport by this much if this is less than 0 then the top of the
-		 *    positioned element will be above the relative element.
-		 * @property {float} [leftOffsetPC] If set then the element is positioned such that the left edge of the
-		 *    element is to the right of the left edge of relative element/viewport by this much. If this is less
-		 *    than 0 then the left of the positioned element will be left of the left edge of the relative element.
+		 * @property {Element} [relativeTo] If set then position the element relative to this target, otherwise position it relative to the viewport.
+		 * @property {float} [topOffsetPC] If set then the element is positioned such that the top of the element is below the top of the relative
+		 *   element/viewport by this much if this is less than 0 then the top of the positioned element will be above the relative element.
+		 * @property {float} [leftOffsetPC] If set then the element is positioned such that the left edge of the element is to the right of the left
+		 *   edge of relative element/viewport by this much. If this is less than 0 then the left of the positioned element will be left of the left
+		 *   edge of the relative element.
 		 */
 	});


### PR DESCRIPTION
When a dialog is manually positioned by the user it no longer responds
to resize events. This may result in a dialog being moved out of view.
To fix this we have to always allow a dialog to reposition after a
resize event. This forms part of the fix for #958.