### PR TITLE
InputRenderers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Fixed an XSLT issue which could result in double-output of some HTML elements embedded in WComponents XML #1056
   (QC 162143)
 * Remove exposure of the `size` attribute when rendering `WNumberField` #1010.
+* Fixed bug which caused WMultiFileWidget to not fire its internal file-select ajax ifthe compoent is in a read-only
+  state #1060.
 
 ## Enhancements
 * Improve efficiency of `Input` renderers when the rendered input is in a read-only state #781.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@
 * Fixed a bug in modalShim which resulted in accesskeys being stripped from inside WDialog content #1051 (QC 162189).
 * Fixed an XSLT issue which could result in double-output of some HTML elements embedded in WComponents XML #1056
   (QC 162143)
+* Remove exposure of the `size` attribute when rendering `WNumberField` #1010.
 
 ## Enhancements
 * Improve efficiency of `Input` renderers when the rendered input is in a read-only state #781.
-* Remove exposure of the `size` attribute when rendering `WNumberField` #1010.
 
 # Release 1.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Fixed a bug in modalShim which resulted in accesskeys being stripped from inside WDialog content #1051.
 
 ## Enhancements
+* Improve efficiency of `Input` renderers when the rendered input is in a read-only state #781.
+* Remove exposure of the `size` attribute when rendering `WNumberField` #1010.
 
 # Release 1.3.2
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WNumberField.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WNumberField.java
@@ -380,7 +380,9 @@ public class WNumberField extends AbstractInput implements AjaxTrigger, AjaxTarg
 
 	/**
 	 * @return the width of the input field in characters.
+	 * @deprecated 1.3 size not used as it is incompatible with HTML specification.
 	 */
+	@Deprecated
 	public int getColumns() {
 		return getComponentModel().columns;
 	}
@@ -389,7 +391,9 @@ public class WNumberField extends AbstractInput implements AjaxTrigger, AjaxTarg
 	 * Sets the width of the input field in characters.
 	 *
 	 * @param columns the number of characters to display.
+	 * @deprecated 1.3 size not used as it is incompatible with HTML specification.
 	 */
+	@Deprecated
 	public void setColumns(final int columns) {
 		getOrCreateComponentModel().columns = columns;
 	}
@@ -485,7 +489,9 @@ public class WNumberField extends AbstractInput implements AjaxTrigger, AjaxTarg
 
 		/**
 		 * The number of columns to display for the field.
+		 * @deprecated 1.3 columns not used as it is incompatible with HTML specification.
 		 */
+		@Deprecated
 		private int columns;
 
 		/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WCheckBoxRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WCheckBoxRenderer.java
@@ -25,7 +25,6 @@ final class WCheckBoxRenderer extends AbstractWebXmlRenderer {
 	public void doRender(final WComponent component, final WebXmlRenderContext renderContext) {
 		WCheckBox checkBox = (WCheckBox) component;
 		XmlStringBuilder xml = renderContext.getWriter();
-		WComponent submitControl = checkBox.getDefaultSubmitButton();
 		boolean readOnly = checkBox.isReadOnly();
 
 		xml.appendTagOpen("ui:checkbox");
@@ -34,8 +33,10 @@ final class WCheckBoxRenderer extends AbstractWebXmlRenderer {
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
 		xml.appendOptionalAttribute("hidden", checkBox.isHidden(), "true");
 		xml.appendOptionalAttribute("selected", checkBox.isSelected(), "true");
-		xml.appendOptionalAttribute("readOnly", readOnly, "true");
-		if (!readOnly) {
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
+			WComponent submitControl = checkBox.getDefaultSubmitButton();
 			String submitControlId = submitControl == null ? null : submitControl.getId();
 			WComponentGroup<WCheckBox> group = checkBox.getGroup();
 			String groupName = group == null ? null : group.getId();

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WCheckBoxSelectRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WCheckBoxSelectRenderer.java
@@ -27,24 +27,29 @@ final class WCheckBoxSelectRenderer extends AbstractWebXmlRenderer {
 	public void doRender(final WComponent component, final WebXmlRenderContext renderContext) {
 		WCheckBoxSelect select = (WCheckBoxSelect) component;
 		XmlStringBuilder xml = renderContext.getWriter();
-		int tabIndex = select.getTabIndex();
 		int cols = select.getButtonColumns();
 		boolean readOnly = select.isReadOnly();
-		int min = select.getMinSelect();
-		int max = select.getMaxSelect();
 
 		xml.appendTagOpen("ui:checkboxselect");
 		xml.appendAttribute("id", component.getId());
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
-		xml.appendOptionalAttribute("disabled", select.isDisabled(), "true");
 		xml.appendOptionalAttribute("hidden", select.isHidden(), "true");
-		xml.appendOptionalAttribute("required", select.isMandatory(), "true");
-		xml.appendOptionalAttribute("readOnly", readOnly, "true");
-		xml.appendOptionalAttribute("submitOnChange", select.isSubmitOnChange(), "true");
-		xml.appendOptionalAttribute("tabIndex", component.hasTabIndex(), tabIndex);
-		xml.appendOptionalAttribute("toolTip", component.getToolTip());
-		xml.appendOptionalAttribute("accessibleText", component.getAccessibleText());
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
+			int min = select.getMinSelect();
+			int max = select.getMaxSelect();
+			int tabIndex = select.getTabIndex();
+			xml.appendOptionalAttribute("disabled", select.isDisabled(), "true");
+			xml.appendOptionalAttribute("required", select.isMandatory(), "true");
+			xml.appendOptionalAttribute("submitOnChange", select.isSubmitOnChange(), "true");
+			xml.appendOptionalAttribute("tabIndex", component.hasTabIndex(), tabIndex);
+			xml.appendOptionalAttribute("toolTip", component.getToolTip());
+			xml.appendOptionalAttribute("accessibleText", component.getAccessibleText());
+			xml.appendOptionalAttribute("min", min > 0, min);
+			xml.appendOptionalAttribute("max", max > 0, max);
+		}
 		xml.appendOptionalAttribute("frameless", select.isFrameless(), "true");
 
 		switch (select.getButtonLayout()) {
@@ -62,8 +67,6 @@ final class WCheckBoxSelectRenderer extends AbstractWebXmlRenderer {
 				throw new SystemException("Unknown layout type: " + select.getButtonLayout());
 		}
 
-		xml.appendOptionalAttribute("min", min > 0, min);
-		xml.appendOptionalAttribute("max", max > 0, max);
 
 		xml.appendClose();
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WDateFieldRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WDateFieldRenderer.java
@@ -30,37 +30,40 @@ final class WDateFieldRenderer extends AbstractWebXmlRenderer {
 	public void doRender(final WComponent component, final WebXmlRenderContext renderContext) {
 		WDateField dateField = (WDateField) component;
 		XmlStringBuilder xml = renderContext.getWriter();
+		boolean readOnly = dateField.isReadOnly();
 
-		WComponent submitControl = dateField.getDefaultSubmitButton();
-		String submitControlId = submitControl == null ? null : submitControl.getId();
 		Date date = dateField.getDate();
-		Date minDate = dateField.getMinDate();
-		Date maxDate = dateField.getMaxDate();
 
 		xml.appendTagOpen("ui:datefield");
 		xml.appendAttribute("id", component.getId());
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
-		xml.appendOptionalAttribute("disabled", dateField.isDisabled(), "true");
 		xml.appendOptionalAttribute("hidden", dateField.isHidden(), "true");
-		xml.appendOptionalAttribute("required", dateField.isMandatory(), "true");
-		xml.appendOptionalAttribute("readOnly", dateField.isReadOnly(), "true");
-		xml.appendOptionalAttribute("tabIndex", dateField.hasTabIndex(), String.valueOf(dateField.
-				getTabIndex()));
-		xml.appendOptionalAttribute("toolTip", dateField.getToolTip());
-		xml.appendOptionalAttribute("accessibleText", dateField.getAccessibleText());
-		xml.appendOptionalAttribute("buttonId", submitControlId);
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
+			xml.appendOptionalAttribute("disabled", dateField.isDisabled(), "true");
+			xml.appendOptionalAttribute("required", dateField.isMandatory(), "true");
+			xml.appendOptionalAttribute("tabIndex", dateField.hasTabIndex(), String.valueOf(dateField.getTabIndex()));
+			xml.appendOptionalAttribute("toolTip", dateField.getToolTip());
+			xml.appendOptionalAttribute("accessibleText", dateField.getAccessibleText());
+
+			WComponent submitControl = dateField.getDefaultSubmitButton();
+			String submitControlId = submitControl == null ? null : submitControl.getId();
+			xml.appendOptionalAttribute("buttonId", submitControlId);
+
+			Date minDate = dateField.getMinDate();
+			Date maxDate = dateField.getMaxDate();
+			if (minDate != null) {
+				xml.appendAttribute("min", new SimpleDateFormat(INTERNAL_DATE_FORMAT).format(minDate));
+			}
+			if (maxDate != null) {
+				xml.appendAttribute("max", new SimpleDateFormat(INTERNAL_DATE_FORMAT).format(maxDate));
+			}
+		}
 
 		if (date != null) {
 			xml.appendAttribute("date", new SimpleDateFormat(INTERNAL_DATE_FORMAT).format(date));
-		}
-
-		if (minDate != null) {
-			xml.appendAttribute("min", new SimpleDateFormat(INTERNAL_DATE_FORMAT).format(minDate));
-		}
-
-		if (maxDate != null) {
-			xml.appendAttribute("max", new SimpleDateFormat(INTERNAL_DATE_FORMAT).format(maxDate));
 		}
 
 		xml.appendClose();

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WDropdownRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WDropdownRenderer.java
@@ -39,7 +39,7 @@ final class WDropdownRenderer extends AbstractWebXmlRenderer {
 		if (readOnly) {
 			xml.appendAttribute("readOnly", "true");
 		} else {
-			xml.appendOptionalAttribute("data", dataKey != null && !readOnly, dataKey);
+			xml.appendOptionalAttribute("data", dataKey != null, dataKey);
 			xml.appendOptionalAttribute("disabled", dropdown.isDisabled(), "true");
 			xml.appendOptionalAttribute("required", dropdown.isMandatory(), "true");
 			xml.appendOptionalAttribute("submitOnChange", dropdown.isSubmitOnChange(), "true");

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WDropdownRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WDropdownRenderer.java
@@ -27,26 +27,28 @@ final class WDropdownRenderer extends AbstractWebXmlRenderer {
 	public void doRender(final WComponent component, final WebXmlRenderContext renderContext) {
 		WDropdown dropdown = (WDropdown) component;
 		XmlStringBuilder xml = renderContext.getWriter();
-		String dataKey = dropdown.getListCacheKey();
-		int optionWidth = dropdown.getOptionWidth();
 		boolean readOnly = dropdown.isReadOnly();
+		String dataKey = dropdown.getListCacheKey();
 
 		// Start tag
 		xml.appendTagOpen("ui:dropdown");
 		xml.appendAttribute("id", component.getId());
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
-		xml.appendOptionalAttribute("data", dataKey != null && !readOnly, dataKey);
-		xml.appendOptionalAttribute("disabled", dropdown.isDisabled(), "true");
 		xml.appendOptionalAttribute("hidden", dropdown.isHidden(), "true");
-		xml.appendOptionalAttribute("required", dropdown.isMandatory(), "true");
-		xml.appendOptionalAttribute("readOnly", readOnly, "true");
-		xml.appendOptionalAttribute("submitOnChange", dropdown.isSubmitOnChange(), "true");
-		xml.appendOptionalAttribute("tabindex", component.hasTabIndex(), component.getTabIndex());
-		xml.appendOptionalAttribute("toolTip", dropdown.getToolTip());
-		xml.appendOptionalAttribute("accessibleText", dropdown.getAccessibleText());
-		xml.appendOptionalAttribute("optionWidth", optionWidth > 0, optionWidth);
-		xml.appendOptionalAttribute("type", getTypeAsString(dropdown.getType()));
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
+			xml.appendOptionalAttribute("data", dataKey != null && !readOnly, dataKey);
+			xml.appendOptionalAttribute("disabled", dropdown.isDisabled(), "true");
+			xml.appendOptionalAttribute("submitOnChange", dropdown.isSubmitOnChange(), "true");
+			xml.appendOptionalAttribute("tabindex", component.hasTabIndex(), component.getTabIndex());
+			xml.appendOptionalAttribute("toolTip", dropdown.getToolTip());
+			xml.appendOptionalAttribute("accessibleText", dropdown.getAccessibleText());
+			int optionWidth = dropdown.getOptionWidth();
+			xml.appendOptionalAttribute("optionWidth", optionWidth > 0, optionWidth);
+			xml.appendOptionalAttribute("type", getTypeAsString(dropdown.getType()));
+		}
 		xml.appendClose();
 
 		// Options

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WDropdownRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WDropdownRenderer.java
@@ -41,6 +41,7 @@ final class WDropdownRenderer extends AbstractWebXmlRenderer {
 		} else {
 			xml.appendOptionalAttribute("data", dataKey != null && !readOnly, dataKey);
 			xml.appendOptionalAttribute("disabled", dropdown.isDisabled(), "true");
+			xml.appendOptionalAttribute("required", dropdown.isMandatory(), "true");
 			xml.appendOptionalAttribute("submitOnChange", dropdown.isSubmitOnChange(), "true");
 			xml.appendOptionalAttribute("tabindex", component.hasTabIndex(), component.getTabIndex());
 			xml.appendOptionalAttribute("toolTip", dropdown.getToolTip());

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WEmailFieldRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WEmailFieldRenderer.java
@@ -25,16 +25,17 @@ class WEmailFieldRenderer extends AbstractWebXmlRenderer {
 	public void doRender(final WComponent component, final WebXmlRenderContext renderContext) {
 		WEmailField field = (WEmailField) component;
 		XmlStringBuilder xml = renderContext.getWriter();
-		boolean isReadOnly = field.isReadOnly();
+		boolean readOnly = field.isReadOnly();
 
 		xml.appendTagOpen("ui:emailfield");
 		xml.appendAttribute("id", component.getId());
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
 		xml.appendOptionalAttribute("hidden", component.isHidden(), "true");
-		xml.appendOptionalAttribute("readOnly", isReadOnly, "true");
 
-		if (!isReadOnly) {
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
 			int cols = field.getColumns();
 			int maxLength = field.getMaxLength();
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WFileWidgetRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WFileWidgetRenderer.java
@@ -25,24 +25,27 @@ final class WFileWidgetRenderer extends AbstractWebXmlRenderer {
 	public void doRender(final WComponent component, final WebXmlRenderContext renderContext) {
 		WFileWidget fileWidget = (WFileWidget) component;
 		XmlStringBuilder xml = renderContext.getWriter();
+		boolean readOnly = fileWidget.isReadOnly();
 		long maxFileSize = fileWidget.getMaxFileSize();
 
 		xml.appendTagOpen("ui:fileupload");
 		xml.appendAttribute("id", component.getId());
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
-		xml.appendOptionalAttribute("disabled", fileWidget.isDisabled(), "true");
 		xml.appendOptionalAttribute("hidden", component.isHidden(), "true");
-		xml.appendOptionalAttribute("required", fileWidget.isMandatory(), "true");
-		xml.appendOptionalAttribute("readOnly", fileWidget.isReadOnly(), "true");
-		xml.appendOptionalAttribute("tabIndex", fileWidget.hasTabIndex(), fileWidget.getTabIndex());
-		xml.appendOptionalAttribute("toolTip", fileWidget.getToolTip());
-		xml.appendOptionalAttribute("accessibleText", fileWidget.getAccessibleText());
-		xml.appendOptionalAttribute("acceptedMimeTypes", typesToString(fileWidget.getFileTypes()));
-		xml.appendOptionalAttribute("maxFileSize", maxFileSize > 0, maxFileSize);
-		xml.appendAttribute("maxFiles", "1");
-		xml.appendAttribute("async", "false");
-
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
+			xml.appendOptionalAttribute("disabled", fileWidget.isDisabled(), "true");
+			xml.appendOptionalAttribute("required", fileWidget.isMandatory(), "true");
+			xml.appendOptionalAttribute("tabIndex", fileWidget.hasTabIndex(), fileWidget.getTabIndex());
+			xml.appendOptionalAttribute("toolTip", fileWidget.getToolTip());
+			xml.appendOptionalAttribute("accessibleText", fileWidget.getAccessibleText());
+			xml.appendOptionalAttribute("acceptedMimeTypes", typesToString(fileWidget.getFileTypes()));
+			xml.appendOptionalAttribute("maxFileSize", maxFileSize > 0, maxFileSize);
+			xml.appendAttribute("maxFiles", "1");
+			xml.appendAttribute("async", "false");
+		}
 		xml.appendEnd();
 	}
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WMultiDropdownRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WMultiDropdownRenderer.java
@@ -27,26 +27,29 @@ final class WMultiDropdownRenderer extends AbstractWebXmlRenderer {
 		WMultiDropdown dropdown = (WMultiDropdown) component;
 		XmlStringBuilder xml = renderContext.getWriter();
 		String dataKey = dropdown.getListCacheKey();
-		int tabIndex = dropdown.getTabIndex();
 		boolean readOnly = dropdown.isReadOnly();
-		int min = dropdown.getMinSelect();
-		int max = dropdown.getMaxSelect();
 
 		xml.appendTagOpen("ui:multidropdown");
 		xml.appendAttribute("id", component.getId());
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
-		xml.appendOptionalAttribute("data", dataKey != null && !readOnly, dataKey);
-		xml.appendOptionalAttribute("disabled", dropdown.isDisabled(), "true");
 		xml.appendOptionalAttribute("hidden", dropdown.isHidden(), "true");
-		xml.appendOptionalAttribute("required", dropdown.isMandatory(), "true");
-		xml.appendOptionalAttribute("readOnly", readOnly, "true");
-		xml.appendOptionalAttribute("submitOnChange", dropdown.isSubmitOnChange(), "true");
-		xml.appendOptionalAttribute("tabIndex", component.hasTabIndex(), tabIndex);
-		xml.appendOptionalAttribute("toolTip", component.getToolTip());
-		xml.appendOptionalAttribute("accessibleText", component.getAccessibleText());
-		xml.appendOptionalAttribute("min", min > 0, min);
-		xml.appendOptionalAttribute("max", max > 0, max);
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
+			xml.appendOptionalAttribute("data", dataKey != null && !readOnly, dataKey);
+			xml.appendOptionalAttribute("disabled", dropdown.isDisabled(), "true");
+			xml.appendOptionalAttribute("required", dropdown.isMandatory(), "true");
+			xml.appendOptionalAttribute("submitOnChange", dropdown.isSubmitOnChange(), "true");
+			int tabIndex = dropdown.getTabIndex();
+			xml.appendOptionalAttribute("tabIndex", component.hasTabIndex(), tabIndex);
+			xml.appendOptionalAttribute("toolTip", component.getToolTip());
+			xml.appendOptionalAttribute("accessibleText", component.getAccessibleText());
+			int min = dropdown.getMinSelect();
+			int max = dropdown.getMaxSelect();
+			xml.appendOptionalAttribute("min", min > 0, min);
+			xml.appendOptionalAttribute("max", max > 0, max);
+		}
 
 		xml.appendClose();
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WMultiFileWidgetRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WMultiFileWidgetRenderer.java
@@ -68,12 +68,12 @@ final class WMultiFileWidgetRenderer extends AbstractWebXmlRenderer {
 					xml.appendAttribute("camera", true);
 				}
 			}
-			if (widget.getFileAjaxAction() != null) {
-				xml.appendAttribute("ajax", "true");
-			}
 		}
 		if (widget.getColumns() != null) {
 			xml.appendAttribute("cols", widget.getColumns());
+		}
+		if (widget.getFileAjaxAction() != null) {
+			xml.appendAttribute("ajax", "true");
 		}
 
 		if (widget.getFiles().isEmpty()) {

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WMultiFileWidgetRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WMultiFileWidgetRenderer.java
@@ -35,40 +35,45 @@ final class WMultiFileWidgetRenderer extends AbstractWebXmlRenderer {
 			handleFileUploadRequest(widget, xml, uploadId);
 			return;
 		}
+		boolean readOnly = widget.isReadOnly();
 
-		long maxFileSize = widget.getMaxFileSize();
-		int maxFiles = widget.getMaxFiles();
-		WComponent dropzone = widget.getDropzone();
-		WImageEditor editor = widget.getEditor();
 
 		xml.appendTagOpen("ui:fileupload");
 		xml.appendAttribute("id", component.getId());
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
-		xml.appendOptionalAttribute("disabled", widget.isDisabled(), "true");
 		xml.appendOptionalAttribute("hidden", widget.isHidden(), "true");
-		xml.appendOptionalAttribute("required", widget.isMandatory(), "true");
-		xml.appendOptionalAttribute("readOnly", widget.isReadOnly(), "true");
-		xml.appendOptionalAttribute("tabIndex", widget.hasTabIndex(), widget.getTabIndex());
-		xml.appendOptionalAttribute("toolTip", widget.getToolTip());
-		xml.appendOptionalAttribute("accessibleText", widget.getAccessibleText());
-		xml.appendOptionalAttribute("acceptedMimeTypes", typesToString(widget.getFileTypes()));
-		xml.appendOptionalAttribute("maxFileSize", maxFileSize > 0, maxFileSize);
-		xml.appendOptionalAttribute("maxFiles", maxFiles > 0, maxFiles);
-		if (widget.getColumns() != null) {
-			xml.appendAttribute("cols", widget.getColumns());
-		}
-		if (dropzone != null) {
-			xml.appendAttribute("dropzone", dropzone.getId());
-		}
-		if (editor != null) {
-			xml.appendAttribute("editor", editor.getId());
-			if (editor.getUseCamera()) {
-				xml.appendAttribute("camera", true);
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
+			long maxFileSize = widget.getMaxFileSize();
+			int maxFiles = widget.getMaxFiles();
+			WComponent dropzone = widget.getDropzone();
+			WImageEditor editor = widget.getEditor();
+
+			xml.appendOptionalAttribute("disabled", widget.isDisabled(), "true");
+			xml.appendOptionalAttribute("required", widget.isMandatory(), "true");
+			xml.appendOptionalAttribute("tabIndex", widget.hasTabIndex(), widget.getTabIndex());
+			xml.appendOptionalAttribute("toolTip", widget.getToolTip());
+			xml.appendOptionalAttribute("accessibleText", widget.getAccessibleText());
+			xml.appendOptionalAttribute("acceptedMimeTypes", typesToString(widget.getFileTypes()));
+			xml.appendOptionalAttribute("maxFileSize", maxFileSize > 0, maxFileSize);
+			xml.appendOptionalAttribute("maxFiles", maxFiles > 0, maxFiles);
+			if (dropzone != null) {
+				xml.appendAttribute("dropzone", dropzone.getId());
+			}
+			if (editor != null) {
+				xml.appendAttribute("editor", editor.getId());
+				if (editor.getUseCamera()) {
+					xml.appendAttribute("camera", true);
+				}
+			}
+			if (widget.getFileAjaxAction() != null) {
+				xml.appendAttribute("ajax", "true");
 			}
 		}
-		if (widget.getFileAjaxAction() != null) {
-			xml.appendAttribute("ajax", "true");
+		if (widget.getColumns() != null) {
+			xml.appendAttribute("cols", widget.getColumns());
 		}
 
 		if (widget.getFiles().isEmpty()) {

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WMultiSelectPairRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WMultiSelectPairRenderer.java
@@ -30,27 +30,29 @@ final class WMultiSelectPairRenderer extends AbstractWebXmlRenderer {
 	public void doRender(final WComponent component, final WebXmlRenderContext renderContext) {
 		WMultiSelectPair multiSelectPair = (WMultiSelectPair) component;
 		XmlStringBuilder xml = renderContext.getWriter();
-		boolean disabled = multiSelectPair.isDisabled();
 		boolean readOnly = multiSelectPair.isReadOnly();
-		int rows = multiSelectPair.getRows();
-		int min = multiSelectPair.getMinSelect();
-		int max = multiSelectPair.getMaxSelect();
 
 		xml.appendTagOpen("ui:multiselectpair");
 		xml.appendAttribute("id", component.getId());
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
-		xml.appendAttribute("size", rows < 2 ? WMultiSelectPair.DEFAULT_ROWS : rows);
-		xml.appendOptionalAttribute("disabled", disabled, "true");
 		xml.appendOptionalAttribute("hidden", multiSelectPair.isHidden(), "true");
-		xml.appendOptionalAttribute("required", multiSelectPair.isMandatory(), "true");
-		xml.appendOptionalAttribute("readOnly", readOnly, "true");
-		xml.appendOptionalAttribute("shuffle", multiSelectPair.isShuffle(), "true");
-		xml.appendOptionalAttribute("fromListName", multiSelectPair.getAvailableListName());
-		xml.appendOptionalAttribute("toListName", multiSelectPair.getSelectedListName());
-		xml.appendOptionalAttribute("accessibleText", multiSelectPair.getAccessibleText());
-		xml.appendOptionalAttribute("min", min > 0, min);
-		xml.appendOptionalAttribute("max", max > 0, max);
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
+			int rows = multiSelectPair.getRows();
+			int min = multiSelectPair.getMinSelect();
+			int max = multiSelectPair.getMaxSelect();
+			xml.appendAttribute("size", rows < 2 ? WMultiSelectPair.DEFAULT_ROWS : rows);
+			xml.appendOptionalAttribute("disabled", multiSelectPair.isDisabled(), "true");
+			xml.appendOptionalAttribute("required", multiSelectPair.isMandatory(), "true");
+			xml.appendOptionalAttribute("shuffle", multiSelectPair.isShuffle(), "true");
+			xml.appendOptionalAttribute("fromListName", multiSelectPair.getAvailableListName());
+			xml.appendOptionalAttribute("toListName", multiSelectPair.getSelectedListName());
+			xml.appendOptionalAttribute("accessibleText", multiSelectPair.getAccessibleText());
+			xml.appendOptionalAttribute("min", min > 0, min);
+			xml.appendOptionalAttribute("max", max > 0, max);
+		}
 		xml.appendClose();
 
 		// Options

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WMultiSelectRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WMultiSelectRenderer.java
@@ -35,18 +35,21 @@ final class WMultiSelectRenderer extends AbstractWebXmlRenderer {
 		xml.appendAttribute("id", component.getId());
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
-		xml.appendOptionalAttribute("data", dataKey != null && !readOnly, dataKey);
-		xml.appendOptionalAttribute("disabled", listBox.isDisabled(), "true");
 		xml.appendOptionalAttribute("hidden", listBox.isHidden(), "true");
-		xml.appendOptionalAttribute("required", listBox.isMandatory(), "true");
-		xml.appendOptionalAttribute("readOnly", readOnly, "true");
-		xml.appendOptionalAttribute("submitOnChange", listBox.isSubmitOnChange(), "true");
-		xml.appendOptionalAttribute("tabIndex", component.hasTabIndex(), listBox.getTabIndex());
-		xml.appendOptionalAttribute("toolTip", component.getToolTip());
-		xml.appendOptionalAttribute("accessibleText", component.getAccessibleText());
-		xml.appendOptionalAttribute("rows", rows >= 2, rows);
-		xml.appendOptionalAttribute("min", min > 0, min);
-		xml.appendOptionalAttribute("max", max > 0, max);
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
+			xml.appendOptionalAttribute("data", dataKey != null && !readOnly, dataKey);
+			xml.appendOptionalAttribute("disabled", listBox.isDisabled(), "true");
+			xml.appendOptionalAttribute("required", listBox.isMandatory(), "true");
+			xml.appendOptionalAttribute("submitOnChange", listBox.isSubmitOnChange(), "true");
+			xml.appendOptionalAttribute("tabIndex", component.hasTabIndex(), listBox.getTabIndex());
+			xml.appendOptionalAttribute("toolTip", component.getToolTip());
+			xml.appendOptionalAttribute("accessibleText", component.getAccessibleText());
+			xml.appendOptionalAttribute("rows", rows >= 2, rows);
+			xml.appendOptionalAttribute("min", min > 0, min);
+			xml.appendOptionalAttribute("max", max > 0, max);
+		}
 		xml.appendClose();
 
 		// Options

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WMultiTextFieldRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WMultiTextFieldRenderer.java
@@ -27,7 +27,7 @@ class WMultiTextFieldRenderer extends AbstractWebXmlRenderer {
 		WMultiTextField textField = (WMultiTextField) component;
 		XmlStringBuilder xml = renderContext.getWriter();
 
-		boolean isReadOnly = textField.isReadOnly();
+		boolean readOnly = textField.isReadOnly();
 
 		String[] values = textField.getTextInputs();
 
@@ -36,9 +36,10 @@ class WMultiTextFieldRenderer extends AbstractWebXmlRenderer {
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
 		xml.appendOptionalAttribute("hidden", textField.isHidden(), "true");
-		xml.appendOptionalAttribute("readOnly", isReadOnly, "true");
 
-		if (!isReadOnly) {
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
 			int cols = textField.getColumns();
 			int minLength = textField.getMinLength();
 			int maxLength = textField.getMaxLength();

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WNumberFieldRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WNumberFieldRenderer.java
@@ -24,13 +24,8 @@ final class WNumberFieldRenderer extends AbstractWebXmlRenderer {
 	public void doRender(final WComponent component, final WebXmlRenderContext renderContext) {
 		WNumberField field = (WNumberField) component;
 		XmlStringBuilder xml = renderContext.getWriter();
-		WComponent submitControl = field.getDefaultSubmitButton();
-		String submitControlId = submitControl == null ? null : submitControl.getId();
-		BigDecimal min = field.getMinValue();
-		BigDecimal max = field.getMaxValue();
-		BigDecimal step = field.getStep();
-		int cols = field.getColumns();
-		int decimals = field.getDecimalPlaces();
+		boolean readOnly = field.isReadOnly();
+
 		BigDecimal value = field.getValue();
 		String userText = field.getText();
 
@@ -38,19 +33,29 @@ final class WNumberFieldRenderer extends AbstractWebXmlRenderer {
 		xml.appendAttribute("id", component.getId());
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
-		xml.appendOptionalAttribute("disabled", field.isDisabled(), "true");
 		xml.appendOptionalAttribute("hidden", component.isHidden(), "true");
-		xml.appendOptionalAttribute("required", field.isMandatory(), "true");
-		xml.appendOptionalAttribute("readOnly", field.isReadOnly(), "true");
-		xml.appendOptionalAttribute("size", cols > 0, cols);
-		xml.appendOptionalAttribute("tabIndex", field.hasTabIndex(), field.getTabIndex());
-		xml.appendOptionalAttribute("toolTip", field.getToolTip());
-		xml.appendOptionalAttribute("accessibleText", field.getAccessibleText());
-		xml.appendOptionalAttribute("min", min != null, String.valueOf(min));
-		xml.appendOptionalAttribute("max", max != null, String.valueOf(max));
-		xml.appendOptionalAttribute("step", step != null, String.valueOf(step));
-		xml.appendOptionalAttribute("decimals", decimals > 0, decimals);
-		xml.appendOptionalAttribute("buttonId", submitControlId);
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
+			WComponent submitControl = field.getDefaultSubmitButton();
+			String submitControlId = submitControl == null ? null : submitControl.getId();
+			BigDecimal min = field.getMinValue();
+			BigDecimal max = field.getMaxValue();
+			BigDecimal step = field.getStep();
+			int cols = field.getColumns();
+			int decimals = field.getDecimalPlaces();
+			xml.appendOptionalAttribute("disabled", field.isDisabled(), "true");
+			xml.appendOptionalAttribute("required", field.isMandatory(), "true");
+			xml.appendOptionalAttribute("size", cols > 0, cols);
+			xml.appendOptionalAttribute("tabIndex", field.hasTabIndex(), field.getTabIndex());
+			xml.appendOptionalAttribute("toolTip", field.getToolTip());
+			xml.appendOptionalAttribute("accessibleText", field.getAccessibleText());
+			xml.appendOptionalAttribute("min", min != null, String.valueOf(min));
+			xml.appendOptionalAttribute("max", max != null, String.valueOf(max));
+			xml.appendOptionalAttribute("step", step != null, String.valueOf(step));
+			xml.appendOptionalAttribute("decimals", decimals > 0, decimals);
+			xml.appendOptionalAttribute("buttonId", submitControlId);
+		}
 
 		xml.appendClose();
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WNumberFieldRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WNumberFieldRenderer.java
@@ -46,7 +46,6 @@ final class WNumberFieldRenderer extends AbstractWebXmlRenderer {
 			int decimals = field.getDecimalPlaces();
 			xml.appendOptionalAttribute("disabled", field.isDisabled(), "true");
 			xml.appendOptionalAttribute("required", field.isMandatory(), "true");
-			xml.appendOptionalAttribute("size", cols > 0, cols);
 			xml.appendOptionalAttribute("tabIndex", field.hasTabIndex(), field.getTabIndex());
 			xml.appendOptionalAttribute("toolTip", field.getToolTip());
 			xml.appendOptionalAttribute("accessibleText", field.getAccessibleText());

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WNumberFieldRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WNumberFieldRenderer.java
@@ -42,7 +42,6 @@ final class WNumberFieldRenderer extends AbstractWebXmlRenderer {
 			BigDecimal min = field.getMinValue();
 			BigDecimal max = field.getMaxValue();
 			BigDecimal step = field.getStep();
-			int cols = field.getColumns();
 			int decimals = field.getDecimalPlaces();
 			xml.appendOptionalAttribute("disabled", field.isDisabled(), "true");
 			xml.appendOptionalAttribute("required", field.isMandatory(), "true");

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WPartialDateFieldRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WPartialDateFieldRenderer.java
@@ -24,25 +24,29 @@ final class WPartialDateFieldRenderer extends AbstractWebXmlRenderer {
 	public void doRender(final WComponent component, final WebXmlRenderContext renderContext) {
 		WPartialDateField dateField = (WPartialDateField) component;
 		XmlStringBuilder xml = renderContext.getWriter();
+		boolean readOnly = dateField.isReadOnly();
 
-		WComponent submitControl = dateField.getDefaultSubmitButton();
-		String submitControlId = submitControl == null ? null : submitControl.getId();
 		String date = formatDate(dateField);
 
 		xml.appendTagOpen("ui:datefield");
 		xml.appendAttribute("id", component.getId());
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
-		xml.appendAttribute("allowPartial", "true");
-		xml.appendOptionalAttribute("disabled", dateField.isDisabled(), "true");
 		xml.appendOptionalAttribute("hidden", dateField.isHidden(), "true");
-		xml.appendOptionalAttribute("required", dateField.isMandatory(), "true");
-		xml.appendOptionalAttribute("readOnly", dateField.isReadOnly(), "true");
-		xml.appendOptionalAttribute("tabIndex", dateField.hasTabIndex(), dateField.getTabIndex());
-		xml.appendOptionalAttribute("toolTip", dateField.getToolTip());
-		xml.appendOptionalAttribute("accessibleText", dateField.getAccessibleText());
-		xml.appendOptionalAttribute("buttonId", submitControlId);
 		xml.appendOptionalAttribute("date", date);
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
+			xml.appendAttribute("allowPartial", "true");
+			xml.appendOptionalAttribute("disabled", dateField.isDisabled(), "true");
+			xml.appendOptionalAttribute("required", dateField.isMandatory(), "true");
+			xml.appendOptionalAttribute("tabIndex", dateField.hasTabIndex(), dateField.getTabIndex());
+			xml.appendOptionalAttribute("toolTip", dateField.getToolTip());
+			xml.appendOptionalAttribute("accessibleText", dateField.getAccessibleText());
+			WComponent submitControl = dateField.getDefaultSubmitButton();
+			String submitControlId = submitControl == null ? null : submitControl.getId();
+			xml.appendOptionalAttribute("buttonId", submitControlId);
+		}
 
 		xml.appendClose();
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WPasswordFieldRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WPasswordFieldRenderer.java
@@ -32,9 +32,10 @@ class WPasswordFieldRenderer extends AbstractWebXmlRenderer {
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
 		xml.appendOptionalAttribute("hidden", component.isHidden(), "true");
-		xml.appendOptionalAttribute("readOnly", readOnly, "true");
 
-		if (!readOnly) {
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
 			int cols = field.getColumns();
 			int minLength = field.getMinLength();
 			int maxLength = field.getMaxLength();

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WPhoneNumberFieldRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WPhoneNumberFieldRenderer.java
@@ -33,9 +33,10 @@ class WPhoneNumberFieldRenderer extends AbstractWebXmlRenderer {
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
 		xml.appendOptionalAttribute("hidden", component.isHidden(), "true");
-		xml.appendOptionalAttribute("readOnly", readOnly, "true");
 
-		if (!readOnly) {
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
 			int cols = field.getColumns();
 			int minLength = field.getMinLength();
 			int maxLength = field.getMaxLength();

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WRadioButtonRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WRadioButtonRenderer.java
@@ -34,6 +34,8 @@ final class WRadioButtonRenderer extends AbstractWebXmlRenderer {
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
 		xml.appendOptionalAttribute("hidden", button.isHidden(), "true");
+		xml.appendAttribute("groupName", button.getGroupName());
+		xml.appendAttribute("value", WebUtilities.encode(value));
 		if (readOnly) {
 			xml.appendAttribute("readOnly", "true");
 		} else {
@@ -46,9 +48,7 @@ final class WRadioButtonRenderer extends AbstractWebXmlRenderer {
 			// Check for null option (ie null or empty). Match isEmpty() logic.
 			boolean isNull = value == null ? true : (value.length() == 0);
 			xml.appendOptionalAttribute("isNull", isNull, "true");
-			xml.appendAttribute("groupName", button.getGroupName());
 		}
-		xml.appendAttribute("value", WebUtilities.encode(value));
 		xml.appendOptionalAttribute("selected", button.isSelected(), "true");
 		xml.appendEnd();
 	}

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WRadioButtonRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WRadioButtonRenderer.java
@@ -26,28 +26,30 @@ final class WRadioButtonRenderer extends AbstractWebXmlRenderer {
 		WRadioButton button = (WRadioButton) component;
 
 		XmlStringBuilder xml = renderContext.getWriter();
-
+		boolean readOnly = button.isReadOnly();
 		String value = button.getValue();
-		// Check for null option (ie null or empty). Match isEmpty() logic.
-		boolean isNull = value == null ? true : (value.length() == 0);
 
 		xml.appendTagOpen("ui:radiobutton");
 		xml.appendAttribute("id", component.getId());
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
-		xml.appendAttribute("groupName", button.getGroupName());
-		xml.appendAttribute("value", WebUtilities.encode(value));
-		xml.appendOptionalAttribute("disabled", button.isDisabled(), "true");
 		xml.appendOptionalAttribute("hidden", button.isHidden(), "true");
-		xml.appendOptionalAttribute("required", button.isMandatory(), "true");
-		xml.appendOptionalAttribute("readOnly", button.isReadOnly(), "true");
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
+			xml.appendOptionalAttribute("disabled", button.isDisabled(), "true");
+			xml.appendOptionalAttribute("required", button.isMandatory(), "true");
+			xml.appendOptionalAttribute("submitOnChange", button.isSubmitOnChange(), "true");
+			xml.appendOptionalAttribute("tabIndex", component.hasTabIndex(), component.getTabIndex());
+			xml.appendOptionalAttribute("toolTip", button.getToolTip());
+			xml.appendOptionalAttribute("accessibleText", button.getAccessibleText());
+			// Check for null option (ie null or empty). Match isEmpty() logic.
+			boolean isNull = value == null ? true : (value.length() == 0);
+			xml.appendOptionalAttribute("isNull", isNull, "true");
+			xml.appendAttribute("groupName", button.getGroupName());
+		}
+		xml.appendAttribute("value", WebUtilities.encode(value));
 		xml.appendOptionalAttribute("selected", button.isSelected(), "true");
-		xml.appendOptionalAttribute("submitOnChange", button.isSubmitOnChange(), "true");
-		xml.appendOptionalAttribute("tabIndex", component.hasTabIndex(), component.getTabIndex());
-		xml.appendOptionalAttribute("toolTip", button.getToolTip());
-		xml.appendOptionalAttribute("accessibleText", button.getAccessibleText());
-		xml.appendOptionalAttribute("isNull", isNull, "true");
 		xml.appendEnd();
 	}
-
 }

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WRadioButtonSelectRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WRadioButtonSelectRenderer.java
@@ -35,14 +35,17 @@ final class WRadioButtonSelectRenderer extends AbstractWebXmlRenderer {
 		xml.appendAttribute("id", component.getId());
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
-		xml.appendOptionalAttribute("disabled", rbSelect.isDisabled(), "true");
 		xml.appendOptionalAttribute("hidden", rbSelect.isHidden(), "true");
-		xml.appendOptionalAttribute("required", rbSelect.isMandatory(), "true");
-		xml.appendOptionalAttribute("readOnly", readOnly, "true");
-		xml.appendOptionalAttribute("submitOnChange", rbSelect.isSubmitOnChange(), "true");
-		xml.appendOptionalAttribute("tabIndex", component.hasTabIndex(), String.valueOf(tabIndex));
-		xml.appendOptionalAttribute("toolTip", component.getToolTip());
-		xml.appendOptionalAttribute("accessibleText", component.getAccessibleText());
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
+			xml.appendOptionalAttribute("disabled", rbSelect.isDisabled(), "true");
+			xml.appendOptionalAttribute("required", rbSelect.isMandatory(), "true");
+			xml.appendOptionalAttribute("submitOnChange", rbSelect.isSubmitOnChange(), "true");
+			xml.appendOptionalAttribute("tabIndex", component.hasTabIndex(), String.valueOf(tabIndex));
+			xml.appendOptionalAttribute("toolTip", component.getToolTip());
+			xml.appendOptionalAttribute("accessibleText", component.getAccessibleText());
+		}
 		xml.appendOptionalAttribute("frameless", rbSelect.isFrameless(), "true");
 
 		switch (rbSelect.getButtonLayout()) {
@@ -57,8 +60,7 @@ final class WRadioButtonSelectRenderer extends AbstractWebXmlRenderer {
 				xml.appendAttribute("layout", "stacked");
 				break;
 			default:
-				throw new SystemException("Unknown radio button layout: " + rbSelect.
-						getButtonLayout());
+				throw new SystemException("Unknown radio button layout: " + rbSelect.getButtonLayout());
 		}
 
 		xml.appendClose();
@@ -75,8 +77,7 @@ final class WRadioButtonSelectRenderer extends AbstractWebXmlRenderer {
 				if (option instanceof OptionGroup) {
 					throw new SystemException("Option groups not supported in WRadioButtonSelect.");
 				} else {
-					renderOption(rbSelect, option, optionIndex++, xml, selectedOption,
-							renderSelectionsOnly);
+					renderOption(rbSelect, option, optionIndex++, xml, selectedOption, renderSelectionsOnly);
 				}
 			}
 		}

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WShufflerRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WShufflerRenderer.java
@@ -25,20 +25,24 @@ final class WShufflerRenderer extends AbstractWebXmlRenderer {
 	public void doRender(final WComponent component, final WebXmlRenderContext renderContext) {
 		WShuffler shuffler = (WShuffler) component;
 		XmlStringBuilder xml = renderContext.getWriter();
-		int rows = shuffler.getRows();
+		boolean readOnly = shuffler.isReadOnly();
 
 		// Start tag
 		xml.appendTagOpen("ui:shuffler");
 		xml.appendAttribute("id", component.getId());
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
-		xml.appendOptionalAttribute("disabled", shuffler.isDisabled(), "true");
 		xml.appendOptionalAttribute("hidden", shuffler.isHidden(), "true");
-		xml.appendOptionalAttribute("readOnly", shuffler.isReadOnly(), "true");
-		xml.appendOptionalAttribute("tabindex", component.hasTabIndex(), component.getTabIndex());
-		xml.appendOptionalAttribute("toolTip", shuffler.getToolTip());
-		xml.appendOptionalAttribute("accessibleText", shuffler.getAccessibleText());
-		xml.appendOptionalAttribute("rows", rows > 0, rows);
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
+			xml.appendOptionalAttribute("disabled", shuffler.isDisabled(), "true");
+			xml.appendOptionalAttribute("tabindex", component.hasTabIndex(), component.getTabIndex());
+			xml.appendOptionalAttribute("toolTip", shuffler.getToolTip());
+			xml.appendOptionalAttribute("accessibleText", shuffler.getAccessibleText());
+			int rows = shuffler.getRows();
+			xml.appendOptionalAttribute("rows", rows > 0, rows);
+		}
 		xml.appendClose();
 
 		// Options

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WSingleSelectRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WSingleSelectRenderer.java
@@ -38,7 +38,7 @@ final class WSingleSelectRenderer extends AbstractWebXmlRenderer {
 		if (readOnly) {
 			xml.appendAttribute("readOnly", "true");
 		} else {
-			xml.appendOptionalAttribute("data", dataKey != null && !readOnly, dataKey);
+			xml.appendOptionalAttribute("data", dataKey != null, dataKey);
 			xml.appendOptionalAttribute("disabled", listBox.isDisabled(), "true");
 			xml.appendOptionalAttribute("required", listBox.isMandatory(), "true");
 			xml.appendOptionalAttribute("submitOnChange", listBox.isSubmitOnChange(), "true");

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WSingleSelectRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WSingleSelectRenderer.java
@@ -34,16 +34,19 @@ final class WSingleSelectRenderer extends AbstractWebXmlRenderer {
 		xml.appendAttribute("id", component.getId());
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
-		xml.appendOptionalAttribute("data", dataKey != null && !readOnly, dataKey);
-		xml.appendOptionalAttribute("disabled", listBox.isDisabled(), "true");
 		xml.appendOptionalAttribute("hidden", listBox.isHidden(), "true");
-		xml.appendOptionalAttribute("required", listBox.isMandatory(), "true");
-		xml.appendOptionalAttribute("readOnly", readOnly, "true");
-		xml.appendOptionalAttribute("submitOnChange", listBox.isSubmitOnChange(), "true");
-		xml.appendOptionalAttribute("tabIndex", component.hasTabIndex(), listBox.getTabIndex());
-		xml.appendOptionalAttribute("toolTip", component.getToolTip());
-		xml.appendOptionalAttribute("accessibleText", component.getAccessibleText());
-		xml.appendOptionalAttribute("rows", rows >= 2, rows);
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
+			xml.appendOptionalAttribute("data", dataKey != null && !readOnly, dataKey);
+			xml.appendOptionalAttribute("disabled", listBox.isDisabled(), "true");
+			xml.appendOptionalAttribute("required", listBox.isMandatory(), "true");
+			xml.appendOptionalAttribute("submitOnChange", listBox.isSubmitOnChange(), "true");
+			xml.appendOptionalAttribute("tabIndex", component.hasTabIndex(), listBox.getTabIndex());
+			xml.appendOptionalAttribute("toolTip", component.getToolTip());
+			xml.appendOptionalAttribute("accessibleText", component.getAccessibleText());
+			xml.appendOptionalAttribute("rows", rows >= 2, rows);
+		}
 		xml.appendAttribute("single", "true");
 
 		xml.appendClose();
@@ -63,14 +66,12 @@ final class WSingleSelectRenderer extends AbstractWebXmlRenderer {
 					xml.appendClose();
 
 					for (Object nestedOption : ((OptionGroup) option).getOptions()) {
-						renderOption(listBox, nestedOption, optionIndex++, xml, selectedOption,
-								renderSelectionsOnly);
+						renderOption(listBox, nestedOption, optionIndex++, xml, selectedOption, renderSelectionsOnly);
 					}
 
 					xml.appendEndTag("ui:optgroup");
 				} else {
-					renderOption(listBox, option, optionIndex++, xml, selectedOption,
-							renderSelectionsOnly);
+					renderOption(listBox, option, optionIndex++, xml, selectedOption, renderSelectionsOnly);
 				}
 			}
 		}

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WTextAreaRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WTextAreaRenderer.java
@@ -31,9 +31,10 @@ class WTextAreaRenderer extends AbstractWebXmlRenderer {
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
 		xml.appendOptionalAttribute("hidden", textArea.isHidden(), "true");
-		xml.appendOptionalAttribute("readOnly", readOnly, "true");
 
-		if (!readOnly) {
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
 			int cols = textArea.getColumns();
 			int rows = textArea.getRows();
 			int minLength = textArea.getMinLength();

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WTextFieldRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WTextFieldRenderer.java
@@ -32,9 +32,10 @@ class WTextFieldRenderer extends AbstractWebXmlRenderer {
 		xml.appendAttribute("id", component.getId());
 		xml.appendOptionalAttribute("class", component.getHtmlClass());
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
-		xml.appendOptionalAttribute("readOnly", readOnly, "true");
 		xml.appendOptionalAttribute("hidden", component.isHidden(), "true");
-		if (!readOnly) {
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
 			int cols = textField.getColumns();
 			int minLength = textField.getMinLength();
 			int maxLength = textField.getMaxLength();

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WToggleButtonRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WToggleButtonRenderer.java
@@ -35,8 +35,9 @@ final class WToggleButtonRenderer extends AbstractWebXmlRenderer {
 		xml.appendOptionalAttribute("track", component.isTracking(), "true");
 		xml.appendOptionalAttribute("hidden", toggle.isHidden(), "true");
 		xml.appendOptionalAttribute("selected", toggle.isSelected(), "true");
-		xml.appendOptionalAttribute("readOnly", readOnly, "true");
-		if (!readOnly) {
+		if (readOnly) {
+			xml.appendAttribute("readOnly", "true");
+		} else {
 			WComponentGroup<WCheckBox> group = toggle.getGroup();
 			String groupName = group == null ? null : group.getId();
 			xml.appendOptionalAttribute("groupName", groupName);

--- a/wcomponents-core/src/main/resources/schema/ui/v1/multiSelectPair.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/multiSelectPair.xsd
@@ -45,10 +45,10 @@
 
 			<xs:attributeGroup ref="ui:input.attributes" />
 
-			<xs:attribute name="size" use="required">
+			<xs:attribute name="size">
 				<xs:annotation>
 					<xs:documentation>Indicates the number of options which should be visible in the component without scrolling. If not set then the display is determined by the
-						user agent.</xs:documentation>
+						user agent. This attribute is mandatory if the field is not in a read-only state.</xs:documentation>
 				</xs:annotation>
 				<xs:simpleType>
 					<xs:restriction base="xs:int">
@@ -59,15 +59,15 @@
 
 			<!--  TODO: we could probably have the @fromListName and @toListName not required and default to theme determined values. -->
 			
-			<xs:attribute name="fromListName" type="xs:string" use="required">
+			<xs:attribute name="fromListName" type="xs:string">
 				<xs:annotation>
-					<xs:documentation>The label text for the list of unselected options.</xs:documentation>
+					<xs:documentation>The label text for the list of unselected options. This attribute is mandatory if the field is not in a read-only state.</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
 
-			<xs:attribute name="toListName" type="xs:string" use="required">
+			<xs:attribute name="toListName" type="xs:string">
 				<xs:annotation>
-					<xs:documentation>The label text for the list of selected options.</xs:documentation>
+					<xs:documentation>The label text for the list of selected options. This attribute is mandatory if the field is not in a read-only state.</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
 

--- a/wcomponents-core/src/main/resources/schema/ui/v1/numberField.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/numberField.xsd
@@ -2,13 +2,6 @@
 <!--
 
 XML schema for numberField (WNumberField)
-
-WNumberField expects that the POSTed form data contains:
-
-Field name      Type        Mandatory       Value
-==========      ====        =========       =====
-@id             String      yes             value
-
 -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0">
@@ -38,37 +31,31 @@ Field name      Type        Mandatory       Value
 				</table>
 			</xs:documentation>
 		</xs:annotation>
-		
+
 		<xs:complexType>
 			<xs:simpleContent>
 				<xs:extension base="xs:string">
 					<xs:attributeGroup ref="ui:submitting.input.attributes"/>
 					<xs:attributeGroup ref="ui:autocomplete.attributes"/>
-					
-					<xs:attribute name="size" type="xs:positiveInteger">
-						<xs:annotation>
-							<xs:documentation>Not implemented: incompatible with HTML spec. Sie determined by @max</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					
+
 					<xs:attribute name="min" type="xs:decimal">
 						<xs:annotation>
 							<xs:documentation>The minimum allowed value in the field. Determined by the user agent if not specified and generally in the region of 0 - &lt;largest supported long integer&gt;. Note that if @step is not an integer then @min must also be not an integer.</xs:documentation>
 						</xs:annotation>
 					</xs:attribute>
-					
+
 					<xs:attribute name="max" type="xs:decimal">
 						<xs:annotation>
 							<xs:documentation>The maximum allowed value in the field. Determined by the user agent if not specified and generally in the region of 0 + &lt;largest supported long integer&gt;.</xs:documentation>
 						</xs:annotation>
 					</xs:attribute>
-					
+
 					<xs:attribute name="step" type="xs:decimal">
 						<xs:annotation>
 							<xs:documentation>The increment to apply when the user interacts with the controls spin button nature. Defaults to 1. NOTE: @step may only be a non-integer if @min is a non-integer.</xs:documentation>
 						</xs:annotation>
 					</xs:attribute>
-					
+
 					<xs:attribute name="decimals" type="xs:positiveInteger">
 						<xs:annotation>
 							<xs:documentation>The number of decimal places to show in the number field. If not set defaults to 0 to display integer values. If @step and @min are non-integer values the field may show floats (with an unqualified but user agent determined number of decimal places) if this attribute is not set or set to "0".</xs:documentation>

--- a/wcomponents-core/src/main/resources/schema/ui/v1/radioButton.xsd
+++ b/wcomponents-core/src/main/resources/schema/ui/v1/radioButton.xsd
@@ -36,9 +36,10 @@
 		<xs:complexType>
 			<xs:attributeGroup ref="ui:input.attributes"/>
 			
-			<xs:attribute name="groupName" type="xs:NMTOKEN" use="required">
+			<xs:attribute name="groupName" type="xs:NMTOKEN">
 				<xs:annotation>
-					<xs:documentation>Used to group a set of WRadioButtons into a usable single-selection control.</xs:documentation>
+					<xs:documentation>Used to group a set of WRadioButtons into a usable single-selection control. This attribute is mandatory if the
+						field is not in a read-only state.</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
 			

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WCheckBoxSelectRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WCheckBoxSelectRenderer_Test.java
@@ -52,6 +52,25 @@ public class WCheckBoxSelectRenderer_Test extends AbstractWebXmlRendererTestCase
 		assertXpathEvaluatesTo("b", "//ui:checkboxselect/ui:option[@selected='true']", wcbTest);
 	}
 
+
+	@Test
+	public void testDoPaintReadOnly() throws IOException, SAXException, XpathException {
+		WCheckBoxSelect wcbTest = new WCheckBoxSelect(new String[]{"a", "b", "c"});
+		assertSchemaMatch(wcbTest);
+		setActiveContext(createUIContext());
+		// Check Readonly - only render selected option
+		wcbTest.setReadOnly(true);
+		wcbTest.setSelected(Arrays.asList(new String[]{"b"}));
+
+		assertSchemaMatch(wcbTest);
+		assertXpathEvaluatesTo("true", "//ui:checkboxselect/@readOnly", wcbTest);
+		assertXpathEvaluatesTo("1", "count(//ui:checkboxselect/ui:option)", wcbTest);
+		assertXpathEvaluatesTo("1", "count(//ui:checkboxselect/ui:option[@selected='true'])",
+				wcbTest);
+		assertXpathEvaluatesTo("b", "//ui:checkboxselect/ui:option[@selected='true']", wcbTest);
+	}
+
+
 	@Test
 	public void testDoPaintAllOptions() throws IOException, SAXException, XpathException {
 		WCheckBoxSelect wcbTest = new WCheckBoxSelect(new String[]{"a", "b", "c"});
@@ -60,7 +79,6 @@ public class WCheckBoxSelectRenderer_Test extends AbstractWebXmlRendererTestCase
 		wcbTest.setDisabled(true);
 		setFlag(wcbTest, ComponentModel.HIDE_FLAG, true);
 		wcbTest.setMandatory(true);
-		wcbTest.setReadOnly(true);
 		wcbTest.setSubmitOnChange(true);
 		wcbTest.setToolTip("tool tip");
 		wcbTest.setAccessibleText("accessible text");
@@ -74,7 +92,6 @@ public class WCheckBoxSelectRenderer_Test extends AbstractWebXmlRendererTestCase
 		assertXpathEvaluatesTo("true", "//ui:checkboxselect/@disabled", wcbTest);
 		assertXpathEvaluatesTo("true", "//ui:checkboxselect/@hidden", wcbTest);
 		assertXpathEvaluatesTo("true", "//ui:checkboxselect/@required", wcbTest);
-		assertXpathEvaluatesTo("true", "//ui:checkboxselect/@readOnly", wcbTest);
 		assertXpathEvaluatesTo("true", "//ui:checkboxselect/@submitOnChange", wcbTest);
 		assertXpathEvaluatesTo("tool tip", "//ui:checkboxselect/@toolTip", wcbTest);
 		assertXpathEvaluatesTo("accessible text", "//ui:checkboxselect/@accessibleText", wcbTest);
@@ -95,7 +112,6 @@ public class WCheckBoxSelectRenderer_Test extends AbstractWebXmlRendererTestCase
 		wcbTest.setButtonLayout(WCheckBoxSelect.LAYOUT_STACKED);
 		assertXpathEvaluatesTo("stacked", "//ui:checkboxselect/@layout", wcbTest);
 		assertXpathNotExists("//ui:checkboxselect/@layoutColumnCount", wcbTest);
-
 	}
 
 	@Test(expected = SystemException.class)

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WDateFieldRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WDateFieldRenderer_Test.java
@@ -73,7 +73,6 @@ public class WDateFieldRenderer_Test extends AbstractWebXmlRendererTestCase {
 		dateField.setDisabled(true);
 		setFlag(dateField, ComponentModel.HIDE_FLAG, true);
 		dateField.setMandatory(true);
-		dateField.setReadOnly(true);
 		dateField.setToolTip("TITLE");
 		dateField.setAccessibleText("ALT");
 		dateField.setDefaultSubmitButton(button);
@@ -91,13 +90,25 @@ public class WDateFieldRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertXpathEvaluatesTo("true", "//ui:datefield/@disabled", dateField);
 		assertXpathEvaluatesTo("true", "//ui:datefield/@hidden", dateField);
 		assertXpathEvaluatesTo("true", "//ui:datefield/@required", dateField);
-		assertXpathEvaluatesTo("true", "//ui:datefield/@readOnly", dateField);
 		assertXpathEvaluatesTo("", "//ui:datefield/@tabIndex", dateField);
 		assertXpathEvaluatesTo("TITLE", "//ui:datefield/@toolTip", dateField);
 		assertXpathEvaluatesTo("ALT", "//ui:datefield/@accessibleText", dateField);
 		assertXpathEvaluatesTo(button.getId(), "//ui:datefield/@buttonId", dateField);
 		assertXpathEvaluatesTo("2011-02-01", "//ui:datefield/@min", dateField);
 		assertXpathEvaluatesTo("2012-03-02", "//ui:datefield/@max", dateField);
+	}
+
+	@Test
+	public void testDoPaintReadOnly() throws IOException, SAXException, XpathException {
+		WDateField dateField = new WDateField();
+		dateField.setDate(TEST_DATE);
+		dateField.setReadOnly(true);
+		setActiveContext(createUIContext());
+
+		// Validate Schema
+		assertSchemaMatch(dateField);
+		assertXpathEvaluatesTo("true", "//ui:datefield/@readOnly", dateField);
+		assertXpathEvaluatesTo(TEST_INTERNAL_DATE_STRING, "//ui:datefield/@date", dateField);
 	}
 
 	@Test

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WDropdownRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WDropdownRenderer_Test.java
@@ -48,16 +48,6 @@ public class WDropdownRenderer_Test extends AbstractWebXmlRendererTestCase {
 		drop.setLocked(true);
 		setActiveContext(createUIContext());
 
-		// Check Readonly - only render selected option
-		drop.setReadOnly(true);
-		drop.setSelected("B");
-		assertSchemaMatch(drop);
-		assertXpathEvaluatesTo(drop.getId(), "//ui:dropdown/@id", drop);
-		assertXpathEvaluatesTo("true", "//ui:dropdown/@readOnly", drop);
-		assertXpathEvaluatesTo("1", "count(//ui:dropdown/ui:option)", drop);
-		assertXpathEvaluatesTo("1", "count(//ui:dropdown/ui:option[@selected='true'])", drop);
-		assertXpathEvaluatesTo("B", "//ui:dropdown/ui:option[@selected='true']", drop);
-
 		resetContext();
 		drop = new WDropdown(new String[]{"A", "B"});
 		assertXpathEvaluatesTo("2", "count(//ui:dropdown/ui:option)", drop);
@@ -70,6 +60,23 @@ public class WDropdownRenderer_Test extends AbstractWebXmlRendererTestCase {
 		drop.setOptions(new String[]{"X"});
 		assertXpathEvaluatesTo("1", "count(//ui:dropdown/ui:option)", drop);
 		assertXpathExists("//ui:dropdown[ui:option='X']", drop);
+	}
+
+	@Test
+	public void testDoPaintReadOnly() throws IOException, SAXException, XpathException {
+		// Shared options.
+		WDropdown drop = new WDropdown();
+		drop.setOptions(new String[]{"A", "B", "C"});
+		setActiveContext(createUIContext());
+
+		// Check Readonly - only render selected option
+		drop.setReadOnly(true);
+		drop.setSelected("B");
+		assertSchemaMatch(drop);
+		assertXpathEvaluatesTo("true", "//ui:dropdown/@readOnly", drop);
+		assertXpathEvaluatesTo("1", "count(//ui:dropdown/ui:option)", drop);
+		assertXpathEvaluatesTo("1", "count(//ui:dropdown/ui:option[@selected='true'])", drop);
+		assertXpathEvaluatesTo("B", "//ui:dropdown/ui:option[@selected='true']", drop);
 	}
 
 	@Test
@@ -101,10 +108,6 @@ public class WDropdownRenderer_Test extends AbstractWebXmlRendererTestCase {
 		drop.setMandatory(true);
 		assertSchemaMatch(drop);
 		assertXpathEvaluatesTo("true", "//ui:dropdown/@required", drop);
-
-		drop.setReadOnly(true);
-		assertSchemaMatch(drop);
-		assertXpathEvaluatesTo("true", "//ui:dropdown/@readOnly", drop);
 
 		drop.setSubmitOnChange(true);
 		assertSchemaMatch(drop);

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WFileWidgetRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WFileWidgetRenderer_Test.java
@@ -54,10 +54,6 @@ public class WFileWidgetRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertSchemaMatch(fileUpload);
 		assertXpathEvaluatesTo("true", "//ui:fileupload/@required", fileUpload);
 
-		fileUpload.setReadOnly(true);
-		assertSchemaMatch(fileUpload);
-		assertXpathEvaluatesTo("true", "//ui:fileupload/@readOnly", fileUpload);
-
 		fileUpload.setToolTip("tooltip");
 		assertSchemaMatch(fileUpload);
 		assertXpathEvaluatesTo(fileUpload.getToolTip(), "//ui:fileupload/@toolTip", fileUpload);
@@ -72,6 +68,15 @@ public class WFileWidgetRenderer_Test extends AbstractWebXmlRendererTestCase {
 
 		fileUpload.setMaxFileSize(12345);
 		assertXpathEvaluatesTo("12345", "//ui:fileupload/@maxFileSize", fileUpload);
+	}
+
+	@Test
+	public void testReadOnly() throws IOException, SAXException, XpathException {
+		WFileWidget fileUpload = new WFileWidget();
+
+		fileUpload.setReadOnly(true);
+		assertSchemaMatch(fileUpload);
+		assertXpathEvaluatesTo("true", "//ui:fileupload/@readOnly", fileUpload);
 	}
 
 	@Test

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WMultiDropdownRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WMultiDropdownRenderer_Test.java
@@ -43,21 +43,26 @@ public class WMultiDropdownRenderer_Test extends AbstractWebXmlRendererTestCase 
 		dropdown.setSelected(Arrays.asList(new String[]{"b"}));
 		assertSchemaMatch(dropdown);
 		assertXpathEvaluatesTo("3", "count(//ui:multidropdown/ui:option)", dropdown);
-		assertXpathEvaluatesTo("b",
-				"normalize-space(//ui:multidropdown/ui:option[@selected='true'])", dropdown);
-
-		// Check Readonly - only render selected option
-		dropdown.setReadOnly(true);
-		assertSchemaMatch(dropdown);
-		assertXpathEvaluatesTo("true", "//ui:multidropdown/@readOnly", dropdown);
-		assertXpathEvaluatesTo("1", "count(//ui:multidropdown/ui:option)", dropdown);
-		assertXpathEvaluatesTo("b",
-				"normalize-space(//ui:multidropdown/ui:option[@selected='true'])", dropdown);
+		assertXpathEvaluatesTo("b", "normalize-space(//ui:multidropdown/ui:option[@selected='true'])", dropdown);
 
 		// Check max inputs
 		dropdown.setMaxInputs(123);
 		assertSchemaMatch(dropdown);
 		assertXpathEvaluatesTo("123", "//ui:multidropdown/@max", dropdown);
+	}
+
+	@Test
+	public void testReadOnly() throws IOException, SAXException, XpathException {
+		WMultiDropdown dropdown = new WMultiDropdown(new String[]{"a", "b", "c"});
+		setActiveContext(createUIContext());
+
+		// Check Readonly - only render selected option
+		dropdown.setReadOnly(true);
+		dropdown.setSelected(Arrays.asList(new String[]{"b"}));
+		assertSchemaMatch(dropdown);
+		assertXpathEvaluatesTo("true", "//ui:multidropdown/@readOnly", dropdown);
+		assertXpathEvaluatesTo("1", "count(//ui:multidropdown/ui:option)", dropdown);
+		assertXpathEvaluatesTo("b", "normalize-space(//ui:multidropdown/ui:option[@selected='true'])", dropdown);
 	}
 
 	@Test
@@ -67,7 +72,6 @@ public class WMultiDropdownRenderer_Test extends AbstractWebXmlRendererTestCase 
 		dropdown.setDisabled(true);
 		setFlag(dropdown, ComponentModel.HIDE_FLAG, true);
 		dropdown.setMandatory(true);
-		dropdown.setReadOnly(true);
 		dropdown.setSubmitOnChange(true);
 		dropdown.setToolTip("tool tip");
 		dropdown.setAccessibleText("accessible text");
@@ -80,7 +84,6 @@ public class WMultiDropdownRenderer_Test extends AbstractWebXmlRendererTestCase 
 		assertXpathEvaluatesTo("true", "//ui:multidropdown/@disabled", dropdown);
 		assertXpathEvaluatesTo("true", "//ui:multidropdown/@hidden", dropdown);
 		assertXpathEvaluatesTo("true", "//ui:multidropdown/@required", dropdown);
-		assertXpathEvaluatesTo("true", "//ui:multidropdown/@readOnly", dropdown);
 		assertXpathEvaluatesTo("true", "//ui:multidropdown/@submitOnChange", dropdown);
 		assertXpathEvaluatesTo("tool tip", "//ui:multidropdown/@toolTip", dropdown);
 		assertXpathEvaluatesTo("accessible text", "//ui:multidropdown/@accessibleText", dropdown);

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WMultiFileWidgetRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WMultiFileWidgetRenderer_Test.java
@@ -59,10 +59,6 @@ public class WMultiFileWidgetRenderer_Test extends AbstractWebXmlRendererTestCas
 		assertSchemaMatch(fileUpload);
 		assertXpathEvaluatesTo("true", "//ui:fileupload/@required", fileUpload);
 
-		fileUpload.setReadOnly(true);
-		assertSchemaMatch(fileUpload);
-		assertXpathEvaluatesTo("true", "//ui:fileupload/@readOnly", fileUpload);
-
 		fileUpload.setToolTip("tooltip");
 		assertSchemaMatch(fileUpload);
 		assertXpathEvaluatesTo(fileUpload.getToolTip(), "//ui:fileupload/@toolTip", fileUpload);
@@ -98,6 +94,14 @@ public class WMultiFileWidgetRenderer_Test extends AbstractWebXmlRendererTestCas
 				fileUpload);
 		assertXpathEvaluatesTo(String.valueOf(fileItem.getSize()), "//ui:fileupload/ui:file/@size",
 				fileUpload);
+	}
+
+	@Test
+	public void testReadOnly() throws IOException, SAXException, XpathException {
+		WMultiFileWidget fileUpload = new WMultiFileWidget();
+		fileUpload.setReadOnly(true);
+		assertSchemaMatch(fileUpload);
+		assertXpathEvaluatesTo("true", "//ui:fileupload/@readOnly", fileUpload);
 	}
 
 	@Test

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WMultiSelectPairRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WMultiSelectPairRenderer_Test.java
@@ -67,13 +67,6 @@ public class WMultiSelectPairRenderer_Test extends AbstractWebXmlRendererTestCas
 				select);
 		assertXpathEvaluatesTo(option2, "//ui:multiselectpair/ui:option[@selected='true']", select);
 
-		// Check Readonly - only render selected option
-		select.setReadOnly(true);
-		assertSchemaMatch(select);
-		assertXpathEvaluatesTo("true", "//ui:multiselectpair/@readOnly", select);
-		assertXpathEvaluatesTo("1", "count(//ui:multiselectpair/ui:option)", select);
-		assertXpathEvaluatesTo(option2, "//ui:multiselectpair/ui:option[@selected='true']", select);
-
 		// Required
 		select.setMandatory(true);
 		assertSchemaMatch(select);
@@ -102,6 +95,27 @@ public class WMultiSelectPairRenderer_Test extends AbstractWebXmlRendererTestCas
 	}
 
 	@Test
+	public void testReadOnlyOption() throws IOException, SAXException, XpathException {
+		final String option1 = "WMultiSelectPairRenderer_Test.testDoPaint.option1";
+		final String option2 = "WMultiSelectPairRenderer_Test.testDoPaint.option2";
+		final String option3 = "WMultiSelectPairRenderer_Test.testDoPaint.option3";
+
+		// Empty list
+		WMultiSelectPair select = new WMultiSelectPair();
+		setActiveContext(createUIContext());
+		select.setOptions(new String[]{option1, option2, option3});
+		select.setSelected(Arrays.asList(new String[]{option2}));
+		assertSchemaMatch(select);
+		// Check Readonly - only render selected option
+		select.setReadOnly(true);
+		assertSchemaMatch(select);
+		assertXpathEvaluatesTo("true", "//ui:multiselectpair/@readOnly", select);
+		assertXpathEvaluatesTo("1", "count(//ui:multiselectpair/ui:option)", select);
+		assertXpathEvaluatesTo(option2, "//ui:multiselectpair/ui:option[@selected='true']", select);
+	}
+
+
+	@Test
 	public void testDoPaintOptions() throws IOException, SAXException, XpathException {
 		WMultiSelectPair select = new WMultiSelectPair(new String[]{"a", "b", "c"});
 
@@ -109,7 +123,6 @@ public class WMultiSelectPairRenderer_Test extends AbstractWebXmlRendererTestCas
 		select.setDisabled(true);
 		setFlag(select, ComponentModel.HIDE_FLAG, true);
 		select.setMandatory(true);
-		select.setReadOnly(true);
 		select.setShuffle(true);
 		select.setAvailableListName("available");
 		select.setSelectedListName("selected");
@@ -124,7 +137,6 @@ public class WMultiSelectPairRenderer_Test extends AbstractWebXmlRendererTestCas
 		assertXpathEvaluatesTo("true", "//ui:multiselectpair/@disabled", select);
 		assertXpathEvaluatesTo("true", "//ui:multiselectpair/@hidden", select);
 		assertXpathEvaluatesTo("true", "//ui:multiselectpair/@required", select);
-		assertXpathEvaluatesTo("true", "//ui:multiselectpair/@readOnly", select);
 		assertXpathEvaluatesTo("true", "//ui:multiselectpair/@shuffle", select);
 		assertXpathEvaluatesTo("available", "//ui:multiselectpair/@fromListName", select);
 		assertXpathEvaluatesTo("selected", "//ui:multiselectpair/@toListName", select);

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WMultiSelectRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WMultiSelectRenderer_Test.java
@@ -41,21 +41,26 @@ public class WMultiSelectRenderer_Test extends AbstractWebXmlRendererTestCase {
 		multi.setSelected(Arrays.asList(new String[]{"b"}));
 		assertSchemaMatch(multi);
 		assertXpathEvaluatesTo("3", "count(//ui:listbox/ui:option)", multi);
-		assertXpathEvaluatesTo("b", "normalize-space(//ui:listbox/ui:option[@selected='true'])",
-				multi);
+		assertXpathEvaluatesTo("b", "normalize-space(//ui:listbox/ui:option[@selected='true'])", multi);
+
+		// Check rows
+		multi.setRows(123);
+		assertSchemaMatch(multi);
+		assertXpathEvaluatesTo("123", "//ui:listbox/@rows", multi);
+	}
+
+	@Test
+	public void testReadOnly() throws IOException, SAXException, XpathException {
+		WMultiSelect multi = new WMultiSelect(new String[]{"a", "b", "c"});
+		setActiveContext(createUIContext());
+		multi.setSelected(Arrays.asList(new String[]{"b"}));
 
 		// Check Readonly - only render selected option
 		multi.setReadOnly(true);
 		assertSchemaMatch(multi);
 		assertXpathEvaluatesTo("true", "//ui:listbox/@readOnly", multi);
 		assertXpathEvaluatesTo("1", "count(//ui:listbox/ui:option)", multi);
-		assertXpathEvaluatesTo("b", "normalize-space(//ui:listbox/ui:option[@selected='true'])",
-				multi);
-
-		// Check rows
-		multi.setRows(123);
-		assertSchemaMatch(multi);
-		assertXpathEvaluatesTo("123", "//ui:listbox/@rows", multi);
+		assertXpathEvaluatesTo("b", "normalize-space(//ui:listbox/ui:option[@selected='true'])", multi);
 	}
 
 	@Test
@@ -69,7 +74,6 @@ public class WMultiSelectRenderer_Test extends AbstractWebXmlRendererTestCase {
 		multi.setDisabled(true);
 		setFlag(multi, ComponentModel.HIDE_FLAG, true);
 		multi.setMandatory(true);
-		multi.setReadOnly(true);
 		multi.setSubmitOnChange(true);
 		multi.setToolTip(tooltip);
 		multi.setAccessibleText(accessible);
@@ -83,7 +87,6 @@ public class WMultiSelectRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertXpathEvaluatesTo("true", "//ui:listbox/@disabled", multi);
 		assertXpathEvaluatesTo("true", "//ui:listbox/@hidden", multi);
 		assertXpathEvaluatesTo("true", "//ui:listbox/@required", multi);
-		assertXpathEvaluatesTo("true", "//ui:listbox/@readOnly", multi);
 		assertXpathEvaluatesTo("true", "//ui:listbox/@submitOnChange", multi);
 		assertXpathEvaluatesTo(tooltip, "//ui:listbox/@toolTip", multi);
 		assertXpathEvaluatesTo(accessible, "//ui:listbox/@accessibleText", multi);

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WNumberFieldRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WNumberFieldRenderer_Test.java
@@ -44,7 +44,6 @@ public class WNumberFieldRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertXpathNotExists("//ui:numberfield/@hidden", numberField);
 		assertXpathNotExists("//ui:numberfield/@required", numberField);
 		assertXpathNotExists("//ui:numberfield/@readOnly", numberField);
-		assertXpathNotExists("//ui:numberfield/@size", numberField);
 		assertXpathNotExists("//ui:numberfield/@toolTip", numberField);
 		assertXpathNotExists("//ui:numberfield/@accessibleText", numberField);
 		assertXpathNotExists("//ui:numberfield/@min", numberField);
@@ -68,10 +67,6 @@ public class WNumberFieldRenderer_Test extends AbstractWebXmlRendererTestCase {
 		numberField.setReadOnly(true);
 		assertSchemaMatch(numberField);
 		assertXpathEvaluatesTo("true", "//ui:numberfield/@readOnly", numberField);
-
-		numberField.setColumns(40);
-		assertSchemaMatch(numberField);
-		assertXpathEvaluatesTo("40", "//ui:numberfield/@size", numberField);
 
 		numberField.setToolTip("toolTip");
 		assertSchemaMatch(numberField);

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WNumberFieldRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WNumberFieldRenderer_Test.java
@@ -64,10 +64,6 @@ public class WNumberFieldRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertSchemaMatch(numberField);
 		assertXpathEvaluatesTo("true", "//ui:numberfield/@required", numberField);
 
-		numberField.setReadOnly(true);
-		assertSchemaMatch(numberField);
-		assertXpathEvaluatesTo("true", "//ui:numberfield/@readOnly", numberField);
-
 		numberField.setToolTip("toolTip");
 		assertSchemaMatch(numberField);
 		assertXpathEvaluatesTo(numberField.getToolTip(), "//ui:numberfield/@toolTip", numberField);
@@ -100,6 +96,15 @@ public class WNumberFieldRenderer_Test extends AbstractWebXmlRendererTestCase {
 		numberField.setNumber(123);
 		assertSchemaMatch(numberField);
 		assertXpathEvaluatesTo("123", "normalize-space(//ui:numberfield)", numberField);
+	}
+
+	@Test
+	public void testReadOnly() throws IOException, SAXException, XpathException {
+		WNumberField numberField = new WNumberField();
+
+		numberField.setReadOnly(true);
+		assertSchemaMatch(numberField);
+		assertXpathEvaluatesTo("true", "//ui:numberfield/@readOnly", numberField);
 	}
 
 	@Test

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WPartialDateFieldRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WPartialDateFieldRenderer_Test.java
@@ -71,7 +71,6 @@ public class WPartialDateFieldRenderer_Test extends AbstractWebXmlRendererTestCa
 		dateField.setDisabled(true);
 		setFlag(dateField, ComponentModel.HIDE_FLAG, true);
 		dateField.setMandatory(true);
-		dateField.setReadOnly(true);
 		dateField.setToolTip(TEST_TITLE);
 		dateField.setAccessibleText(TEST_ALT_TEXT);
 		dateField.setDefaultSubmitButton(new WButton(TEST_BUTTON_ID));
@@ -87,7 +86,6 @@ public class WPartialDateFieldRenderer_Test extends AbstractWebXmlRendererTestCa
 		assertXpathEvaluatesTo("true", "//ui:datefield/@disabled", dateField);
 		assertXpathEvaluatesTo("true", "//ui:datefield/@hidden", dateField);
 		assertXpathEvaluatesTo("true", "//ui:datefield/@required", dateField);
-		assertXpathEvaluatesTo("true", "//ui:datefield/@readOnly", dateField);
 		assertXpathEvaluatesTo(TEST_TITLE, "//ui:datefield/@toolTip", dateField);
 		assertXpathEvaluatesTo(TEST_ALT_TEXT, "//ui:datefield/@accessibleText", dateField);
 		assertXpathEvaluatesTo(String.valueOf(dateField.getDefaultSubmitButton().getId()),
@@ -96,6 +94,18 @@ public class WPartialDateFieldRenderer_Test extends AbstractWebXmlRendererTestCa
 
 		// Actual date value not set
 		assertXpathEvaluatesTo("", "//ui:datefield", dateField);
+	}
+
+	/**
+	 * Test doPaint - optional attributes.
+	 */
+	@Test
+	public void testReadOnly() throws IOException, SAXException, XpathException {
+		WPartialDateField dateField = new WPartialDateField();
+
+		dateField.setReadOnly(true);
+		assertSchemaMatch(dateField);
+		assertXpathEvaluatesTo("true", "//ui:datefield/@readOnly", dateField);
 	}
 
 	/**

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WRadioButtonRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WRadioButtonRenderer_Test.java
@@ -64,12 +64,6 @@ public class WRadioButtonRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertSchemaMatch(button);
 		assertXpathEvaluatesTo("true", "//ui:radiobutton/@required", button);
 
-		// Check readOnly
-		assertXpathNotExists("//ui:radiobutton/@readOnly", button);
-		button.setReadOnly(true);
-		assertSchemaMatch(button);
-		assertXpathEvaluatesTo("true", "//ui:radiobutton/@readOnly", button);
-
 		// Check toolTip
 		String toolTip = "WRadioButton_Test.testRenderedFormat.toolTip";
 		button.setToolTip(toolTip);
@@ -86,6 +80,24 @@ public class WRadioButtonRenderer_Test extends AbstractWebXmlRendererTestCase {
 		group.setSubmitOnChange(true);
 		assertSchemaMatch(button);
 		assertXpathEvaluatesTo("true", "//ui:radiobutton/@submitOnChange", button);
+	}
+
+	@Test
+	public void testReadOnly() throws IOException, SAXException, XpathException {
+		RadioButtonGroup group = new RadioButtonGroup();
+		WRadioButton button = group.addRadioButton(1);
+
+		button.setVisible(true);
+		// Check readOnly
+		assertXpathNotExists("//ui:radiobutton/@readOnly", button);
+		button.setReadOnly(true);
+		assertSchemaMatch(button);
+		assertXpathEvaluatesTo("true", "//ui:radiobutton/@readOnly", button);
+		// Check selected read-only
+		assertXpathNotExists("//ui:radiobutton/@selected", button);
+		button.setSelected(true);
+		assertSchemaMatch(button);
+		assertXpathEvaluatesTo("true", "//ui:radiobutton/@selected", button);
 	}
 
 	@Test

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WRadioButtonSelectRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WRadioButtonSelectRenderer_Test.java
@@ -32,26 +32,24 @@ public class WRadioButtonSelectRenderer_Test extends AbstractWebXmlRendererTestC
 		WRadioButtonSelect buttonGroup = new WRadioButtonSelect(new String[]{"a", "b", "c"});
 		assertSchemaMatch(buttonGroup);
 		assertXpathEvaluatesTo("3", "count(//ui:radiobuttonselect/ui:option)", buttonGroup);
-
 		// Check selected
 		assertXpathNotExists("//ui:radiobuttonselect/ui:option[@selected='true']", buttonGroup);
-
 		buttonGroup.setSelected("b");
 		assertSchemaMatch(buttonGroup);
-		assertXpathEvaluatesTo("1", "count(//ui:radiobuttonselect/ui:option[@selected='true'])",
-				buttonGroup);
-		assertXpathEvaluatesTo("b", "//ui:radiobuttonselect/ui:option[@selected='true']",
-				buttonGroup);
+		assertXpathEvaluatesTo("1", "count(//ui:radiobuttonselect/ui:option[@selected='true'])", buttonGroup);
+		assertXpathEvaluatesTo("b", "//ui:radiobuttonselect/ui:option[@selected='true']", buttonGroup);
+	}
 
+	@Test
+	public void testReadOnly() throws IOException, SAXException, XpathException {
+		WRadioButtonSelect buttonGroup = new WRadioButtonSelect(new String[]{"a", "b", "c"});
 		// Check Readonly - only render selected option
 		buttonGroup.setReadOnly(true);
+		buttonGroup.setSelected("b");
 		assertSchemaMatch(buttonGroup);
 		assertXpathEvaluatesTo("true", "//ui:radiobuttonselect/@readOnly", buttonGroup);
-		assertXpathEvaluatesTo("1", "count(//ui:radiobuttonselect/ui:option[@selected='true'])",
-				buttonGroup);
-		assertXpathEvaluatesTo("b", "//ui:radiobuttonselect/ui:option[@selected='true']",
-				buttonGroup);
-
+		assertXpathEvaluatesTo("1", "count(//ui:radiobuttonselect/ui:option[@selected='true'])", buttonGroup);
+		assertXpathEvaluatesTo("b", "//ui:radiobuttonselect/ui:option[@selected='true']", buttonGroup);
 	}
 
 	@Test
@@ -62,7 +60,6 @@ public class WRadioButtonSelectRenderer_Test extends AbstractWebXmlRendererTestC
 		group.setDisabled(true);
 		setFlag(group, ComponentModel.HIDE_FLAG, true);
 		group.setMandatory(true);
-		group.setReadOnly(true);
 		group.setSubmitOnChange(true);
 		group.setToolTip("tip");
 		group.setFrameless(true);
@@ -76,7 +73,6 @@ public class WRadioButtonSelectRenderer_Test extends AbstractWebXmlRendererTestC
 		assertXpathEvaluatesTo("true", "//ui:radiobuttonselect/@disabled", group);
 		assertXpathEvaluatesTo("true", "//ui:radiobuttonselect/@hidden", group);
 		assertXpathEvaluatesTo("true", "//ui:radiobuttonselect/@required", group);
-		assertXpathEvaluatesTo("true", "//ui:radiobuttonselect/@readOnly", group);
 		assertXpathEvaluatesTo("true", "//ui:radiobuttonselect/@submitOnChange", group);
 		assertXpathEvaluatesTo("tip", "//ui:radiobuttonselect/@toolTip", group);
 		assertXpathEvaluatesTo("true", "//ui:radiobuttonselect/@frameless", group);

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WShufflerRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WShufflerRenderer_Test.java
@@ -67,15 +67,31 @@ public class WShufflerRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertXpathEvaluatesTo(optionX, "//ui:shuffler/ui:option[1]/@value", shuffler);
 
 		// Check optional attributes
-		shuffler.setReadOnly(true);
 		shuffler.setDisabled(true);
 		shuffler.setToolTip("TITLE");
 		shuffler.setRows(2);
 		assertSchemaMatch(shuffler);
-		assertXpathEvaluatesTo("true", "//ui:shuffler/@readOnly", shuffler);
 		assertXpathEvaluatesTo("true", "//ui:shuffler/@disabled", shuffler);
 		assertXpathEvaluatesTo("TITLE", "//ui:shuffler/@toolTip", shuffler);
 		assertXpathEvaluatesTo("2", "//ui:shuffler/@rows", shuffler);
+
+	}
+
+	@Test
+	public void testReadOnly() throws IOException, SAXException, XpathException {
+		String optionA = "A";
+		String optionB = "B";
+		String optionC = "C";
+
+		// No options.
+		WShuffler shuffler = new WShuffler();
+
+		// Default options
+		shuffler.setOptions(Arrays.asList(new String[]{optionA, optionB, optionC}));
+		// Check optional attributes
+		shuffler.setReadOnly(true);
+		assertSchemaMatch(shuffler);
+		assertXpathEvaluatesTo("true", "//ui:shuffler/@readOnly", shuffler);
 
 	}
 

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WSingleSelectRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WSingleSelectRenderer_Test.java
@@ -41,21 +41,22 @@ public class WSingleSelectRenderer_Test extends AbstractWebXmlRendererTestCase {
 		single.setSelected("b");
 		assertSchemaMatch(single);
 		assertXpathEvaluatesTo("3", "count(//ui:listbox/ui:option)", single);
-		assertXpathEvaluatesTo("b", "normalize-space(//ui:listbox/ui:option[@selected='true'])",
-				single);
-
-		// Check Readonly - only render selected option
-		single.setReadOnly(true);
-		assertSchemaMatch(single);
-		assertXpathEvaluatesTo("true", "//ui:listbox/@readOnly", single);
-		assertXpathEvaluatesTo("1", "count(//ui:listbox/ui:option)", single);
-		assertXpathEvaluatesTo("b", "normalize-space(//ui:listbox/ui:option[@selected='true'])",
-				single);
-
+		assertXpathEvaluatesTo("b", "normalize-space(//ui:listbox/ui:option[@selected='true'])", single);
 		// Check rows
 		single.setRows(123);
 		assertSchemaMatch(single);
 		assertXpathEvaluatesTo("123", "//ui:listbox/@rows", single);
+	}
+
+	@Test
+	public void testReadOnly() throws IOException, SAXException, XpathException {
+		WSingleSelect single = new WSingleSelect(new String[]{"a", "b", "c"});
+		single.setSelected("b");
+		single.setReadOnly(true);
+		assertSchemaMatch(single);
+		assertXpathEvaluatesTo("true", "//ui:listbox/@readOnly", single);
+		assertXpathEvaluatesTo("1", "count(//ui:listbox/ui:option)", single);
+		assertXpathEvaluatesTo("b", "normalize-space(//ui:listbox/ui:option[@selected='true'])", single);
 	}
 
 	@Test
@@ -68,7 +69,6 @@ public class WSingleSelectRenderer_Test extends AbstractWebXmlRendererTestCase {
 		single.setDisabled(true);
 		setFlag(single, ComponentModel.HIDE_FLAG, true);
 		single.setMandatory(true);
-		single.setReadOnly(true);
 		single.setSubmitOnChange(true);
 		single.setToolTip(tooltip);
 		single.setAccessibleText(accessible);
@@ -77,7 +77,6 @@ public class WSingleSelectRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertXpathEvaluatesTo("true", "//ui:listbox/@disabled", single);
 		assertXpathEvaluatesTo("true", "//ui:listbox/@hidden", single);
 		assertXpathEvaluatesTo("true", "//ui:listbox/@required", single);
-		assertXpathEvaluatesTo("true", "//ui:listbox/@readOnly", single);
 		assertXpathEvaluatesTo("true", "//ui:listbox/@submitOnChange", single);
 		assertXpathEvaluatesTo(tooltip, "//ui:listbox/@toolTip", single);
 		assertXpathEvaluatesTo(accessible, "//ui:listbox/@accessibleText", single);

--- a/wcomponents-theme/src/main/xslt/wc.common.registrationScripts.coreRegistrationScripts.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.registrationScripts.coreRegistrationScripts.xsl
@@ -23,7 +23,7 @@
 		<xsl:variable name="dialogs" select=".//ui:dialog"/>
 		<xsl:variable name="dataListCombos" select=".//ui:dropdown[@data and @type and not(@readOnly)]|.//ui:suggestions[@data]"/>
 		<xsl:variable name="dataListComponents" select=".//ui:dropdown[@data and not(@type) and not(@readOnly)]|.//ui:listbox[@data and not(@readOnly)]|.//ui:shuffler[@data and not(@readOnly)]"/>
-		<xsl:variable name="filedrops" select=".//ui:fileupload[not(@readOnly)]"/>
+		<xsl:variable name="filedrops" select=".//ui:fileupload[@ajax or @dropzone]"/>
 		<xsl:variable name="multiDDData" select=".//ui:multidropdown[@data and not(@readOnly)]"/>
 		<xsl:variable name="popups" select=".//ui:popup"/>
 		<xsl:variable name="redirects" select=".//ui:redirect"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.fileUpload.file.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.fileUpload.file.xsl
@@ -26,6 +26,11 @@
 				<xsl:when test="ui:link">
 					<xsl:apply-templates select="ui:link">
 						<xsl:with-param name="imageAltText" select="concat('Thumbnail for uploaded file: ', @name)"/>
+						<xsl:with-param name="ajax">
+							<xsl:if test="parent::ui:fileupload[@ajax] and ../@readOnly">
+								<xsl:value-of select="../@id"/>
+							</xsl:if>
+						</xsl:with-param>
 					</xsl:apply-templates>
 				</xsl:when>
 				<xsl:otherwise>

--- a/wcomponents-theme/src/main/xslt/wc.ui.fileUpload.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.fileUpload.xsl
@@ -83,16 +83,11 @@
 						<xsl:with-param name="isError" select="$isError"/>
 						<xsl:with-param name="myLabel" select="$myLabel"/>
 						<xsl:with-param name="class">
-							<xsl:choose>
-								<xsl:when test="number($readOnly) eq 1">
-									<xsl:text>wc_ro</xsl:text>
-								</xsl:when>
-								<xsl:when test="@ajax">
-									<xsl:text>wc-ajax</xsl:text>
-								</xsl:when>
-							</xsl:choose>
+							<xsl:if test="@ajax">
+								<xsl:text>wc-ajax</xsl:text>
+							</xsl:if>
 							<xsl:if test="number($readOnly) eq 1">
-								<xsl:text>wc_ro</xsl:text>
+								<xsl:text> wc_ro</xsl:text>
 							</xsl:if>
 						</xsl:with-param>
 					</xsl:call-template>

--- a/wcomponents-theme/src/main/xslt/wc.ui.link.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.link.xsl
@@ -28,6 +28,7 @@
 	-->
 	<xsl:template match="ui:link">
 		<xsl:param name="imageAltText" select="''"/>
+		<xsl:param name="ajax" select="''"/>
 		<xsl:variable name="type" select="@type"/>
 		<xsl:variable name="hasPopup">
 			<xsl:choose>
@@ -69,6 +70,11 @@
 					<xsl:attribute name="href">
 						<xsl:value-of select="@url"/>
 					</xsl:attribute>
+					<xsl:if test="$ajax != ''">
+						<xsl:attribute name="data-wc-ajaxalias">
+							<xsl:value-of select="$ajax"/>
+						</xsl:attribute>
+					</xsl:if>
 					<xsl:if test="@rel or windowAttributes">
 						<xsl:attribute name="rel">
 							<xsl:choose>


### PR DESCRIPTION
1. Update renderers for fields which extend `Input` so that if the rendered field is in a read-only state only those attributes relevant to the state are rendered. Reolves #781.

2. Update WNumberField, its renderer and its schema to remove the output of a `size` attribute. The internal columns member and its accessors are deprecated. Fixes #1010.

@jonathanaustin PTAL