### PR TITLE
Fix WMultiFileUpload progress bars (#1000)

### DIFF
--- a/wcomponents-theme/src/main/sass/wc.ui.fileUpload.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fileUpload.scss
@@ -32,6 +32,7 @@
 	progress {
 		margin-left: $wc-gap-small;
 		margin-right: $wc-gap-small;
+		min-width: 10em; // see https://github.com/BorderTech/wcomponents/issues/1000
 	}
 
 	> .wc_filelist {


### PR DESCRIPTION
Set min-width (10em) on progress elements inside a WMultiFileUpload.
Fixes #1000.