### PR TITLE
Dialog open safari

### DIFF
--- a/wcomponents-theme/src/main/sass/wc.ui.dialog.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog.scss
@@ -79,10 +79,10 @@ dialog {
 @include respond-not-phonelike {
 	dialog {
 		height: auto;
-		left: auto;
+		// left: auto;
 		min-height: $wc-ui-dialog-min-height;
 		min-width: $wc-ui-dialog-min-width;
-		top: auto;
+		// top: auto;
 		width: auto;
 
 		> footer {

--- a/wcomponents-theme/src/main/sass/wc.ui.dialog.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.dialog.scss
@@ -79,10 +79,12 @@ dialog {
 @include respond-not-phonelike {
 	dialog {
 		height: auto;
-		// left: auto;
-		min-height: $wc-ui-dialog-min-height;
-		min-width: $wc-ui-dialog-min-width;
-		// top: auto;
+		@if ($wc-ui-dialog-min-height > 0) {
+			min-height: $wc-ui-dialog-min-height;
+		}
+		@if ($wc-ui-dialog-min-width > 0) {
+			min-width: $wc-ui-dialog-min-width;
+		}
 		width: auto;
 
 		> footer {


### PR DESCRIPTION
Safari (OS X) when a dialog is first opened can cause scroll. This can
be alleviated by having the default position of a dialog (top and left)
at 0 rather than auto. Part of #958