### PR TITLE
Fix error in WLink XSLT

### DIFF
--- a/wcomponents-theme/src/main/xslt/wc.ui.link.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.link.xsl
@@ -75,7 +75,7 @@
 							<xsl:value-of select="$ajax"/>
 						</xsl:attribute>
 					</xsl:if>
-					<xsl:if test="@rel or windowAttributes">
+					<xsl:if test="@rel or ui:windowAttributes">
 						<xsl:attribute name="rel">
 							<xsl:choose>
 								<xsl:when test="@rel">


### PR DESCRIPTION
When WLink XSLT was modified for `rel` attribute changes were made in [August 2016](https://github.com/BorderTech/wcomponents/blob/eddie/wcomponents-theme/src/main/xslt/wc.ui.link.xsl#L78) a test for `ui:windowAttributes` was added but the test omitted the namespace so was never invoked. This change fixes that omission.