### PR TITLE
Dialog position

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/dialogFrame.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dialogFrame.js
@@ -80,8 +80,12 @@ define(["wc/dom/event",
 			 * @returns {Boolean} true is move/resize are supportable.
 			 */
 			function canMoveResize() {
-				var conf = wcconfig.get("wc/ui/dialogFrame"),
-					func = conf && conf.vpUtil ? conf.vpUtil : "isPhoneLike";
+				var conf,
+					func = "isPhoneLike";
+
+				if ((conf = wcconfig.get("wc/ui/dialogFrame")) && conf.vpUtil && viewportUtils[conf.vpUtil]) {
+					func = conf.vpUtil;
+				}
 				return !viewportUtils[func]();
 			}
 
@@ -351,8 +355,19 @@ define(["wc/dom/event",
 				var globalConf = wcconfig.get("wc/ui/dialogFrame"),
 					offset = INITIAL_TOP_PROPORTION;
 
-				if (globalConf && globalConf.offset && !isNaN(globalConf.offset)) {
-					offset = Math.min(1, Math.max(0, globalConf.offset));
+				if (globalConf && globalConf.offset) {
+					if (isNaN(globalConf.offset)) {
+						console.log("Offset must be a number, what are you playing at?");
+					}
+					else if (globalConf.offset <= 0) {
+						console.log("Offset must be greater than zero otherwise dialogs will be above the top of the screen.");
+					}
+					else if (globalConf.offset >= 1) {
+						console.log("Offset must be less than one otherwise dialogs will be below the bottom of the screen.");
+					}
+					else {
+						offset = globalConf.offset;
+					}
 				}
 				return {width: width, height: height, topOffsetPC: offset};
 			}

--- a/wcomponents-theme/src/main/js/wc/ui/dialogFrame.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dialogFrame.js
@@ -16,8 +16,9 @@ define(["wc/dom/event",
 	"wc/ui/draggable",
 	"wc/dom/role",
 	"lib/handlebars/handlebars",
-	"wc/ui/viewportUtils"],
-	function (event, focus, initialise, shed, tag, uid, Widget, i18n, loader, processResponse, modalShim, timers, has, resizeable, positionable, draggable, $role, handlebars, viewportUtils) {
+	"wc/ui/viewportUtils",
+	"wc/config"],
+	function (event, focus, initialise, shed, tag, uid, Widget, i18n, loader, processResponse, modalShim, timers, has, resizeable, positionable, draggable, $role, handlebars, viewportUtils, wcconfig) {
 		"use strict";
 
 		/**
@@ -79,7 +80,9 @@ define(["wc/dom/event",
 			 * @returns {Boolean} true is move/resize are supportable.
 			 */
 			function canMoveResize() {
-				return !viewportUtils.isPhoneLike();
+				var conf = wcconfig.get("wc/ui/dialogFrame"),
+					func = conf && conf.vpUtil ? conf.vpUtil : "isPhoneLike";
+				return !viewportUtils[func]();
 			}
 
 			/**
@@ -344,6 +347,16 @@ define(["wc/dom/event",
 				setUnsetDimensionsPosition(dialog);
 			}
 
+			function getResizeConfig(width, height) {
+				var globalConf = wcconfig.get("wc/ui/dialogFrame"),
+					offset = INITIAL_TOP_PROPORTION;
+
+				if (globalConf && globalConf.offset && !isNaN(globalConf.offset)) {
+					offset = Math.min(1, Math.max(0, globalConf.offset));
+				}
+				return {width: width, height: height, topOffsetPC: offset};
+			}
+
 			/**
 			 * Helper for `openDlg`.
 			 * Positions the dialog immediately after it has been opened.
@@ -357,7 +370,7 @@ define(["wc/dom/event",
 				var disabledAnimations, configObj;
 				try {
 					if (obj) {
-						configObj = {width: obj.width, height: obj.height, topOffsetPC: INITIAL_TOP_PROPORTION};
+						configObj = getResizeConfig(obj.width, obj.height);
 						// set the initial position. If the position (top, left) is set in the config object we do not need to calculate position.
 						if (!((obj.top || obj.top === 0) && (obj.left || obj.left === 0))) {
 							if (canMoveResize()) {
@@ -534,8 +547,7 @@ define(["wc/dom/event",
 				}
 
 				if (canMoveResize()) {
-					repositionTimer = timers.setTimeout(setPositionBySize, 100, dialog,
-						{width: width, height: height, topOffsetPC: INITIAL_TOP_PROPORTION});
+					repositionTimer = timers.setTimeout(setPositionBySize, 100, dialog, getResizeConfig(width, height));
 				}
 			};
 
@@ -830,6 +842,19 @@ define(["wc/dom/event",
 		 *
 		 * Dialogs are positionable, resizeable and draggable (including keyboard driven facilities for each).
 		 *
+		 * ### Configuration
+		 *
+		 * Some aspects of WDialog may be set in a configuration object {@link module:wc/ui/dialogFrame~config}. See
+		 * [the WComponents wiki](https://github.com/BorderTech/wcomponents/wiki/WDialog#client-configuration) for more information.
+		 *
+		 * @example
+		 * require(["wc/config"], function(wcconfig) {
+		 *   wcconfig.set({
+		 *     vpUtil: "isSmallScreen",
+		 *     offset: 0.25
+		 *   },"wc/ui/dialogFrame");
+		 * });
+		 *
 		 *
 		 * @module
 		 * @requires module:wc/dom/event
@@ -867,22 +892,26 @@ define(["wc/dom/event",
 		/**
 		 * @typedef {Object} module:wc/ui/dialogFrame~dto An object which stores information about a dialog.
 		 * @property {String} id The content id. If this is not set everything will fail.
-		 * @property {String} [formId] The id of the form the dialog is in (more useful than you may think). If this is not set we will use the LAST form
-		 * in the current view. You may not want this!
+		 * @property {String} [formId] The id of the form the dialog is in (more useful than you may think). If this is not set we will use the LAST
+		 *   form in the current view. You may not want this!
 		 * @property {String} openerId The ID of the control which is opening the dialog.
 		 * @property {int} [width] The dialog width in px.
 		 * @property {int} [height] The dialog height in px.
-		 * @property {int} [initWidth] The dialog width in px as set by the Java. This is used if the theme allows
-		 *    resizing but prevents a dialog being made smaller than its intial size. This property is not in the
-		 *    registration object passed in to the module.
-		 * @property {int} [initHeight] The dialog height in px as set by the Java. This is used if the theme allows
-		 *    resizing but prevents a dialog being made smaller than its intial size. This property is not in the
-		 *    registration object passed in to the module.
+		 * @property {int} [initWidth] The dialog width in px as set by the Java. This is used if the theme allows resizing but prevents a dialog
+		 *   being made smaller than its intial size. This property is not in the registration object passed in to the module.
+		 * @property {int} [initHeight] The dialog height in px as set by the Java. This is used if the theme allows resizing but prevents a dialog
+		 *   being made smaller than its intial size. This property is not in the registration object passed in to the module.
 		 * @property {Boolean} [resizeable] Is the dialog resizeable?
 		 * @property {Boolean} [modal] Is the dialog modal?
 		 * @property {String} [title] The WDialog title. If not set a default title is used.
-		 * @property {Boolean} [open] If true then the dialog is to be open on page load. This is passed in as part of
-		 *    the registration object but is not stored in the registry.
+		 * @property {Boolean} [open] If true then the dialog is to be open on page load. This is passed in as part ofthe registration object but is
+		 *   not stored in the registry.
+		 *
+		 * @typedef {Object} module:wc/ui/dialogFrame~config An object which allows override of aspects of the dialogFrame
+		 * @property {String} [vpUtil="isPhonelike"] A name of a public member of {@link module:wc/ui/viewportUtils. This should only be set if a Sass
+		 * override is used to change the point at which dialogs become full screen.
+		 * @property {number} [offset=0.33] the vertical offset to apply when opening a dialog. This must be between 0 and 1 and should be between 0.1
+		 * and 0.5.
 		 */
 
 	});

--- a/wcomponents-theme/src/main/js/wc/ui/positionable.js
+++ b/wcomponents-theme/src/main/js/wc/ui/positionable.js
@@ -653,8 +653,6 @@ define(["wc/dom/attribute", "wc/dom/getViewportSize", "wc/dom/getBox", "wc/dom/g
 				}
 			};
 
-
-
 			/**
 			 * Re-set an elements position if it is currently partly or wholly out of view.
 			 *

--- a/wcomponents-theme/src/main/js/wc/ui/viewportUtils.js
+++ b/wcomponents-theme/src/main/js/wc/ui/viewportUtils.js
@@ -8,11 +8,9 @@ define(["wc/dom/getViewportSize", "wc/config"], function (getViewportSize, wccon
 	 * @alias module:wc/ui/viewportUtils~VpUtils
 	 */
 	function VpUtils() {
+		// For device limits in Sass see _common.scss.
 
-		var conf = wcconfig.get("wc/ui/viewportUtils"),
-			// For device limits in Sass see _common.scss.
-			// The size of the largest device considered a phone: currently 773px of a Nexus 6.
-			phoneLimit = 773,
+		var phoneLimit = 773, // The size of the largest device considered a phone: currently 773px of a Nexus 6.
 			// What is the upper limit of a small screen? This could be the 768 of a iPad in portrait orientation,
 			// the 1024 of an old-school monitor or an iPad in landscape orientation or something aribrary. The default
 			// 1000 was chosen as we find some things are quite usable on a tablet in landscape but are less usable in
@@ -24,12 +22,6 @@ define(["wc/dom/getViewportSize", "wc/config"], function (getViewportSize, wccon
 			medDefinition = 1.5,
 			highDefinition = 2,
 			pixelRatio = window.devicePixelRation || 1;
-
-		if (conf) {
-			phoneLimit = conf.phone || phoneLimit;
-			smallScreenLimit = conf.small || smallScreenLimit;
-			largeScreenLimit = conf.large || largeScreenLimit;
-		}
 
 		/**
 		 * Determine if the current viewport is smaller or larger than a given limit.
@@ -61,9 +53,13 @@ define(["wc/dom/getViewportSize", "wc/config"], function (getViewportSize, wccon
 		 * @returns {Boolean} true if the viewport width is no bigger than the configured limit for a phone.
 		 */
 		this.isPhoneLike = function() {
-			return testViewportSize(phoneLimit);
+			var conf = wcconfig.get("wc/ui/viewportUtils"),
+				limit = phoneLimit;
+			if (conf && conf.phone && !isNan(conf.phone)) {
+				limit = conf.phone;
+			}
+			return testViewportSize(limit);
 		};
-
 
 		/**
 		 * Is the width of the current viewport "small"?
@@ -74,9 +70,13 @@ define(["wc/dom/getViewportSize", "wc/config"], function (getViewportSize, wccon
 		 * @returns {Boolean} true if the viewport width is no bigger than the configured limit for a small screen.
 		 */
 		this.isSmallScreen = function() {
-			return testViewportSize(smallScreenLimit);
+			var conf = wcconfig.get("wc/ui/viewportUtils"),
+				limit = smallScreenLimit;
+			if (conf && conf.small && !isNan(conf.small)) {
+				limit = conf.small;
+			}
+			return testViewportSize(limit);
 		};
-
 
 		/**
 		 * Is the width of the current viewport at least that of a large monitor?
@@ -87,7 +87,12 @@ define(["wc/dom/getViewportSize", "wc/config"], function (getViewportSize, wccon
 		 * @returns {Boolean} true if the viewport width is at least that of the configured limit for a big screen.
 		 */
 		this.isLargeScreen = function() {
-			return testViewportSize(largeScreenLimit, true);
+			var conf = wcconfig.get("wc/ui/viewportUtils"),
+				limit = largeScreenLimit;
+			if (conf && conf.large && !isNan(conf.large)) {
+				limit = conf.large;
+			}
+			return testViewportSize(limit, true);
 		};
 
 		/**
@@ -143,11 +148,23 @@ define(["wc/dom/getViewportSize", "wc/config"], function (getViewportSize, wccon
 	 * Provides utility methods regarding the current state of the viewport for use in synchronising responsive UI
 	 * manipulation with CSS media queries.
 	 *
+	 * ### Configuration
+	 *
+	 * This midule may be configured using an object {@link module:wc/ui/viewportUtils~config}.
+	 *
+	 *
 	 * @module wc/ui/viewportUtils
 	 * @requires module:wc/dom/getViewportSize
 	 * @requires module:wc/config
 	 */
 	return new VpUtils();
+
+	/**
+	 * @typedef {Object} module:wc/ui/viewportUtils~config Optional configuration for vpUtils.
+	 * @property {number} [phone=773] the pixel number representing the CSS pixel width of the largest viewport considered "phone-like"
+	 * @property {number} [small=1000] the pixel number representing the CSS pixel width of the largest viewport considered "small-screen"
+	 * @property {number} [large=1981] the pixel number representing the CSS pixel width of the smallest viewport considered "large-like"
+	 */
 });
 
 


### PR DESCRIPTION
* Fixed wcconfig use in dialogFrame, resizeable and viewportUtils as it was being called too early to be useful. Another part of #958 which was closed too soon.