### PR TITLE
CSS simplification and a11y fixes

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/calendar.js
+++ b/wcomponents-theme/src/main/js/wc/ui/calendar.js
@@ -1,44 +1,3 @@
-/**
- * Provides a calendar based date chooser control for use by WDateFields when a native date control is not available
- * and WPartialDateFields in all cases.
- *
- * @typedef {Object} module:wc/ui/calendar.config() Optional module configuration.
- * @property {?int} min The minimum year to allow in the date picker.
- * @default 1000
- * @property {?int} max The maximum year to allow in the date picker.
- * @default 9999.
- *
- * @module
- * @requires module:wc/dom/attribute
- * @requires module:wc/date/addDays
- * @requires module:wc/date/copy
- * @requires module:wc/date/dayName
- * @requires module:wc/date/daysInMonth
- * @requires module:wc/date/getDifference
- * @requires module:wc/date/monthName
- * @requires module:wc/date/today
- * @requires module:wc/date/interchange
- * @requires module:wc/dom/classList
- * @requires module:wc/dom/event
- * @requires module:wc/dom/focus
- * @requires module:wc/dom/shed
- * @requires module:wc/dom/tag
- * @requires module:wc/dom/viewportCollision
- * @requires module:wc/dom/getBox
- * @requires module:wc/dom/Widget
- * @requires module:wc/i18n/i18n
- * @requires module:wc/loader/resource
- * @requires module:wc/isNumeric
- * @requires module:wc/ui/dateField
- * @requires module:wc/dom/initialise
- * @requires module:wc/timers
- * @requires module:lib/handlebars
- * @requires module:wc/config
- *
- * @see {@link module:wc/ui/datefield}
- *
- * @todo needs a lot of documentation of private members.
- */
 define(["wc/dom/attribute",
 		"wc/date/addDays",
 		"wc/date/copy",
@@ -64,11 +23,9 @@ define(["wc/dom/attribute",
 		"wc/timers",
 		"lib/handlebars/handlebars",
 		"wc/config"],
-
 function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthName, today, interchange, classList, event,
 		focus, shed, tag, viewportCollision, getBox, Widget, i18n, loader, isNumeric, dateField, initialise,
 		timers, handlebars, wcconfig) {
-
 	"use strict";
 
 	/**
@@ -516,6 +473,7 @@ function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthNam
 
 			container = document.createElement("div");
 			container.id = CONTAINER_ID;
+			container.setAtribute("role", "dialog");
 			document.body.appendChild(container);
 			container.innerHTML = calendar;
 			document.getElementById(MONTH_SELECT_ID).selectedIndex = _today.getMonth();
@@ -1161,9 +1119,44 @@ function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthNam
 		this._keydownEventHandler = _calendarKeydownEvent;
 	}
 
-	var /** @alias module:wc/ui/calendar */ instance = new Calendar();
-
 	/**
+	 * Provides a calendar based date chooser control for use by WDateFields when a native date control is not available
+	 * and WPartialDateFields in all cases.
+	 *
+	 * @module
+	 * @requires module:wc/dom/attribute
+	 * @requires module:wc/date/addDays
+	 * @requires module:wc/date/copy
+	 * @requires module:wc/date/dayName
+	 * @requires module:wc/date/daysInMonth
+	 * @requires module:wc/date/getDifference
+	 * @requires module:wc/date/monthName
+	 * @requires module:wc/date/today
+	 * @requires module:wc/date/interchange
+	 * @requires module:wc/dom/classList
+	 * @requires module:wc/dom/event
+	 * @requires module:wc/dom/focus
+	 * @requires module:wc/dom/shed
+	 * @requires module:wc/dom/tag
+	 * @requires module:wc/dom/viewportCollision
+	 * @requires module:wc/dom/getBox
+	 * @requires module:wc/dom/Widget
+	 * @requires module:wc/i18n/i18n
+	 * @requires module:wc/loader/resource
+	 * @requires module:wc/isNumeric
+	 * @requires module:wc/ui/dateField
+	 * @requires module:wc/dom/initialise
+	 * @requires module:wc/timers
+	 * @requires module:lib/handlebars
+	 * @requires module:wc/config
+	 *
+	 * @see {@link module:wc/ui/datefield}
+	 *
+	 * @todo needs a lot of documentation of private members.
+	 */
+	var instance = new Calendar();
+
+	/*
 	 * Registers a handlebars helper that takes a dayname and returns the shortest possible meaningful
 	 * abbreviation for use when building a month-view calendar as each "day of week" column header.
 	 * For example in English this suffices: M, T, W, T, F, S, S (even though S and S are theoretically
@@ -1179,4 +1172,12 @@ function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthNam
 
 	initialise.register(instance);
 	return instance;
+
+	/**
+	 * @typedef {Object} module:wc/ui/calendar.config() Optional module configuration.
+	 * @property {?int} min The minimum year to allow in the date picker.
+	 * @default 1000
+	 * @property {?int} max The maximum year to allow in the date picker.
+	 * @default 9999.
+	 */
 });

--- a/wcomponents-theme/src/main/js/wc/ui/dateField.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dateField.js
@@ -122,7 +122,7 @@ define(["wc/has",
 				// Add the calendar launch button.
 				if (!(LAUNCHER.findDescendant(element))) {
 					launcherHtml = "<button value='" + id + "_input' tabindex='-1' id='" + id +
-							"_cal' type='button' aria-hidden='true' class='wc_wdf_cal wc_btn_icon wc-invite' ";
+							"_cal' type='button' aria-hidden='true' class='wc_wdf_cal wc_btn_icon wc-invite' aria-haspopup='true'";
 					if (shed.isDisabled(childEl)) {
 						launcherHtml += " disabled='disabled'";
 					}

--- a/wcomponents-theme/src/main/resource/wc.ui.dateField.calendar.html
+++ b/wcomponents-theme/src/main/resource/wc.ui.dateField.calendar.html
@@ -8,7 +8,7 @@
 		<input id="wc_calyear" value="{{fullYear}}" autocomplete="off" type="number" title="{{yearLabel}}" min="1000" max="9999"/><!-- DON'T GIVE NAME! -->
 	</div>
 	<div class="wc-column">
-    <button type="button" class="wc_wdf_mv wc_btn_icon wc-invite" value="-1" title="{{lastMonth}}"><span aria-hidden="true" class="fa fa-calendar-minus-o"></span></button>
+	<button type="button" class="wc_wdf_mv wc_btn_icon wc-invite" value="-1" title="{{lastMonth}}"><span aria-hidden="true" class="fa fa-calendar-minus-o"></span></button>
 		<button type="button" class="wc_wdf_mv wc_btn_icon wc-invite" value="t" title="{{today}}"><span aria-hidden="true" class="fa fa-calendar-o"></span></button>
 		<button type="button" class="wc_wdf_mv wc_btn_icon wc-invite" value="1" title="{{nextMonth}}"><span aria-hidden="true" class="fa fa-calendar-plus-o"></span></button>
 	</div>

--- a/wcomponents-theme/src/main/sass/_colors.scss
+++ b/wcomponents-theme/src/main/sass/_colors.scss
@@ -94,6 +94,11 @@ $wc-ui-color-border: #ccc !default;
 $wc-ui-color-border-form-control: $wc-ui-color-border !default;
 
 // *****************************************************************************
+// BODY
+$wc-ui-body-bg: $wc-use-color-global-bg !default;
+$wc-ui-body-fg: $wc-use-color-global-fg !default;
+
+// *****************************************************************************
 // LINKS
 // Set to -1 to not output a colour block for `a` elements.
 $wc-ui-color-link: $std-color-primary !default;

--- a/wcomponents-theme/src/main/sass/_vars.scss
+++ b/wcomponents-theme/src/main/sass/_vars.scss
@@ -270,6 +270,12 @@ $wc-list-layout-ordered-spacing: 2rem !default;
 $wc-list-layout-bar-width-offset: 2 * $wc-gap-normal !default;
 
 // *****************************************************************************
+// WColumnLayout
+// *****************************************************************************
+// Important to ensure heading elements are sized correctly.
+$wc-collapsible-icon-width: $wc-icon-normal !default;
+
+// *****************************************************************************
 // WColumn, ColumnLayout
 // *****************************************************************************
 // Provides for a list of support COLUMN widths for WColumn and ColumnLayout. This is similar to $wc-fld-list below but

--- a/wcomponents-theme/src/main/sass/_wc.common.color.scss
+++ b/wcomponents-theme/src/main/sass/_wc.common.color.scss
@@ -1,8 +1,8 @@
 @import 'mixins-common';
 
 body {
-	background-color: $wc-ui-color-global-bg;
-	color: $wc-ui-color-global-fg;
+	background-color: $wc-ui-body-bg;
+	color: $wc-ui-body-fg;
 }
 
 input,

--- a/wcomponents-theme/src/main/sass/_wc.section.color.scss
+++ b/wcomponents-theme/src/main/sass/_wc.section.color.scss
@@ -1,7 +1,7 @@
 @import 'mixins-common';
 
 @if ($wc-ui-color-section-heading-bg != -1) {
-	.wc-section > .wc-decoratedlabel {
+	section > header {
 		background-color: $wc-ui-color-section-heading-bg;
 		color: $wc-ui-color-section-heading-fg;
 

--- a/wcomponents-theme/src/main/sass/wc.collapsible.scss
+++ b/wcomponents-theme/src/main/sass/wc.collapsible.scss
@@ -1,9 +1,6 @@
 // WCollapsible is a close map of the HTML5 details element in which the header is a summary element.
 @import 'mixins-common';
 
-// Important to ensure heading elements are sized correctly.
-$wc-collapsible-icon-width: $wc-icon-normal;
-
 details {
 	// We only have to style immediate child elements of the collapsible container. In an ideal world we would not have
 	// to do this but so far only webkit has native support for <details> and that is still flawed.

--- a/wcomponents-theme/src/main/sass/wc.section.scss
+++ b/wcomponents-theme/src/main/sass/wc.section.scss
@@ -64,20 +64,21 @@ section {
 			}
 		}
 	}
-}
 
-// We *really* want to prevent Margin being set on the WPanel content holder of a WSection.
-// We also want to make sure the default styling of types FEATURE, BOX, BLOCK etc are not
-// applied. It would be better if this was enforced in the Java API.
-.wc-section > .wc-panel {
-	background-color: transparent;
-	border: 0 none;
-	margin: 0;
+	// We *really* want to prevent Margin being set on the WPanel content holder of a WSection.
+	// We also want to make sure the default styling of types FEATURE, BOX, BLOCK etc are not
+	// applied. It would be better if this was enforced in the Java API.
+	&.wc-section > .wc-panel {
+		background-color: transparent;
+		border: 0 none;
+		margin: 0;
 
-	@if ($wc-section-space-normal > 0) {
-		padding: $wc-section-space-normal;
+		@if ($wc-section-space-normal > 0) {
+			padding: $wc-section-space-normal;
+		}
 	}
 }
+
 
 @import 'wc.section.respond';
 @import 'wc.section.color';

--- a/wcomponents-theme/src/main/xslt/wc.ui.dateField.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.dateField.xsl
@@ -51,7 +51,7 @@
 				</xsl:attribute>
 			</xsl:element>
 			<!-- This is the date picker launch control element. -->
-			<button value="{concat(@id,'_input')}" tabindex="-1" type="button" aria-hidden="true" class="wc_wdf_cal wc_btn_icon wc-invite">
+			<button value="{concat(@id,'_input')}" tabindex="-1" type="button" aria-hidden="true" class="wc_wdf_cal wc_btn_icon wc-invite" aria-haspopup="true">
 				<xsl:call-template name="disabledElement"/>
 				<xsl:call-template name="icon">
 					<xsl:with-param name="class">fa-calendar</xsl:with-param>

--- a/wcomponents-theme/src/main/xslt/wc.ui.simpleinput.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.simpleinput.xsl
@@ -214,7 +214,17 @@
 	-->
 	<xsl:template match="ui:textarea">
 		<xsl:variable name="tickerId" select="concat(@id,'_tick')"/>
-		<span>
+		<xsl:variable name="element">
+			<xsl:choose>
+				<xsl:when test="ui:rtf">
+					<xsl:text>div</xsl:text>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:text>span</xsl:text>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+		<xsl:element name="{$element}">
 			<xsl:call-template name="commonInputWrapperAttributes"/>
 			<textarea>
 				<xsl:call-template name="wrappedTextInputAttributes"/>
@@ -256,7 +266,7 @@
 			<xsl:if test="@maxLength">
 				<output id="{$tickerId}" name="{$tickerId}" for="{@id}_input" hidden="hidden"></output>
 			</xsl:if>
-		</span>
+		</xsl:element>
 	</xsl:template>
 
 	<xsl:template match="ui:rtf"/>


### PR DESCRIPTION
Part of #1160. This code simplifies the core CSS making overrides easier. This is a mitigation only: it does not address the build order issue which is still under investigation.

Fix some minor a11y issues in the date-picker calendar.