### PR TITLE
I18n cache buster 1016

### DIFF
--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WPanelTypeExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WPanelTypeExample.java
@@ -4,6 +4,7 @@ import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
 import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.Margin;
+import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.WAjaxControl;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WCheckBox;
@@ -147,6 +148,7 @@ public class WPanelTypeExample extends WContainer {
 		tfHeading = new WTextField();
 		selectedMenuText = new WText();
 		menu = (new MenuBarExample(selectedMenuText)).getMenu();
+		menu.addHtmlClass(HtmlClassProperties.RESPOND);
 		applyConfigButton = new WButton("Apply");
 
 		//set immutable options
@@ -192,10 +194,13 @@ public class WPanelTypeExample extends WContainer {
 			heading.setText(SAMPLE_HEADER);
 			panel.setTitleText(SAMPLE_TITLE_TEXT);
 		}
+	}
 
+	@Override
+	protected void preparePaintComponent(final Request request) {
+		super.preparePaintComponent(request);
 		boolean isHeader = panel.getType() == WPanel.Type.HEADER;
 		heading.setVisible(isHeader);
-		menu.addHtmlClass(HtmlClassProperties.RESPOND);
 		utilBar.setVisible(isHeader && showUtilBar.isSelected());
 		menu.setVisible(isHeader && showMenu.isSelected());
 		panelContentRO.setVisible(!isHeader);
@@ -205,9 +210,7 @@ public class WPanelTypeExample extends WContainer {
 	 * Add the components in the required order.
 	 */
 	private void buildUI() {
-
 		buildTargetPanel();
-
 		buildConfigOptions();
 		add(new WHorizontalRule());
 		add(panel);
@@ -231,7 +234,7 @@ public class WPanelTypeExample extends WContainer {
 	 * Set up the UI for the configuration options.
 	 */
 	private void buildConfigOptions() {
-		WFieldLayout layout = new WFieldLayout();
+		WFieldLayout layout = new WFieldLayout(WFieldLayout.LAYOUT_STACKED);
 		layout.setMargin(new Margin(0, 0, 12, 0));
 		layout.addField("Select a WPanel Type", panelType);
 		contentField = layout.addField("Panel content", panelContent);

--- a/wcomponents-theme/src/main/js/wc/i18n/i18n.js
+++ b/wcomponents-theme/src/main/js/wc/i18n/i18n.js
@@ -159,13 +159,15 @@ define(["lib/sprintf", "wc/array/toArray", "wc/config", "wc/mixin", "wc/ajax/aja
 		function getOptions(i18nConfig) {
 			var basePath = i18nConfig.basePath || resource.getResourceUrl(),
 				currentLanguage = instance._getLang(),
+				cachebuster = resource.getCacheBuster(),
+				nsResource = "{{ns}}/{{lng}}.json" + (cachebuster ? "?" + cachebuster : ""),
 				defaultOptions = {
 					load: "currentOnly",
 					initImmediate: true,
 					lng: currentLanguage,
 					fallbackLng: instance._DEFAULT_LANG,
 					backend: {
-						loadPath: basePath + "{{ns}}/{{lng}}.json"
+						loadPath: basePath + nsResource
 					}
 				},
 				result = mixin(defaultOptions, {});

--- a/wcomponents-theme/src/main/js/wc/loader/resource.js
+++ b/wcomponents-theme/src/main/js/wc/loader/resource.js
@@ -76,6 +76,18 @@ define(["wc/ajax/ajax", "wc/loader/prefetch", "wc/config", "module"],
 				return url;
 			};
 
+			/**
+			 * Allows other modules to get the cachebuster used by the resource loader.
+			 * @returns {?String} the cachebuster if present.
+			 */
+			this.getCacheBuster = function() {
+				var config = getConfig();
+				if (config && config.cachebuster) {
+					return config.cachebuster;
+				}
+				return null;
+			};
+
 			function getConfig() {
 				var config = wcconfig.get("wc/loader/resource");
 				if (!config) {


### PR DESCRIPTION
i18next caching plugin is able to use timed expiry. I have decided to
go with a querystring cachebuster using the same string as is used in
wc/resource/loader. This is because we cannot be sure that the use of
cache expiry is set correctly.

Happy to revisit this but I consider this fixes #1016.