### PR TITLE
DialogOpenTrigger Interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * Fixed an issue which could result in a dialog opener to _not_ open its dialog if the opener contained an image #967.
 
 ## Enhancements
+* New DialogOpenTrigger interface to identify components that can open a dialog. WDialog can also have an action
+  set via setTriggerOpenAction(action) to run when the dialog is opened via a trigger #963.
 
 # Release 1.2.11
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/DialogOpenTrigger.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/DialogOpenTrigger.java
@@ -1,0 +1,10 @@
+package com.github.bordertech.wcomponents;
+
+/**
+ * This interface is used to mark components which can open a {@link WDialog} via AJAX.
+ *
+ * @author Jonathan Austin
+ * @since 1.2.12
+ */
+public interface DialogOpenTrigger extends WComponent {
+}

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WButton.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WButton.java
@@ -28,8 +28,7 @@ import org.apache.commons.logging.LogFactory;
  * @since 1.0.0
  */
 public class WButton extends WBeanComponent implements Container, Disableable, AjaxTrigger,
-		AjaxTarget,
-		SubordinateTarget {
+		AjaxTarget, SubordinateTarget, DialogOpenTrigger {
 
 	/**
 	 * The logger instance for this class.
@@ -314,8 +313,8 @@ public class WButton extends WBeanComponent implements Container, Disableable, A
 	}
 
 	/**
-	 * Sets the button text. A button must have text even if it only displays an image. In this case the text is used
-	 * to provide a text alternative to the image.
+	 * Sets the button text. A button must have text even if it only displays an image. In this case the text is used to
+	 * provide a text alternative to the image.
 	 *
 	 * @param text the button text, using {@link MessageFormat} syntax
 	 * @param args optional arguments for the button text format string
@@ -501,20 +500,22 @@ public class WButton extends WBeanComponent implements Container, Disableable, A
 	}
 
 	/**
-	 * @return {@code true} if the button fires a client side command without causing a submit action. This is not necessarily incompatible with being
-	 * an AjaxTrigger.
+	 * @return {@code true} if the button fires a client side command without causing a submit action. This is not
+	 * necessarily incompatible with being an AjaxTrigger.
 	 */
 	public boolean isClientCommandOnly() {
 		return getComponentModel().client;
 	}
 
 	/**
-	 * Sets whether this button should fire a client command without submitting the form. What this actually does is indicates to the client that the
-	 * button element is not a submit button so a form submit will not be triggered when the button is pressed.  If the button is also an AjaxTrigger
-	 * then the Ajax request will still fire unless the custom command specifically prevents this.
+	 * Sets whether this button should fire a client command without submitting the form. What this actually does is
+	 * indicates to the client that the button element is not a submit button so a form submit will not be triggered
+	 * when the button is pressed. If the button is also an AjaxTrigger then the Ajax request will still fire unless the
+	 * custom command specifically prevents this.
 	 *
-	 * <p>If this is true then interacting with the button on the client will not submit the form. A custom command will fire if one is attached to
-	 * the button through custom JavaScript.</p>
+	 * <p>
+	 * If this is true then interacting with the button on the client will not submit the form. A custom command will
+	 * fire if one is attached to the button through custom JavaScript.</p>
 	 *
 	 * @param client indicates if the current button is to trigger a client action without a submit
 	 */
@@ -532,9 +533,8 @@ public class WButton extends WBeanComponent implements Container, Disableable, A
 	}
 
 	/**
-	 * Sets whether this button will trigger a WPopup when used. This flag is used to provide information to the
-	 * client on the button's intent. The actual invocation of the WPopup is done elsewhere, e.g. in the button's
-	 * action.
+	 * Sets whether this button will trigger a WPopup when used. This flag is used to provide information to the client
+	 * on the button's intent. The actual invocation of the WPopup is done elsewhere, e.g. in the button's action.
 	 *
 	 * <p>
 	 * This <strong>must</strong> be set on every button which has a submit action or causes an ajax action if the

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WMenuItem.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WMenuItem.java
@@ -15,7 +15,8 @@ import org.apache.commons.logging.LogFactory;
  * @author Jonathan Austin
  * @since 1.0.0
  */
-public class WMenuItem extends AbstractContainer implements Disableable, AjaxTrigger, MenuItemSelectable {
+public class WMenuItem extends AbstractContainer implements Disableable, AjaxTrigger, MenuItemSelectable,
+		DialogOpenTrigger {
 
 	/**
 	 * The logger instance for this class.

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WDialogRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WDialogRenderer.java
@@ -1,6 +1,6 @@
 package com.github.bordertech.wcomponents.render.webxml;
 
-import com.github.bordertech.wcomponents.AjaxTrigger;
+import com.github.bordertech.wcomponents.DialogOpenTrigger;
 import com.github.bordertech.wcomponents.Renderer;
 import com.github.bordertech.wcomponents.WComponent;
 import com.github.bordertech.wcomponents.WDialog;
@@ -42,10 +42,10 @@ final class WDialogRenderer extends AbstractWebXmlRenderer {
 			xml.appendOptionalAttribute("open", dialog.getState() == WDialog.ACTIVE_STATE, "true");
 			xml.appendOptionalAttribute("title", title);
 
-			AjaxTrigger trigger = dialog.getTrigger();
+			DialogOpenTrigger trigger = dialog.getTrigger();
 			if (trigger != null) {
 				xml.appendOptionalAttribute("triggerid", trigger.getId());
-				if (dialog.hasTriggerButton()) {
+				if (dialog.hasLegacyTriggerButton()) {
 					xml.appendClose();
 					trigger.paint(renderContext);
 					xml.appendEndTag("ui:dialog");

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WDialog_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WDialog_Test.java
@@ -26,7 +26,7 @@ public class WDialog_Test extends AbstractWComponentTestCase {
 		Assert.assertEquals("Default mode should be MODELESS", WDialog.MODELESS, dialog.getMode());
 		Assert.assertNull("Content is null by default", dialog.getContent());
 		Assert.assertNull("Trigger is null by default", dialog.getTrigger());
-		Assert.assertFalse("Has trigger should be false by defualt", dialog.hasTriggerButton());
+		Assert.assertFalse("Has trigger should be false by defualt", dialog.hasLegacyTriggerButton());
 	}
 
 	@Test
@@ -43,7 +43,7 @@ public class WDialog_Test extends AbstractWComponentTestCase {
 		WDialog dialog = new WDialog(wText, trigger);
 		Assert.assertEquals("Content should be set", wText, dialog.getContent());
 		Assert.assertEquals("Trigger should be set", trigger, dialog.getTrigger());
-		Assert.assertTrue("Has trigger should be true", dialog.hasTriggerButton());
+		Assert.assertTrue("Has trigger should be true", dialog.hasLegacyTriggerButton());
 	}
 
 	@Test
@@ -63,9 +63,9 @@ public class WDialog_Test extends AbstractWComponentTestCase {
 
 	@Test
 	public void testTriggerAccessors() {
-		assertAccessorsCorrect(new WDialog(), "trigger", null, new WButton(), new WCheckBox());
+		assertAccessorsCorrect(new WDialog(), "trigger", null, new WButton(), new WMenuItem("A"));
 	}
-
+	
 	@Test
 	public void testHeightAccessors() {
 		assertAccessorsCorrect(new WDialog(), "height", 0, 1, 2);
@@ -74,6 +74,11 @@ public class WDialog_Test extends AbstractWComponentTestCase {
 	@Test
 	public void testWidthAccessors() {
 		assertAccessorsCorrect(new WDialog(), "width", 0, 1, 2);
+	}
+
+	@Test
+	public void testTriggerOpenActionAccessors() {
+		assertAccessorsCorrect(new WDialog(), "triggerOpenAction", null, new TestAction(), new TestAction());
 	}
 
 	@Test

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WDialogExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WDialogExample.java
@@ -8,7 +8,6 @@ import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.WAjaxControl;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WCancelButton;
-import com.github.bordertech.wcomponents.WCheckBox;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WDefinitionList;
 import com.github.bordertech.wcomponents.WDialog;
@@ -71,6 +70,7 @@ public class WDialogExample extends WPanel implements MessageContainer {
 	 * WButton used to launch an immediate non-modal dialog.
 	 */
 	private final WDialog nonModalDialog;
+
 	/**
 	 * Creates a WDialogExample.
 	 */
@@ -207,7 +207,7 @@ public class WDialogExample extends WPanel implements MessageContainer {
 		 * Each of these opens immediately (that is, without having to reload
 		 * the underlying page).
 		 */
-		/*
+ /*
 		 * DIALOG with a TITLE
 		 * If not set explicitly, the title of a dialog is determined by the UI theme.
 		 * ALL dialogs must have a title, you probably DO NOT WANT the theme default!
@@ -292,7 +292,6 @@ public class WDialogExample extends WPanel implements MessageContainer {
 		fileUploadDialog.setWidth(600);
 		add(fileUploadDialog);
 
-
 		final WPartialDateField pdfDate = new WPartialDateField();
 		WButton dateButton = new WButton("Set Date");
 		dateButton.setAction(new Action() {
@@ -313,19 +312,8 @@ public class WDialogExample extends WPanel implements MessageContainer {
 		dateDlg.setWidth(450);
 		dateDlg.setMode(WDialog.MODAL);
 
-
 		add(dateDlg);
 		add(outputPanel);
-
-		final WDialog dialogWithOtherTrigger = new WDialog(new ViewPersonList());
-		add(dialogWithOtherTrigger);
-
-		final WCheckBox cbShowDialog = new WCheckBox();
-		WFieldLayout layout = new WFieldLayout(WFieldLayout.LAYOUT_STACKED);
-		add(layout);
-		layout.addField("Show dialog", cbShowDialog);
-
-		dialogWithOtherTrigger.setTrigger(cbShowDialog);
 	}
 
 	/**


### PR DESCRIPTION
Addresses #963.

New `DialogOpenTrigger` interface to identify components that can open a dialog.

`WDialog` can also have an action set via `setTriggerOpenAction(action)` to run when the dialog is opened via a trigger.
