### PR TITLE
Update getVisibleText and unit tests

### DIFF
--- a/wcomponents-theme/src/main/js/wc/dom/shed.js
+++ b/wcomponents-theme/src/main/js/wc/dom/shed.js
@@ -631,7 +631,7 @@ define(["wc/Observer",
 					result = !element.getAttribute(OPEN);
 				}
 				else {
-					result = !!element.getAttribute(HIDDEN);
+					result = !!element.hasAttribute(HIDDEN);
 				}
 				if (onlyHiddenAttribute || result) {
 					return result;

--- a/wcomponents-theme/src/main/js/wc/ui/getVisibleText.js
+++ b/wcomponents-theme/src/main/js/wc/ui/getVisibleText.js
@@ -1,18 +1,8 @@
-/**
- * @module
- * @requires module:wc/dom/Widget
- * @requires module:wc/dom/textContent
- * @requires module:wc/dom/shed
- * @requires module:wc/dom/getStyle
- * @requires module:wc/ui/tooltip
- */
 define(["wc/dom/Widget",
 		"wc/dom/textContent",
 		"wc/dom/shed",
-		"wc/dom/getStyle",
 		"wc/ui/tooltip"],
-	/** @param @param Widget @param textContent @param shed @param getStyle @param tooltip @ignore */
-	function(Widget, textContent, shed, getStyle, tooltip) {
+	function(Widget, textContent, shed, tooltip) {
 		"use strict";
 		var HINT;
 
@@ -26,7 +16,7 @@ define(["wc/dom/Widget",
 		 * @returns {Number} NodeFilter.FILTER_ACCEPT if the node is hidden (and can therefore be removed).
 		 */
 		function treeWalkerFilter(element) {
-			if (shed.isDisabled(element) || shed.isHidden(element)) {
+			if (shed.isHidden(element, true)) {
 				return NodeFilter.FILTER_ACCEPT;
 			}
 
@@ -77,6 +67,13 @@ define(["wc/dom/Widget",
 			removeInvisibles(clone);
 			return textContent.get(clone);
 		}
+		/*
+		 * @module
+		 * @requires module:wc/dom/Widget
+		 * @requires module:wc/dom/textContent
+		 * @requires module:wc/dom/shed
+		 * @requires module:wc/ui/tooltip
+		 */
 		return getVisibleText;
 	});
 

--- a/wcomponents-theme/src/test/intern/resources/domShed.html
+++ b/wcomponents-theme/src/test/intern/resources/domShed.html
@@ -85,4 +85,5 @@
 	<div id="visibletests">
 		<span id="visibletests1">hello<span>
 	</div>
+	<div id="hiddenhtmlsyntax" hidden>hello</div>
 </form>

--- a/wcomponents-theme/src/test/intern/wc.dom.shed.test.js
+++ b/wcomponents-theme/src/test/intern/wc.dom.shed.test.js
@@ -576,6 +576,10 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils!"],
 				finally {
 					controller.show(parent);
 				}
+			},
+			testIsHiddenHTMLSyntax: function() {
+				var element = document.getElementById("hiddenhtmlsyntax");
+				assert.isTrue(controller.isHidden(element));
 			}
 		});
 	});

--- a/wcomponents-theme/src/test/intern/wc.ui.getVisibleText.test.js
+++ b/wcomponents-theme/src/test/intern/wc.ui.getVisibleText.test.js
@@ -1,85 +1,87 @@
 define(["intern!object", "intern/chai!assert", "wc/ui/getVisibleText"],
 	function (registerSuite, assert, controller) {
-	"use strict";
+		"use strict";
 
-	var testHolder,
-		testContent = "\
-<div id='div1'>text</div>\n\
-<div id='div2'>\n\
-	<p>yes</p>\n\
-	<p>yes</p>\n\
-</div>\n\
-<div id='div3'>\n\
-	<p>yes</p>\n\
-	<p hidden>no</p>\n\
-</div>\n\
-<label id='withhint'>maincontent<span class='wc-label-hint'>hint</span></label>\n\
-<button id='withtooltip'><span role='tooltip'>H</span>hello</button>\n\
-<label id='withhinttooltip'><span role='tooltip'>M</span>maincontent<span class='wc-label-hint'>hint</span></label>\n\
-";
-	registerSuite({
-		name: "getVisibleText",
-		setup: function() {
-			testHolder = document.getElementById("testholder");
-			if (!testHolder) {
-				document.body.insertAdjacentHTML("beforeend", "<div id='testholder'></div>");
+		var testHolder,
+			testContent = "\
+<div id='div1'>text</div>\
+<div id='div2'><p>yes</p><p>yes</p></div>\
+<div id='div3'><p>yes</p><p hidden='hidden'>no</p></div>\
+<div id='div4'><p>yes</p><p hidden>no</p></div>\
+<label id='withhint'>maincontent<span class='wc-label-hint'>hint</span></label>\
+<button id='withtooltip'><span role='tooltip'>H</span>hello</button>\
+<label id='withhinttooltip'><span role='tooltip'>M</span>maincontent<span class='wc-label-hint'>hint</span></label>";
+
+		registerSuite({
+			name: "getVisibleText",
+			setup: function() {
 				testHolder = document.getElementById("testholder");
-			}
-		},
-		teardown: function (){
-			testHolder.innerHTML = "";
-		},
-		beforeEach: function() {
-			testHolder.innerHTML = testContent;
-		},
-		testGetVisibleText: function() {
-			var testId = "div1",
-				element = document.getElementById(testId),
-				expected = "text";
-			assert.strictEqual(controller(element), expected, "Did not get correct text");
+				if (!testHolder) {
+					document.body.insertAdjacentHTML("beforeend", "<div id='testholder'></div>");
+					testHolder = document.getElementById("testholder");
+				}
+			},
+			teardown: function () {
+				testHolder.innerHTML = "";
+			},
+			beforeEach: function() {
+				testHolder.innerHTML = testContent;
+			},
+			testGetVisibleText: function() {
+				var testId = "div1",
+					element = document.getElementById(testId),
+					expected = "text";
+				assert.strictEqual(controller(element), expected, "Did not get correct text");
 
-		},
-		testGetVisibleTextNested: function() {
-			var testId = "div2",
-				element = document.getElementById(testId),
-				expected = "yesyes";
-			assert.strictEqual(controller(element), expected, "Did not get correct text");
-		},
-		testGetVisibleTextNestedHidden: function() {
-			var testId = "div3",
-				element = document.getElementById(testId),
-				expected = "yes";
-			assert.strictEqual(controller(element), expected, "Did not get correct text");
-		},
-		testGetVisibleTextWithHint: function() {
-			var testId = "withhint",
-				element = document.getElementById(testId),
-				expected = "maincontent";
-			assert.strictEqual(controller(element), expected, "Did not get correct text");
-		},
-		testGetVisibleTextKeepHint: function() {
-			var testId = "withhint",
-				element = document.getElementById(testId, true),
-				expected = "maincontenthint";
-			assert.strictEqual(controller(element), expected, "Did not get correct text");
-		},
-		testGetVisibleTextWithTooltip: function() {
-			var testId = "withtooltip",
-				element = document.getElementById(testId),
-				expected = "hello";
-			assert.strictEqual(controller(element), expected, "Did not get correct text");
-		},
-		testGetVisibleTextWithHintTooltip: function() {
-			var testId = "withhinttooltip",
-				element = document.getElementById(testId),
-				expected = "maincontent";
-			assert.strictEqual(controller(element), expected, "Did not get correct text");
-		},
-		testGetVisibleTextKeepHintTooltip: function() {
-			var testId = "withhinttooltip",
-				element = document.getElementById(testId, true),
-				expected = "maincontenthint";
-			assert.strictEqual(controller(element), expected, "Did not get correct text");
-		}
-	});
-});
+			},
+			testGetVisibleTextNested: function() {
+				var testId = "div2",
+					element = document.getElementById(testId),
+					expected = "yesyes";
+				assert.strictEqual(controller(element), expected, "Did not get correct text");
+			},
+			testGetVisibleTextNestedHidden: function() {
+				var testId = "div3",
+					element = document.getElementById(testId),
+					expected = "yes";
+				assert.strictEqual(controller(element), expected, "Did not get correct text");
+			},
+			testGetVisibleTextNestedHiddenHTMLSyntax: function() {
+				var testId = "div4",
+					element = document.getElementById(testId),
+					expected = "yes";
+				assert.strictEqual(controller(element), expected, "Did not get correct text");
+			},
+			testGetVisibleTextWithHint: function() {
+				var testId = "withhint",
+					element = document.getElementById(testId),
+					expected = "maincontenthint";
+				assert.strictEqual(controller(element), expected, "Did not get correct text");
+			},
+			testGetVisibleTextRemoveHint: function() {
+				var testId = "withhint",
+					element = document.getElementById(testId),
+					expected = "maincontent";
+				assert.strictEqual(controller(element, true), expected, "Did not get correct text");
+			},
+			testGetVisibleTextWithTooltip: function() {
+				var testId = "withtooltip",
+					element = document.getElementById(testId),
+					expected = "hello";
+				assert.strictEqual(controller(element), expected, "Did not get correct text");
+			},
+			testGetVisibleTextWithHintTooltip: function() {
+				var testId = "withhinttooltip",
+					element = document.getElementById(testId),
+					expected = "maincontenthint";
+				assert.strictEqual(controller(element), expected, "Did not get correct text");
+			},
+			testGetVisibleTextKeepHintTooltip: function() {
+				var testId = "withhinttooltip",
+					element = document.getElementById(testId, true),
+					expected = "maincontent";
+				assert.strictEqual(controller(element, true), expected, "Did not get correct text");
+			}
+		});
+	}
+);

--- a/wcomponents-theme/src/test/intern/wc.ui.getVisibleText.test.js
+++ b/wcomponents-theme/src/test/intern/wc.ui.getVisibleText.test.js
@@ -1,0 +1,85 @@
+define(["intern!object", "intern/chai!assert", "wc/ui/getVisibleText"],
+	function (registerSuite, assert, controller) {
+	"use strict";
+
+	var testHolder,
+		testContent = "\
+<div id='div1'>text</div>\n\
+<div id='div2'>\n\
+	<p>yes</p>\n\
+	<p>yes</p>\n\
+</div>\n\
+<div id='div3'>\n\
+	<p>yes</p>\n\
+	<p hidden>no</p>\n\
+</div>\n\
+<label id='withhint'>maincontent<span class='wc-label-hint'>hint</span></label>\n\
+<button id='withtooltip'><span role='tooltip'>H</span>hello</button>\n\
+<label id='withhinttooltip'><span role='tooltip'>M</span>maincontent<span class='wc-label-hint'>hint</span></label>\n\
+";
+	registerSuite({
+		name: "getVisibleText",
+		setup: function() {
+			testHolder = document.getElementById("testholder");
+			if (!testHolder) {
+				document.body.insertAdjacentHTML("beforeend", "<div id='testholder'></div>");
+				testHolder = document.getElementById("testholder");
+			}
+		},
+		teardown: function (){
+			testHolder.innerHTML = "";
+		},
+		beforeEach: function() {
+			testHolder.innerHTML = testContent;
+		},
+		testGetVisibleText: function() {
+			var testId = "div1",
+				element = document.getElementById(testId),
+				expected = "text";
+			assert.strictEqual(controller(element), expected, "Did not get correct text");
+
+		},
+		testGetVisibleTextNested: function() {
+			var testId = "div2",
+				element = document.getElementById(testId),
+				expected = "yesyes";
+			assert.strictEqual(controller(element), expected, "Did not get correct text");
+		},
+		testGetVisibleTextNestedHidden: function() {
+			var testId = "div3",
+				element = document.getElementById(testId),
+				expected = "yes";
+			assert.strictEqual(controller(element), expected, "Did not get correct text");
+		},
+		testGetVisibleTextWithHint: function() {
+			var testId = "withhint",
+				element = document.getElementById(testId),
+				expected = "maincontent";
+			assert.strictEqual(controller(element), expected, "Did not get correct text");
+		},
+		testGetVisibleTextKeepHint: function() {
+			var testId = "withhint",
+				element = document.getElementById(testId, true),
+				expected = "maincontenthint";
+			assert.strictEqual(controller(element), expected, "Did not get correct text");
+		},
+		testGetVisibleTextWithTooltip: function() {
+			var testId = "withtooltip",
+				element = document.getElementById(testId),
+				expected = "hello";
+			assert.strictEqual(controller(element), expected, "Did not get correct text");
+		},
+		testGetVisibleTextWithHintTooltip: function() {
+			var testId = "withhinttooltip",
+				element = document.getElementById(testId),
+				expected = "maincontent";
+			assert.strictEqual(controller(element), expected, "Did not get correct text");
+		},
+		testGetVisibleTextKeepHintTooltip: function() {
+			var testId = "withhinttooltip",
+				element = document.getElementById(testId, true),
+				expected = "maincontenthint";
+			assert.strictEqual(controller(element), expected, "Did not get correct text");
+		}
+	});
+});


### PR DESCRIPTION
* Also updated `wc/dom/shed.isHidden` to use `hasAttribute(“hidden”)`
rather than `getAttribute(“hidden”)` so that it functions with elements
in HTML syntax not just in XHTML syntax.
* Added new test to `wc.dom.shed.test` to test for hidden using HTML
syntax
* Added new unit tests for `wc/ui/getVisibleText`