### PR TITLE
Fix new error in WHeading XSLT

### DIFF
--- a/wcomponents-theme/src/main/xslt/wc.ui.heading.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.heading.xsl
@@ -20,7 +20,7 @@
 		</xsl:variable>
 		<xsl:variable name="emptyHeading">
 			<xsl:choose>
-				<xsl:when test="normalize-space($labelText) ne ''">
+				<xsl:when test="normalize-space($labelText) eq ''">
 					<xsl:number value="1"/>
 				</xsl:when>
 				<xsl:otherwise>


### PR DESCRIPTION
Error in XSLT changeover caused headings to always output the empty heading error text.