### PR TITLE
Img edit icon

### DIFF
--- a/wcomponents-theme/src/main/sass/_wc.ui.fileUploadIcons.scss
+++ b/wcomponents-theme/src/main/sass/_wc.ui.fileUploadIcons.scss
@@ -1,7 +1,7 @@
 /* wc.ui.fileUploadIcons.scss */
 @import 'mixins-common';
 
-.wc-fileupload button.wc_btn_abort:before {
+.wc-fileupload .wc_btn_abort:before {
 	content: $fa-var-ban;
 }
 

--- a/wcomponents-theme/src/main/sass/_wc.ui.imageEditIcons.scss
+++ b/wcomponents-theme/src/main/sass/_wc.ui.imageEditIcons.scss
@@ -2,7 +2,7 @@
 @import 'mixins-common';
 
 button[data-wc-img][data-wc-editor]:before {
-	content: $fa-var-picture-o;
+	content: $fa-var-pencil-square-o;
 }
 
 .wc_img_editor {


### PR DESCRIPTION
Update image edit icon to remove ambiguity with common browser “no image” iconography. Fix #1061 