### PR TITLE
1158 double handlebars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### API Changes
 
 ### Bug Fixes
-* Fixed partial text matches in dropdown typeahead #1164.
-* MultiFileWidget better handles when the response "lies" and says it is "200 OK" when it isn't #1163.
+* Fixed partial text matches in select element typeahead #1164.
+* WMultiFileWidget better handles when the response "lies" and says it is "200 OK" when it isn't #1163.
+* Fixed double request for images by wrapping initial render in a script element and using Handlebars on that element
+  #1158.
 
 ### Enhancements
 

--- a/wcomponents-theme/build_all.xsl
+++ b/wcomponents-theme/build_all.xsl
@@ -145,11 +145,8 @@
 	<xsl:template match="concat">
 		<x:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml"
 					  version="2.0" exclude-result-prefixes="xsl ui html doc">
-			<x:output encoding="UTF-8" indent="no" method="html" doctype-system="about:legacy-compat" omit-xml-declaration="yes" />
+			<x:output encoding="UTF-8" indent="no" method="xhtml" doctype-system="about:legacy-compat" omit-xml-declaration="yes" media-type="text/html" />
 			<x:strip-space elements="*" />
-			<xsl:comment>
-				<xsl:value-of select="system-property('xsl:vendor')" />
-			</xsl:comment>
 			<xsl:apply-templates select=".//xsl:param[parent::xsl:stylesheet]" />
 			<xsl:apply-templates select=".//xsl:key[parent::xsl:stylesheet]" />
 			<xsl:apply-templates select=".//xsl:variable[parent::xsl:stylesheet]" />

--- a/wcomponents-theme/src/main/js/wc/dom/removeElement.js
+++ b/wcomponents-theme/src/main/js/wc/dom/removeElement.js
@@ -12,7 +12,7 @@ define(["wc/timers"], /** @param timers wc/timers @ignore */ function(timers) {
 	 *
 	 * @function module:wc/dom/removeElement
 	 *
-	 * @param {string} id The id of the element to be removed.
+	 * @param {String|Element} id The element, or id of the element, to be removed.
 	 * @param {int} [useTimeout] If set then wrap the removal in a timeout of this many milliseconds. Probably pointless
 	 * especially if this is called from a finally block.
 	 */
@@ -23,9 +23,9 @@ define(["wc/timers"], /** @param timers wc/timers @ignore */ function(timers) {
 		}
 
 		function _remove() {
-			var el,
+			var el = id.nodeType === Node.ELEMENT_NODE ? id : document.getElementById(id),
 				parent;
-			if ((el = document.getElementById(id)) && (parent = el.parentNode)) {
+			if (el && (parent = el.parentNode)) {
 				parent.removeChild(el);
 			}
 		}

--- a/wcomponents-theme/src/main/js/wc/template.js
+++ b/wcomponents-theme/src/main/js/wc/template.js
@@ -81,16 +81,11 @@ define(["wc/dom/textContent", "lib/handlebars/handlebars", "wc/has", "wc/dom/rem
 						processContainer(document.body);
 					}
 				}
-				else {
+				else if (params && params.source && params.target && params.removeSrc) {
 					// We may end up with the whole page inside a script element.
-					var source = document.getElementById("ui:root"),
-						target = document.getElementById("wc-root"),
-						content;
-					if (source && target) {
-						content = source.innerHTML;
-						removeElement(target); // remove first otherwise double elements!
-						target.innerHTML = content;
-					}
+					var content = source.innerHTML;
+					removeElement(params.source); // remove first otherwise double elements and duplicate IDs
+					params.target.innerHTML = content;
 				}
 			};
 

--- a/wcomponents-theme/src/main/js/wc/template.js
+++ b/wcomponents-theme/src/main/js/wc/template.js
@@ -201,5 +201,6 @@ define(["wc/dom/textContent", "lib/handlebars/handlebars", "wc/has", "wc/dom/rem
 		 * @property {Node|String} source The template source, can be an element or text node which contain the template or a string.
 		 * @property {Node} [target] The element that will be updated with the result of the translation; if not provided then container will be used as the target, if it is a Node.
 		 * @property {Object} [context] The context that will be passed to the compiled template.
+		 * @property {boolean} [removeSrc] Set true to remove the source element from the HTML tree after processing. This will only be honoured if source and target are both defined.
 		 */
 	});

--- a/wcomponents-theme/src/main/js/wc/template.js
+++ b/wcomponents-theme/src/main/js/wc/template.js
@@ -1,5 +1,5 @@
-define(["wc/dom/textContent", "lib/handlebars/handlebars", "wc/has"],
-	function(textContent, Handlebars, has) {
+define(["wc/dom/textContent", "lib/handlebars/handlebars", "wc/has", "wc/dom/removeElement"],
+	function(textContent, Handlebars, has, removeElement) {
 		"use strict";
 
 		/**
@@ -79,6 +79,17 @@ define(["wc/dom/textContent", "lib/handlebars/handlebars", "wc/has"],
 					}
 					else if (document.body) {
 						processContainer(document.body);
+					}
+				}
+				else {
+					// We may end up with the whole page inside a script element.
+					var source = document.getElementById("ui:root"),
+						target = document.getElementById("wc-root"),
+						content;
+					if (source && target) {
+						content = source.innerHTML;
+						removeElement(target); // remove first otherwise double elements!
+						target.innerHTML = content;
 					}
 				}
 			};
@@ -174,7 +185,9 @@ define(["wc/dom/textContent", "lib/handlebars/handlebars", "wc/has"],
 			 * @returns {undefined}
 			 */
 			this.unregisterHelper = function(token) {
-				Handlebars.unregisterHelper(token);
+				if (!has("ie") || has("ie") > 9) {
+					Handlebars.unregisterHelper(token);
+				}
 			};
 		}
 

--- a/wcomponents-theme/src/main/js/wc/ui/template.js
+++ b/wcomponents-theme/src/main/js/wc/ui/template.js
@@ -13,7 +13,7 @@ require(["wc/template", "wc/dom/initialise", "wc/dom/removeElement"], function (
 				templateTarget;
 			if (templateSrc) {
 				templateTarget = document.getElementById("wc-root");
-				template.process({ source: templateSrc, target: templateTarget });
+				template.process({ source: templateSrc, target: templateTarget, removeSrc: true });
 				removeElement(templateSrc);
 				return;
 			}

--- a/wcomponents-theme/src/main/js/wc/ui/template.js
+++ b/wcomponents-theme/src/main/js/wc/ui/template.js
@@ -1,4 +1,4 @@
-require(["wc/template", "wc/dom/initialise"], function (template, initialise) {
+require(["wc/template", "wc/dom/initialise", "wc/dom/removeElement"], function (template, initialise, removeElement) {
 	/*
 	 * This module exists because QC158400.
 	 */
@@ -9,6 +9,14 @@ require(["wc/template", "wc/dom/initialise"], function (template, initialise) {
 		 * @public
 		 */
 		preInit: function () {
+			var templateSrc = document.getElementById("ui:root"),
+				templateTarget;
+			if (templateSrc) {
+				templateTarget = document.getElementById("wc-root");
+				template.process({ source: templateSrc, target: templateTarget });
+				removeElement(templateSrc);
+				return;
+			}
 			Array.prototype.forEach.call(document.getElementsByTagName("form"), function (form) {
 				template.process({ source: form });
 			});

--- a/wcomponents-theme/src/main/xslt/wc.common.html.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.html.xsl
@@ -155,4 +155,16 @@
 		Do not put a HTML form inside any ui:application.
 	-->
 	<xsl:template match="html:form" />
+
+	<xsl:template match="html:script[not(@src)]">
+		<xsl:variable name="scriptcontent">
+			<xsl:value-of select="normalize-space(text())"/>
+		</xsl:variable>
+		<xsl:if test="$scriptcontent != ''">
+			<xsl:element name="script">
+				<xsl:apply-templates select="@*"/>
+				<xsl:value-of select="$scriptcontent" disable-output-escaping="yes"/>
+			</xsl:element>
+		</xsl:if>
+	</xsl:template>
 </xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.common.html.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.common.html.xsl
@@ -156,12 +156,27 @@
 	-->
 	<xsl:template match="html:form" />
 
-	<xsl:template match="html:script[not(@src)]">
+	<xsl:template match="html:script[not(@src)]|html:style">
 		<xsl:variable name="scriptcontent">
 			<xsl:value-of select="normalize-space(text())"/>
 		</xsl:variable>
 		<xsl:if test="$scriptcontent != ''">
-			<xsl:element name="script">
+			<xsl:variable name="element">
+				<xsl:choose>
+					<xsl:when test="self::html:script">script</xsl:when>
+					<xsl:otherwise>style</xsl:otherwise>
+				</xsl:choose>
+			</xsl:variable>
+			<xsl:element name="{$element}">
+				<xsl:if test="not(@type)">
+					<xsl:attribute name="type">
+						<xsl:text>text/</xsl:text>
+						<xsl:choose>
+							<xsl:when test="self::html:script">javascript</xsl:when>
+							<xsl:otherwise>css</xsl:otherwise>
+						</xsl:choose>
+					</xsl:attribute>
+				</xsl:if>
 				<xsl:apply-templates select="@*"/>
 				<xsl:value-of select="$scriptcontent" disable-output-escaping="yes"/>
 			</xsl:element>

--- a/wcomponents-theme/src/main/xslt/wc.ui.root.n.makeRequireConfig.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.root.n.makeRequireConfig.xsl
@@ -15,8 +15,7 @@
 		You really don't want to be here.
 	-->
 	<xsl:template name="makeRequireConfig">
-		<script type="text/javascript" class="wcconfig"><!-- todo: I think this class is no longer required -->
-			<!-- Yes, we are defining a global require here. We are not using window.require = {} because the doco says this can cause problems in IE. -->
+		<xsl:variable name="requireconfigcontent">
 			<xsl:text>(function(){
 	var wcconfig, timing,
 		config = {
@@ -107,6 +106,10 @@
 	if(window.requirejs) window.requirejs.config(config);
 	else require = config;
 })();</xsl:text>
+		</xsl:variable>
+		<script type="text/javascript" class="wcconfig"><!-- todo: I think this class is no longer required -->
+			<!-- Yes, we are defining a global require here. We are not using window.require = {} because the doco says this can cause problems in IE. -->
+			<xsl:value-of select="$requireconfigcontent" disable-output-escaping="yes"/>
 		</script>
 	</xsl:template>
 </xsl:stylesheet>

--- a/wcomponents-theme/src/main/xslt/wc.ui.root.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.root.xsl
@@ -105,7 +105,10 @@
 				<div id="wc-ui-loading">
 					<div tabindex="0" class="wc-icon">&#x200b;</div>
 				</div>
-				<xsl:apply-templates />
+				<div id="wc-root"></div>
+				<script type="x-handlebars-template" id="ui:root">
+					<xsl:apply-templates />
+				</script>
 			</body>
 		</html>
 	</xsl:template>

--- a/wcomponents-theme/src/main/xslt/wc.ui.root.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.root.xsl
@@ -95,7 +95,6 @@
 					the page level loading indicator.
 				-->
 				<div id="wc-shim" class="wc_shim_loading">
-					<xsl:text>&#xa0;</xsl:text>
 					<noscript>
 						<p>
 							<xsl:text>You must have JavaScript enabled to use this application.</xsl:text>
@@ -103,10 +102,10 @@
 					</noscript>
 				</div>
 				<div id="wc-ui-loading">
-					<div tabindex="0" class="wc-icon">&#x200b;</div>
+					<div tabindex="0" class="wc-icon"></div>
 				</div>
 				<div id="wc-root"></div>
-				<script type="x-handlebars-template" id="ui:root">
+				<script type="text/x-handlebars-template" id="ui:root" hidden="hidden" style="display:none;">
 					<xsl:apply-templates />
 				</script>
 			</body>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.subTr.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.subTr.xsl
@@ -75,7 +75,7 @@
 			-->
 			<xsl:if test="$myTable/ui:rowselection">
 				<td class="wc_table_sel_wrapper">
-					<xsl:text>&#x2002;</xsl:text>
+					<xsl:text>&#x200b;</xsl:text>
 				</td>
 			</xsl:if>
 
@@ -84,7 +84,7 @@
 				to its parent row.
 			-->
 			<td class="wc_table_rowexp_container">
-				<xsl:text>&#x2002;</xsl:text>
+				<xsl:text>&#x200b;</xsl:text>
 			</td>
 
 			<td>

--- a/wcomponents-theme/src/main/xslt/wc.ui.table.thead.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.table.thead.xsl
@@ -12,7 +12,7 @@
 			<tr>
 				<xsl:if test="../ui:rowselection">
 					<th class="wc_table_sel_wrapper" scope="col" aria-hidden="true">
-						<xsl:text>&#xa0;</xsl:text>
+						<xsl:text>&#x200b;</xsl:text>
 					</th>
 				</xsl:if>
 				<xsl:if test="../ui:rowexpansion">
@@ -23,7 +23,6 @@
 					</th>
 				</xsl:if>
 				<xsl:apply-templates select="ui:th" mode="thead"/>
-				
 			</tr>
 		</thead>
 	</xsl:template>

--- a/wcomponents-theme/src/main/xslt/wc.ui.treeitem.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.treeitem.xsl
@@ -85,7 +85,7 @@
 					</xsl:attribute>
 					<xsl:call-template name="title"/>
 					<span class="wc_leaf_vopener wc-icon" aria-hidden="true">
-						<xsl:text>&#x0a;</xsl:text>
+						<xsl:text>&#x200b;</xsl:text>
 					</span>
 					<xsl:call-template name="treeitemContent"/>
 				</xsl:when>
@@ -104,7 +104,7 @@
 							<xsl:value-of select="concat(@id, '-branch-name')"/>
 					</xsl:variable>
 					<button class="wc-nobutton wc-invite wc_leaf_vopener wc-icon" aria-hidden="true" type="button" tabindex="-1">
-						<xsl:text>&#x0a;</xsl:text>
+						<xsl:text>&#x200b;</xsl:text>
 					</button>
 					<!-- leave tabindex="0" on this button, it is used as a short-hand to find focusable controls in the core menu JavaScript. -->
 					<button type="button" class="wc-nobutton wc-invite wc_leaf" id="{$nameButtonId}" aria-controls="{@id}" tabindex="0">
@@ -153,12 +153,13 @@
 			<xsl:if test="@imageUrl">
 				<img src="{@imageUrl}" alt=""/>
 			</xsl:if>
+			<xsl:text>&#x200b;</xsl:text>
 		</span>
 		<span class="wc_leaf_name">
 			<xsl:value-of select="@label"/>
 		</span>
 		<span class="wc_leaf_hopener wc-icon" aria-hidden="true">
-			<xsl:text>&#x0a;</xsl:text>
+			<xsl:text>&#x200b;</xsl:text>
 		</span>
 	</xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
1.3 solution for # 1158. 

Having tried XML output from the XSLT processor along with ensuring no
empty elements got short-tagged and `script` elements did not get
output escaping I remembered I converted the whole lot to XSLT2.0 so I
was able to use output method `xhtml`.

This has its own problems: script elements are no longer automatically
output escaped so JavaScript which contains `&&`, `<` etc can go
terribly wrong. To alleviate this I have built a template match on
`html:script` which will ensure the content is unescaped. Unfortunately
to do this just for script elements requires using the deprecated
`disable-output-escaping="on"` attribute on `xsl:value-of` and/or
`xsl:text` when doing the output. We use what we can.

This is an exceptionally good argument against XML/XSLT for web
applications.