### PR TITLE
Readonly output resolve #1029

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ## Enhancements
 
+* Output component name hint for Inputs in a read-only state to improve Selenium testing #1029.
 * Improve performance by not calling unnecessary preparePaint in DataListInterceptor #975.
 * Improve performance and type-safety of XSLT.
 

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WPasswordFieldExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WPasswordFieldExample.java
@@ -1,0 +1,64 @@
+package com.github.bordertech.wcomponents.examples;
+
+import com.github.bordertech.wcomponents.WContainer;
+import com.github.bordertech.wcomponents.WFieldLayout;
+import com.github.bordertech.wcomponents.WPasswordField;
+
+/**
+ * Shows the various properties of WPasswordField.
+ *
+ * @author Mark Reeves
+ * @since 1.3.0
+ */
+public class WPasswordFieldExample extends WContainer {
+
+	/**
+	 * Construct example.
+	 */
+	public WPasswordFieldExample() {
+		WPasswordField pwfield;
+
+		WFieldLayout layout = new WFieldLayout(WFieldLayout.LAYOUT_STACKED);
+		add(layout);
+		layout.addField("Normal input", new WPasswordField());
+
+
+		pwfield = new WPasswordField();
+		pwfield.setText("Initial value");
+		layout.addField("Normal input with value should not echo value", pwfield);
+
+		pwfield = new WPasswordField();
+		pwfield.setDisabled(true);
+		layout.addField("Disabled input", pwfield);
+
+		pwfield = new WPasswordField();
+		pwfield.setText("Initial value");
+		pwfield.setDisabled(true);
+		layout.addField("Disabled input with value should not echo value", pwfield);
+
+		pwfield = new WPasswordField();
+		pwfield.setMandatory(true);
+		layout.addField("Mandatory input", pwfield);
+
+		pwfield = new WPasswordField();
+		pwfield.setReadOnly(true);
+		layout.addField("Read only input", pwfield);
+
+		pwfield = new WPasswordField();
+		pwfield.setText("Initial value");
+		pwfield.setReadOnly(true);
+		layout.addField("Read only input with value should not echo value", pwfield);
+
+		// constraints
+		pwfield = new WPasswordField();
+		pwfield.setMaxLength(20);
+		layout.addField("Max length 20", pwfield);
+		pwfield = new WPasswordField();
+		pwfield.setMinLength(20);
+		layout.addField("Min length 20", pwfield);
+		pwfield = new WPasswordField();
+		pwfield.setPlaceholder("type here");
+		layout.addField("placeholder", pwfield);
+	}
+
+}

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/picker/ExampleData.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/picker/ExampleData.java
@@ -51,6 +51,7 @@ import com.github.bordertech.wcomponents.examples.WMultiFileWidgetAjaxExample;
 import com.github.bordertech.wcomponents.examples.WMultiSelectExample;
 import com.github.bordertech.wcomponents.examples.WNumberFieldExample;
 import com.github.bordertech.wcomponents.examples.WPanelExample;
+import com.github.bordertech.wcomponents.examples.WPasswordFieldExample;
 import com.github.bordertech.wcomponents.examples.WPopupExample;
 import com.github.bordertech.wcomponents.examples.WRadioButtonInRepeater;
 import com.github.bordertech.wcomponents.examples.WRadioButtonTriggerActionExample;
@@ -250,6 +251,7 @@ public final class ExampleData implements Serializable {
 		new ExampleData("Multi-text field", WMultiTextFieldExample.class),
 		new ExampleData("Number Field", WNumberFieldExample.class),
 		new ExampleData("Partial date field", WPartialDateFieldExample.class),
+		new ExampleData("WPasswordField", WPasswordFieldExample.class),
 		new ExampleData("Phone Number Field", WPhoneNumberFieldExample.class),
 		new ExampleData("RadioButton", WRadioButtonExample.class),
 		new ExampleData("RadioButton (action on change)", WRadioButtonTriggerActionExample.class),

--- a/wcomponents-theme/src/main/xslt/wc.common.checkableSelect.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.checkableSelect.xsl
@@ -138,6 +138,7 @@
 						</xsl:when>
 						<xsl:otherwise>
 							<xsl:call-template name="title"/>
+							<xsl:call-template name="roComponentName"/>
 						</xsl:otherwise>
 					</xsl:choose>
 

--- a/wcomponents-theme/src/main/xslt/wc.common.multiFormComponent.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.multiFormComponent.xsl
@@ -53,6 +53,7 @@
 							<xsl:value-of select="$myLabel/@id"/>
 						</xsl:attribute>
 					</xsl:if>
+					<xsl:call-template name="roComponentName"/>
 					<xsl:choose>
 						<xsl:when test="self::ui:multidropdown">
 							<xsl:apply-templates select="ui:option[@selected]|ui:optgroup[ui:option[@selected]]" mode="readOnly">

--- a/wcomponents-theme/src/main/xslt/wc.common.readOnly.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.readOnly.xsl
@@ -91,6 +91,22 @@
 					<xsl:value-of select="$label/@id"/>
 				</xsl:attribute>
 			</xsl:if>
+			<xsl:call-template name="roComponentName"/>
+			<xsl:if test="self::ui:checkbox or self::ui:radiobutton or self::ui:togglebutton or self::ui:numberfield">
+				<xsl:attribute name="data-wc-value">
+					<xsl:choose>
+						<xsl:when test="self::ui:numberfield">
+							<xsl:value-of select="text()"/>
+						</xsl:when>
+						<xsl:when test="@selected">
+							<xsl:text>true</xsl:text>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:text>false</xsl:text>
+						</xsl:otherwise>
+					</xsl:choose>
+				</xsl:attribute>
+			</xsl:if>
 			<xsl:if test="number($linkWithText) eq 1">
 				<xsl:attribute name="href">
 					<xsl:choose>
@@ -106,7 +122,7 @@
 			</xsl:if>
 			<xsl:if test="$applies ne 'none'">
 				<xsl:choose>
-					<xsl:when test="self::ui:textarea">
+					<xsl:when test="self::ui:textarea[not(ui:rtf)]">
 						<xsl:apply-templates xml:space="preserve"/>
 					</xsl:when>
 					<xsl:when test="$applies ne '' and number($useReadOnlyMode) eq 1">
@@ -124,5 +140,14 @@
 				</xsl:choose>
 			</xsl:if>
 		</xsl:element>
+	</xsl:template>
+
+	<xsl:template name="roComponentName">
+		<xsl:attribute name="data-wc-component">
+			<xsl:value-of select="local-name()"/>
+		</xsl:attribute>
+	</xsl:template>
+
+	<xsl:template name="roSelected">
 	</xsl:template>
 </xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.common.selectableList.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.selectableList.xsl
@@ -108,6 +108,7 @@
 					</xsl:if>
 					<xsl:call-template name="hideElementIfHiddenSet"/>
 					<xsl:call-template name="ajaxTarget"/>
+					<xsl:call-template name="roComponentName"/>
 					<xsl:apply-templates select="ui:option[@selected]|ui:optgroup[ui:option[@selected]]" mode="readOnly">
 						<xsl:with-param name="single" select="0"/>
 					</xsl:apply-templates>

--- a/wcomponents-theme/src/main/xslt/wc.ui.dateField.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.dateField.xsl
@@ -36,6 +36,7 @@
 							<xsl:value-of select="$myLabel/@id"/>
 						</xsl:attribute>
 					</xsl:if>
+					<xsl:call-template name="roComponentName"/>
 					<xsl:choose>
 						<xsl:when test="@date">
 							<xsl:variable name="datetimeattrib">

--- a/wcomponents-theme/src/main/xslt/wc.ui.fieldSet.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.fieldSet.xsl
@@ -10,31 +10,6 @@
 	<xsl:import href="wc.common.n.className.xsl"/>
 	<!--
 		Transform for ui:fieldset which is the XML output of WFieldSet.
-
-		Child Elements
-		* ui:decoratedlabel
-		* ui:content
-
-		Base element:
-
-		If the WFieldset has @readOnly="true" it transforms to a HTML div element; otherwise it transforms
-		to a HTML fieldset element.
-
-		Heading element:
-		A fieldset has a mandatory legend child element. When the fieldset transforms
-		to a div we test whether a heading style element is required and if so
-		(that is @frame is not 'notext' or 'none') we output a HTML div element.
-
-
-
-		This template determines the appropriate HTML element and outputs it. If the
-		frame attribute indicates there should not be a border or if the fieldSet is
-		'in error' (see {{{Error}Error State}}) then classes are set to style
-		these.
-
-		The label is determined and output then the content is applied. Finally if the
-		fieldset in in an error state the error message are output before the fieldset
-		is closed.
 	-->
 	<xsl:template match="ui:fieldset">
 		<xsl:variable name="frame">
@@ -63,35 +38,6 @@
 			<xsl:if test="$isError">
 				<xsl:call-template name="invalid"/>
 			</xsl:if>
-			<!--
-				The Legend/Label/Heading
-
-				The fieldset should be labelled with a HTML LEGEND element.
-
-				In HTML5 a FIELDSET must have a LEGEND child element. This legend provides
-				context to the form controls contained within the fieldset. For more details see
-				{{{./fieldsets.html}using fieldsets and WFieldSet}}. The WDecoratedLabel of the
-				WFieldSet (set by the constructor using the passed in java.lang.String title
-				argument or by using one of the setTitle functions) is the content of the legend.
-				It MUST be meaningful and, if setTitle(WComponent title) is used then the
-				WComponent used <<must>> meet the following conditions:
-
-				[[1]] The component must not be an interactive form component
-
-				[[2]] The component must not be empty or null, including an empty string or
-				WContainer;
-
-				[[3]] The component must output some content which is perceivable as text
-				either as a text node or a title attribute on transformed output; and
-
-				[[4]] The perceivable text content must add context to the components
-				contained within the fieldset.
-
-				When readOnly the heading element may not be output at all, depending upon the
-				value of the frame property.
-
-				The legend will always be output but may be rendered out of viewport by the frame attribute.
-			-->
 			<xsl:variable name="labelText" >
 				<xsl:value-of select="ui:decoratedlabel"/>
 				<xsl:value-of select="ui:decoratedLabel//ui:image/@alt"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.fileUpload.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.fileUpload.xsl
@@ -69,12 +69,14 @@
 			</xsl:when>
 			<xsl:otherwise>
 				<xsl:variable name="containerTag">
-					<xsl:if test="number($readOnly) ne 1">
-						<xsl:text>fieldset</xsl:text>
-					</xsl:if>
-					<xsl:if test="number($readOnly) eq 1">
-						<xsl:text>div</xsl:text>
-					</xsl:if>
+					<xsl:choose>
+						<xsl:when test="number($readOnly) eq 1">
+							<xsl:text>div</xsl:text>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:text>fieldset</xsl:text>
+						</xsl:otherwise>
+					</xsl:choose>
 				</xsl:variable>
 				<xsl:element name="{$containerTag}">
 					<xsl:call-template name="commonWrapperAttributes">
@@ -100,6 +102,7 @@
 					<xsl:choose>
 						<xsl:when test="number($readOnly) eq 1">
 							<xsl:call-template name="title"/>
+							<xsl:call-template name="roComponentName"/>
 						</xsl:when>
 						<xsl:otherwise>
 							<xsl:call-template name="makeLegend">

--- a/wcomponents-theme/src/main/xslt/wc.ui.multiSelectPair.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.multiSelectPair.xsl
@@ -1,9 +1,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="2.0">
-	<xsl:import href="wc.common.ajax.xsl"/>
-	<xsl:import href="wc.common.attributeSets.xsl"/>
 	<xsl:import href="wc.common.listSortControls.xsl"/>
 	<xsl:import href="wc.ui.multiSelectPair.n.multiSelectPairButton.xsl"/>
-	<xsl:import href="wc.common.makeLegend.xsl"/>
+	<xsl:import href="wc.common.readOnly.xsl"/>
 	<!--
 		Transform for WMultiSelectPair. This component is a mechanism to select 0 or
 		more options from a list. It is presented in a way which puts two lists side by
@@ -63,6 +61,9 @@
 				</xsl:with-param>
 				<xsl:with-param name="myLabel" select="$myLabel"/>
 			</xsl:call-template>
+			<xsl:if test="number($readOnly) eq 1">
+				<xsl:call-template name="roComponentName"/>
+			</xsl:if>
 			<xsl:choose>
 				<xsl:when test="number($readOnly) ne 1">
 					<xsl:if test="@min">

--- a/wcomponents-theme/src/main/xslt/wc.ui.numberField.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.numberField.xsl
@@ -1,5 +1,4 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="2.0">
-	<xsl:import href="wc.common.attributeSets.xsl"/>
 	<xsl:import href="wc.common.readOnly.xsl"/>
 
 	<xsl:template match="ui:numberfield">

--- a/wcomponents-theme/src/main/xslt/wc.ui.passwordfield.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.passwordfield.xsl
@@ -1,7 +1,5 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="2.0">
-	<xsl:import href="wc.common.attributeSets.xsl"/>
 	<xsl:import href="wc.common.readOnly.xsl"/>
-	<xsl:import href="wc.common.required.xsl"/>
 	<!--
 		Single line input controls which may be associated with a datalist.
    -->

--- a/wcomponents-theme/src/main/xslt/wc.ui.shuffler.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.shuffler.xsl
@@ -1,11 +1,6 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="2.0">
-	<xsl:import href="wc.common.ajax.xsl"/>
-	<xsl:import href="wc.common.attributeSets.xsl"/>
 	<xsl:import href="wc.common.listSortControls.xsl"/>
-	<xsl:import href="wc.common.missingLabel.xsl"/>
-	<xsl:import href="wc.common.title.xsl"/>
-	<xsl:import href="wc.common.makeLegend.xsl"/>
-	<xsl:import href="wc.common.n.className.xsl"/>
+	<xsl:import href="wc.common.readOnly.xsl"/>
 	<!--
 		WShuffler is a component designed to allow a fixed list of options to have their order changed.
 
@@ -34,6 +29,7 @@
 							<xsl:value-of select="$myLabel/@id"/>
 						</xsl:attribute>
 					</xsl:if>
+					<xsl:call-template name="roComponentName"/>
 					<xsl:apply-templates select="ui:option|ui:optgroup" mode="readOnly">
 						<xsl:with-param name="showOptions" select="'all'"/>
 						<xsl:with-param name="single" select="0"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.textArea.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.textArea.xsl
@@ -1,12 +1,5 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="2.0">
-	<xsl:import href="wc.common.attributeSets.xsl"/>
-	<xsl:import href="wc.common.disabledElement.xsl"/>
-	<xsl:import href="wc.common.inlineError.xsl"/>
-	<xsl:import href="wc.common.hide.xsl"/>
 	<xsl:import href="wc.common.readOnly.xsl"/>
-	<xsl:import href="wc.common.required.xsl"/>
-	<xsl:import href="wc.constants.xsl"/>
-	<xsl:import href="wc.common.missingLabel.xsl"/>
 	<!--
 		Simple transform to textarea.
 
@@ -24,20 +17,10 @@
 	-->
 	<xsl:template match="ui:textarea">
 		<xsl:variable name="id" select="@id"/>
-		<xsl:variable name="readOnly">
-			<xsl:choose>
-				<xsl:when test="@readOnly">
-					<xsl:number value="1"/>
-				</xsl:when>
-				<xsl:otherwise>
-					<xsl:number value="0"/>
-				</xsl:otherwise>
-			</xsl:choose>
-		</xsl:variable>
 		<xsl:variable name="tickerId" select="concat(@id,'_tick')"/>
 		<xsl:variable name="myLabel" select="key('labelKey',$id)"/>
 		<xsl:choose>
-			<xsl:when test="number($readOnly) eq 1">
+			<xsl:when test="@readOnly">
 				<xsl:call-template name="readOnlyControl">
 					<xsl:with-param name="label" select="$myLabel[1]"/>
 				</xsl:call-template>

--- a/wcomponents-theme/src/main/xslt/wc.ui.togglebutton.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.togglebutton.xsl
@@ -1,10 +1,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="2.0">
-	<xsl:import href="wc.common.attributeSets.xsl"/>
-	<xsl:import href="wc.common.hField.xsl"/>
 	<xsl:import href="wc.common.readOnly.xsl"/>
 	
 	<xsl:template match="ui:togglebutton">
-	
 		<xsl:variable name="id">
 			<xsl:value-of select="@id"/>
 		</xsl:variable>


### PR DESCRIPTION
1. Updated read only control XSLT to output the local name of the XML
element as a data attribute `data-wc-component`.
2. Added data attribute `data-wc-value` to read only WNumberField
exposing value; and WCheckBox, WRadioButton and WToggleButton exposing
selected state as string ‘true’ for selected or ‘false’ for unselected.
3. Added missing example of WPasswordField