### PR TITLE
Default lde launch component 1005

### DIFF
--- a/wcomponents-examples-lde/src/main/resources/wcomponents-app.properties
+++ b/wcomponents-examples-lde/src/main/resources/wcomponents-app.properties
@@ -1,2 +1,4 @@
 #Server side XSLT.
 bordertech.wcomponents.xslt.enabled=true
+#Default component
+bordertech.wcomponents.lde.component.to.launch=com.github.bordertech.wcomponents.examples.picker.ExamplePicker

--- a/wcomponents-examples-lde/src/main/resources/wcomponents-app.properties
+++ b/wcomponents-examples-lde/src/main/resources/wcomponents-app.properties
@@ -1,4 +1,4 @@
 #Server side XSLT.
 bordertech.wcomponents.xslt.enabled=true
-#Default component
+#Default component. See https://github.com/BorderTech/wcomponents/issues/1005
 bordertech.wcomponents.lde.component.to.launch=com.github.bordertech.wcomponents.examples.picker.ExamplePicker


### PR DESCRIPTION
Set the default component to launch to the pre-1.2 default string by adding it to the wcomponents-app.properties file in the
wcomponents-examples-lde project. Fixes #1005.

@jonathanaustin or @Joshua-Barclay PTAL