### PR TITLE
i18n handle google translate

### DIFF
--- a/wcomponents-theme/src/main/js/wc/i18n/i18n.js
+++ b/wcomponents-theme/src/main/js/wc/i18n/i18n.js
@@ -1,8 +1,7 @@
 define(["lib/sprintf", "wc/array/toArray", "wc/config", "wc/mixin", "wc/ajax/ajax", "wc/loader/resource", "wc/template", "wc/has"],
 	function(sprintf, toArray, wcconfig, mixin, ajax, resource, template, has) {
 		"use strict";
-		var DEFAULT_LANG = "en",
-			funcTranslate;
+		var funcTranslate;
 
 		/**
 		 * Manages the loading of i18n "messages" from the relevant i18n "resource bundle".
@@ -21,12 +20,52 @@ define(["lib/sprintf", "wc/array/toArray", "wc/config", "wc/mixin", "wc/ajax/aja
 		 * @requires module:wc/template
 		 */
 		var i18next, instance = new I18n();
+
 		/**
 		 * @constructor
 		 * @alias module:wc/i18n/i18n~I18n
 		 * @private
 		 */
 		function I18n() {
+
+			var GOOG_RE = /^(.+)-x-mtfrom-(.+)$/;
+
+			/**
+			 * The language to use when no preference has been explicitly specified.
+			 * In the unlikely event this ever needs to be changed bear in mind the server
+			 * side i18n also has a similar hardcoded setting.
+			 */
+			this._DEFAULT_LANG = "en";
+
+			/**
+			 * Determine the language of the document.
+			 * @param Element [element] Optionally provide a context element which will take precedence over the documentElement.
+			 * @returns {String} the current document language.
+			 */
+			this._getLang = function(element) {
+				/*
+				 * Handles a special case for Google Tranlate, full details here: https://github.com/BorderTech/wcomponents/issues/994
+				 * Format is: toLang-x-mtfrom-fromLang
+				 */
+				var result, docElement, doc = document, googParsed;
+				if (element) {
+					result = element.lang;
+				}
+				if (!result && doc) {
+					docElement = doc.documentElement;
+					if (docElement) {
+						result = docElement.lang;  // should we consider xml:lang (which takes precedence over lang)?
+					}
+				}
+				if (!result) {
+					result = this._DEFAULT_LANG;
+				}
+				else if ((googParsed = GOOG_RE.exec(result))) {
+					result = googParsed[1];
+				}
+				return result;
+			};
+
 			/**
 			 * Initialize this module.
 			 * @function module:wc/i18n/i18n.initialize
@@ -119,36 +158,18 @@ define(["lib/sprintf", "wc/array/toArray", "wc/config", "wc/mixin", "wc/ajax/aja
 		 */
 		function getOptions(i18nConfig) {
 			var basePath = i18nConfig.basePath || resource.getResourceUrl(),
-				currentLanguage = getLang(),
+				currentLanguage = instance._getLang(),
 				defaultOptions = {
 					load: "currentOnly",
 					initImmediate: true,
 					lng: currentLanguage,
-					fallbackLng: DEFAULT_LANG,
+					fallbackLng: instance._DEFAULT_LANG,
 					backend: {
 						loadPath: basePath + "{{ns}}/{{lng}}.json"
 					}
 				},
 				result = mixin(defaultOptions, {});
 			result = mixin(i18nConfig.options, result);
-			return result;
-		}
-
-		/**
-		 * Determine the language of the document.
-		 * @returns {String} the current document language.
-		 */
-		function getLang() {
-			var result, docElement, doc = document;
-			if (doc) {
-				docElement = doc.documentElement;
-				if (docElement) {
-					result = docElement.lang;
-				}
-			}
-			if (!result) {
-				result = DEFAULT_LANG;
-			}
 			return result;
 		}
 

--- a/wcomponents-theme/src/test/intern/wc.i18n.test.js
+++ b/wcomponents-theme/src/test/intern/wc.i18n.test.js
@@ -6,9 +6,32 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils!"],
 		registerSuite({
 			name: "i18n",
 			setup: function() {
+				var lang, docEl = document.documentElement;
+				if (docEl) {
+					lang = docEl.getAttribute("lang");
+					if (lang) {
+						docEl.setAttribute("data-wci18ntest-lang", lang);
+						docEl.removeAttribute("lang");
+					}
+				}
 				return testutils.setupHelper(["wc/i18n/i18n"], function(obj) {
 					i18n = obj;
 				});
+			},
+			afterEach: function() {
+				var docEl = document.documentElement;
+				if (docEl) {
+					docEl.removeAttribute("lang");
+				}
+			},
+			teardown: function() {
+				var lang, docEl = document.documentElement;
+				if (docEl) {
+					lang = docEl.getAttribute("data-wci18ntest-lang");
+					if (lang) {
+						docEl.setAttribute("lang", lang);
+					}
+				}
 			},
 			testGet: function() {
 				/*
@@ -63,6 +86,37 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils!"],
 				assert.isTrue(result.indexOf(arg) === -1);
 				result = i18n.get(key, arg);
 				assert.isTrue(result.indexOf(arg) >= 0);
+			},
+			testGetLang: function() {
+				var actual, expected = "de", element = document.createElement("span");
+				element.setAttribute("lang", expected);
+				actual = i18n._getLang(element);
+				assert.equal(actual, expected);
+				assert.notEqual(i18n._DEFAULT_LANG, expected, "This test should not test the fallback language");
+			},
+			testGetLangDefaultFallback: function() {
+				var actual, expected = i18n._DEFAULT_LANG, element = document.createElement("span");
+				actual = i18n._getLang(element);
+				assert.equal(actual, expected);
+			},
+			testGetLangDocumentFallback: function() {
+				var actual, expected = "wc", element = document.createElement("span");
+				document.documentElement.setAttribute("lang", expected);
+				actual = i18n._getLang(element);
+				assert.equal(actual, expected);
+			},
+			testGetLangDocumentFallbackWithNoScope: function() {
+				var actual, expected = "wc";
+				document.documentElement.setAttribute("lang", expected);
+				actual = i18n._getLang();
+				assert.equal(actual, expected);
+			},
+			testGetLangGoogleTranslate: function() {
+				var actual, expected = "it", element = document.createElement("span");
+				element.setAttribute("lang", "it-x-mtfrom-en");  // see https://github.com/BorderTech/wcomponents/issues/994
+				actual = i18n._getLang(element);
+				assert.equal(actual, expected);
+				assert.notEqual(i18n._DEFAULT_LANG, expected, "This test should not test the fallback language");
 			}
 		});
 	});


### PR DESCRIPTION
Do not attempt to fetch nonsense locales generated by google translate.

Note that setting "available" language resources should be easily possible using [i18next `whitelist` init option](http://i18next.com/docs/options/). This would prevent 404s on languages where there is no available translation.

Closes #994
