### PR TITLE
Dialog open 967

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Fixed issues which could cause resize and positioning errors in WDialog #958.
 * Fixed WDialog that was not handling its open state correctly #963 QC160323.
+* Fixed issues which could cause a WDialog to prevent refocus of the opener control when the dialog was closed #965.
+* Fixed an issue which could result in a dialog opener to _not_ open its dialog if the opener contained an image #967.
 
 ## Enhancements
 

--- a/wcomponents-theme/src/main/js/wc/ui/ajaxRegion.js
+++ b/wcomponents-theme/src/main/js/wc/ui/ajaxRegion.js
@@ -12,12 +12,6 @@ define(["wc/dom/event",
 	function(event, attribute, isSuccessfulElement, tag, Trigger, triggerManager, shed, Widget, initialise, processResponse, mixin) {
 		"use strict";
 
-		// prevent circular dependency
-		var dialog;
-		require(["wc/ui/dialog"], function (d) {
-			dialog = d;
-		});
-
 		/**
 		 * @constructor
 		 * @alias module:wc/ui/ajaxRegion~AjaxRegion
@@ -30,8 +24,6 @@ define(["wc/dom/event",
 				PSEUDO_PROTOCOL_RE = /^[\w]+\:[^\/].*$/,
 				ALIAS = "data-wc-ajaxalias",
 				ignoreChange = false;
-
-
 
 			function fireThisTrigger(element, trigger) {
 				var result = false, isSuccessful;
@@ -64,17 +56,11 @@ define(["wc/dom/event",
 			 * NOTE: all ajaxTriggers will have an attribute "data-wc-ajaxalias"
 			 */
 			function checkActivateTrigger(element) {
-				var result = false,
-					trigger;
-
-				if (dialog && dialog.isTrigger(element)) {
-					dialog.open(element);
-					result = true; // do not return, could be a dialog trigger AND an ajax trigger.
-				}
+				var trigger;
 				if ((trigger = instance.getTrigger(element, true))) {
-					result = fireThisTrigger(element, trigger);
+					return fireThisTrigger(element, trigger);
 				}
-				return result;
+				return false;
 			}
 
 			/**
@@ -129,13 +115,11 @@ define(["wc/dom/event",
 			 */
 			function clickEvent($event) {
 				var element;
-				if (!$event.defaultPrevented) {
-					BUTTON = BUTTON || new Widget(tag.BUTTON);
-					element = Widget.findAncestor($event.target, [BUTTON, ANCHOR]);
+				BUTTON = BUTTON || new Widget(tag.BUTTON);
+				element = Widget.findAncestor($event.target, [BUTTON, ANCHOR]);
 
-					if (element && !shed.isDisabled(element) && checkActivateTrigger(element) && (isSubmitElement(element) || isNavLink(element))) {
-						$event.preventDefault();
-					}
+				if (element && !shed.isDisabled(element) && checkActivateTrigger(element) && (isSubmitElement(element) || isNavLink(element))) {
+					$event.preventDefault();
 				}
 			}
 
@@ -233,11 +217,6 @@ define(["wc/dom/event",
 					loads,
 					id,
 					controls;
-
-				if (dialog && dialog.isTrigger(element)) {
-					dialog.open(element);
-				}
-				// do not return, we may still have ajax to attend to.
 
 				if (!trigger) {
 					if (obj) {

--- a/wcomponents-theme/src/main/js/wc/ui/dialog.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dialog.js
@@ -60,7 +60,7 @@ define(["wc/dom/classList",
 				if (ignoreAncestor) {
 					return null;
 				}
-				while((parent = parent.parentNode) && parent.nodeType === Node.ELEMENT_NODE) {
+				while ((parent = parent.parentNode) && parent.nodeType === Node.ELEMENT_NODE) {
 					if ((id = parent.id)) {
 						if (registry[id]) {
 							return parent;

--- a/wcomponents-theme/src/main/js/wc/ui/dialog.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dialog.js
@@ -131,7 +131,7 @@ define(["wc/dom/classList",
 
 				// Are we opening a dialog?
 				if ((_element = getTrigger(element))) {
-					dialog.open(_element);
+					instance.open(_element);
 					return true;
 				}
 

--- a/wcomponents-theme/src/main/js/wc/ui/dialog.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dialog.js
@@ -45,32 +45,6 @@ define(["wc/dom/classList",
 			}
 
 			/**
-			 * Find a dialog opener from a given start point.
-			 *
-			 * @param {Element} element the start element
-			 * @param {boolean} ignoreAncestor if {@code} true then stop without checking ancestors for a trigger
-			 * @returns {?Element} a dialog trigger element if found
-			 */
-			function getTrigger(element, ignoreAncestor) {
-				var parent = element,
-					id = parent.id;
-				if (registry[id]) {
-					return element;
-				}
-				if (ignoreAncestor) {
-					return null;
-				}
-				while ((parent = parent.parentNode) && parent.nodeType === Node.ELEMENT_NODE) {
-					if ((id = parent.id)) {
-						if (registry[id]) {
-							return parent;
-						}
-					}
-				}
-				return null;
-			}
-
-			/**
 			 * Array.forEach function to add each dialog definition object to the registry.
 			 * @see module:wc/ui/dialog#register
 			 * @function
@@ -102,7 +76,51 @@ define(["wc/dom/classList",
 			}
 
 			/**
-			 * Action click events within the dialog.
+			 * Find a dialog opener from a given start point.
+			 *
+			 * @function
+			 * @private
+			 * @param {Element} element the start element
+			 * @param {boolean} ignoreAncestor if {@code} true then stop without checking ancestors for a trigger
+			 * @returns {?Element} a dialog trigger element if found
+			 */
+			function getTrigger(element, ignoreAncestor) {
+				var parent = element,
+					id = parent.id;
+				if (registry[id]) {
+					return element;
+				}
+				if (ignoreAncestor) {
+					return null;
+				}
+				while ((parent = parent.parentNode) && parent.nodeType === Node.ELEMENT_NODE) {
+					if ((id = parent.id)) {
+						if (registry[id]) {
+							return parent;
+						}
+					}
+				}
+				return null;
+			}
+
+			/**
+			 * We need to know if an element is a submit element so that we can prevent the submit action if it opens a dialog.
+			 * @function
+			 * @private
+			 * @param {Element} element the element to test
+			 * @returns {Boolean} {@code true} if the element is a submitting element
+			 */
+			function isSubmitElement(element) {
+				var result = false,
+					type = element.type;
+				if (type === "submit" || type === "image") {
+					result = true;
+				}
+				return result;
+			}
+
+			/**
+			 * Action click events on a dialog trigger or within a dialog.
 			 * @function
 			 * @private
 			 * @param {Element} element The element which was clicked.
@@ -132,7 +150,7 @@ define(["wc/dom/classList",
 				// Are we opening a dialog?
 				if ((_element = getTrigger(element))) {
 					instance.open(_element);
-					return true;
+					return isSubmitElement(_element);
 				}
 
 				if (!(


### PR DESCRIPTION
1. Modify dialog to find a trigger from an event target rather than
assuming the target is the potential trigger.
2. Move the click listener from `wc/ui/ajaxRegion` to `wc/ui/dialog`
where it belongs. This will work into the Java change of creating a
specific DialogTrigger interface **and** allow certain triggers to be
both DialogTrigger and AjaxTrigger.

Fixes #967