### PR TITLE
Wlink image url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 
+* Fixed a flaw which could result in images inside links getting the incrrect URL under some conditions #1150.
 * Fixed a flaw which could result in a WSubMenu being stuck open when a not-submitting WMenuItem is clicked #1137.
 * Fixed an accessibility flaw which could result in AT attempting to read icons #1136.
 * Fixed a JavaScript flaw which could result in unhandled events on buttons in some conditions #1135.

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WButtonExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WButtonExample.java
@@ -190,7 +190,7 @@ public class WButtonExample extends WPanel implements MessageContainer {
 		add(new ExplanatoryText("These examples show ways to add a Font-Awesome icon to a button using 'setHtmlClass'."));
 		iconButton = new WButton("\u200b"); // \u200b is a zero-width space.
 		iconButton.setToolTip("Open Menu");
-		iconButton.setHtmlClass(HtmlIconUtil.getIconClasses("fa bars"));
+		iconButton.setHtmlClass(HtmlIconUtil.getIconClasses("fa-bars"));
 		add(iconButton);
 
 		iconButton = new WButton("With text content");

--- a/wcomponents-theme/src/main/sass/_wc.buttons.scss
+++ b/wcomponents-theme/src/main/sass/_wc.buttons.scss
@@ -61,7 +61,7 @@ button {
 	text-decoration: underline;
 
 	// class wc_nti (no text image) is applied to buttons and links which hold an image but no visible text.
-	&.wc_nti,
+	.wc_nti,
 	&.wc-icon:before,
 	> .fa {
 		text-decoration: none;

--- a/wcomponents-theme/src/main/sass/wc.link.scss
+++ b/wcomponents-theme/src/main/sass/wc.link.scss
@@ -1,0 +1,5 @@
+// Links which contain a positioned image must be forced to be inline block.
+// For generic `a` styles see sc.common.scss
+.wc_a_ilb {
+	display: inline-block;
+}

--- a/wcomponents-theme/src/main/xslt/wc.ui.button.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.button.xsl
@@ -16,14 +16,6 @@
 					<xsl:if test="@type">
 						<xsl:text> wc-linkbutton</xsl:text>
 					</xsl:if>
-					<xsl:choose>
-						<xsl:when test="@imagePosition">
-							<xsl:value-of select="concat(' wc_btn_img wc_btn_img', @imagePosition)"/><!-- no gap after 2nd `_img` -->
-						</xsl:when>
-						<xsl:when test="@imageUrl">
-							<xsl:text> wc_nti</xsl:text>
-						</xsl:when>
-					</xsl:choose>
 				</xsl:with-param>
 			</xsl:call-template>
 			<xsl:call-template name="title"/>
@@ -62,11 +54,6 @@
 			<xsl:call-template name="accessKey"/>
 			<xsl:choose>
 				<xsl:when test="@imageUrl">
-					<xsl:if test="@imagePosition">
-						<span>
-							<xsl:apply-templates />
-						</span>
-					</xsl:if>
 					<xsl:variable name="alt">
 						<xsl:choose>
 							<xsl:when test="@imagePosition">
@@ -77,7 +64,24 @@
 							</xsl:otherwise>
 						</xsl:choose>
 					</xsl:variable>
-					<img src="{@imageUrl}" alt="{$alt}" />
+					<span>
+						<xsl:attribute name="class">
+							<xsl:choose>
+								<xsl:when test="@imagePosition">
+									<xsl:value-of select="concat('wc_btn_img wc_btn_img', @imagePosition)"/><!-- no gap after 2nd `_img` -->
+								</xsl:when>
+								<xsl:otherwise>
+									<xsl:text>wc_nti</xsl:text>
+								</xsl:otherwise>
+							</xsl:choose>
+						</xsl:attribute>
+						<xsl:if test="@imagePosition">
+							<span>
+								<xsl:apply-templates />
+							</span>
+						</xsl:if>
+						<img src="{@imageUrl}" alt="{$alt}" />
+					</span>
 				</xsl:when>
 				<xsl:otherwise>
 					<xsl:apply-templates />

--- a/wcomponents-theme/src/main/xslt/wc.ui.link.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.link.xsl
@@ -107,7 +107,7 @@
 							</xsl:otherwise>
 						</xsl:choose>
 					</xsl:variable>
-					<img src="{@url}" alt="{$alt}" />
+					<img src="{@imageUrl}" alt="{$alt}" />
 				</xsl:when>
 				<xsl:otherwise>
 					<xsl:apply-templates />

--- a/wcomponents-theme/src/main/xslt/wc.ui.link.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.link.xsl
@@ -1,12 +1,12 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" 
 	xmlns:html="http://www.w3.org/1999/xhtml" version="2.0">
 	<xsl:import href="wc.common.attributes.xsl"/>
-	<!-- 
+	<!--
 		WLink and WInternalLink. 
 	-->
 	<xsl:template match="ui:link">
 		<xsl:param name="imageAltText" select="''"/>
-		<xsl:param name="ajax" select="''"/>
+		<xsl:param name="ajax" select="''"/><!-- file in multi-file-upload -->
 		<xsl:variable name="elementType">
 			<xsl:choose>
 				<xsl:when test="@type">
@@ -28,6 +28,9 @@
 							<xsl:number value="0"/>
 						</xsl:otherwise>
 					</xsl:choose>
+				</xsl:with-param>
+				<xsl:with-param name="class">
+					<xsl:if test="not(@type) and @imageUrl and @imagePosition">wc_a_ilb</xsl:if>
 				</xsl:with-param>
 			</xsl:call-template>
 			<xsl:call-template name="title"/>
@@ -52,6 +55,11 @@
 					<xsl:attribute name="href">
 						<xsl:value-of select="@url"/>
 					</xsl:attribute>
+					<xsl:if test="ui:windowAttributes">
+						<xsl:attribute name="target">
+							<xsl:value-of select="ui:windowAttributes/@name"/>
+						</xsl:attribute>
+					</xsl:if>
 					<xsl:if test="$ajax != ''">
 						<xsl:attribute name="data-wc-ajaxalias">
 							<xsl:value-of select="$ajax"/>
@@ -79,21 +87,11 @@
 							</xsl:choose>
 						</xsl:attribute>
 					</xsl:if>
-					<xsl:if test="ui:windowAttributes">
-						<xsl:attribute name="target">
-							<xsl:value-of select="ui:windowAttributes/@name"/>
-						</xsl:attribute>
-					</xsl:if>
 				</xsl:otherwise>
 			</xsl:choose>
 			<xsl:call-template name="accessKey"/>
 			<xsl:choose>
 				<xsl:when test="@imageUrl">
-					<xsl:if test="@imagePosition">
-						<span>
-							<xsl:apply-templates />
-						</span>
-					</xsl:if>
 					<xsl:variable name="alt">
 						<xsl:choose>
 							<xsl:when test="$imageAltText ne ''">
@@ -107,7 +105,24 @@
 							</xsl:otherwise>
 						</xsl:choose>
 					</xsl:variable>
-					<img src="{@imageUrl}" alt="{$alt}" />
+					<span>
+						<xsl:attribute name="class">
+							<xsl:choose>
+								<xsl:when test="@imagePosition">
+									<xsl:value-of select="concat('wc_btn_img wc_btn_img', @imagePosition)"/><!-- no gap after 2nd `_img` -->
+								</xsl:when>
+								<xsl:otherwise>
+									<xsl:text>wc_nti</xsl:text>
+								</xsl:otherwise>
+							</xsl:choose>
+						</xsl:attribute>
+						<xsl:if test="@imagePosition">
+							<span>
+								<xsl:apply-templates />
+							</span>
+						</xsl:if>
+						<img src="{@imageUrl}" alt="{$alt}" />
+					</span>
 				</xsl:when>
 				<xsl:otherwise>
 					<xsl:apply-templates />
@@ -115,7 +130,7 @@
 			</xsl:choose>
 		</xsl:element>
 	</xsl:template>
-	
+
 	<!-- Window Attrributes applied to WLink -->
 	<xsl:template match="ui:windowAttributes"/>
 </xsl:stylesheet>


### PR DESCRIPTION
When a WLink or WButton has a content image the display method may
result in the button/a becoming blocky by using display:flex. To
alleviate this the whole content is now rendered in an inner span.