### PR TITLE
Url encode

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/XmlStringBuilder.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/XmlStringBuilder.java
@@ -207,13 +207,7 @@ public final class XmlStringBuilder extends PrintWriter {
 	 * @param value the URL value of the attribute to be added.
 	 */
 	public void appendUrlAttribute(final String name, final String value) {
-		write(' ');
-		write(name);
-		write("=\"");
-		if (value != null) {
-			write(WebUtilities.encodeUrl(value));
-		}
-		write('"');
+		appendAttribute(name, value);
 	}
 
 	/**

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/AbstractWebXmlRendererTestCase.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/AbstractWebXmlRendererTestCase.java
@@ -7,7 +7,6 @@ import com.github.bordertech.wcomponents.UIContextHolder;
 import com.github.bordertech.wcomponents.UIContextImpl;
 import com.github.bordertech.wcomponents.WComponent;
 import com.github.bordertech.wcomponents.WebComponent;
-import com.github.bordertech.wcomponents.WebUtilities;
 import com.github.bordertech.wcomponents.layout.UIManager;
 import com.github.bordertech.wcomponents.servlet.WebXmlRenderContext;
 import com.github.bordertech.wcomponents.util.NullWriter;
@@ -195,9 +194,7 @@ public abstract class AbstractWebXmlRendererTestCase extends AbstractWComponentT
 	 */
 	public void assertXpathUrlEvaluatesTo(final String expectedUrlValue, final String xpathExpression,
 			final String xml) throws SAXException, IOException, XpathException {
-		// As XPATH undoes the XML entites, only percentEncode the expected value
-		String encoded = WebUtilities.percentEncodeUrl(expectedUrlValue);
-		XMLAssert.assertXpathEvaluatesTo(encoded, xpathExpression, xml);
+		XMLAssert.assertXpathEvaluatesTo(expectedUrlValue, xpathExpression, xml);
 	}
 
 	/**

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/LinkOptionsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/LinkOptionsExample.java
@@ -77,7 +77,7 @@ public class LinkOptionsExample extends WPanel {
 	/**
 	 * link URL.
 	 */
-	private static final String URL = "http://www.example.com";
+	private static final String URL = "http://www.example.com/&foo=fu%2Fbar";
 
 	private final WTextField tfUrlField = new WTextField();
 


### PR DESCRIPTION
See PR #1211:

> This is basically reverting to previous behaviour. This needs to be
thought out in detail before we start messing with URLs. There is one
unit test, my hunch is it needs at least 10 to cover the various
permutations.

> Before this change this `http://www.example.com/&foo=fu%2Fbar` would
be rendered as this `http://www.example.com/&foo=fu/bar` and that's not
right at all.

> My gut feeling is that URL encoding (all or part of the URL) is the
responsibility of the application developer. If we give it some thought
maybe there is a way.... I guess if there's a space in the URL it
hasn't been encoded (but maybe part of it has?)