### PR TITLE
Selenium Performance

### DIFF
--- a/wcomponents-examples/pom.xml
+++ b/wcomponents-examples/pom.xml
@@ -127,6 +127,7 @@
 					<parallelTestsTimeoutInSeconds>0</parallelTestsTimeoutInSeconds>
 					<threadCount>4</threadCount>
 					<perCoreThreadCount>false</perCoreThreadCount>
+					<rerunFailingTestsCount>2</rerunFailingTestsCount>
 					<properties>
 						<property>
 							<name>listener</name>


### PR DESCRIPTION
Allow failed tests to rerun twice.

Relates to #1132.