### PR TITLE
Cherry pick remove url encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### Bug Fixes
 
-* Reverted an undocumented change to URL handling which resulted in URLs becoming mal-formed under some circumstances.
+* Reverted a change (commit facddabd6842e884877ba762d921b517b2f49e74 cherry picked see PR #1185) to URL handling which resulted in URLs becoming
+  mal-formed under some circumstances.
 * Improved the Sass to CSS build to ensure implementation CSS is placed after default CSS in the output #1160.
 * Modified `HtmlSanitizerUtil` and `HtmlToXMLUtil` to handle escaping brackets'; `WTextArea` now defaults to `santizeOutput` on #1158.
 * Remove client handlebars i18n support #1158.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+* Reverted an undocumented change to URL handling which resulted in URLs becoming mal-formed under some circumstances.
 * Improved the Sass to CSS build to ensure implementation CSS is placed after default CSS in the output #1160.
 * Modified `HtmlSanitizerUtil` and `HtmlToXMLUtil` to handle escaping brackets'; `WTextArea` now defaults to `santizeOutput` on #1158.
 * Remove client handlebars i18n support #1158.

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/XmlStringBuilder.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/XmlStringBuilder.java
@@ -207,13 +207,7 @@ public final class XmlStringBuilder extends PrintWriter {
 	 * @param value the URL value of the attribute to be added.
 	 */
 	public void appendUrlAttribute(final String name, final String value) {
-		write(' ');
-		write(name);
-		write("=\"");
-		if (value != null) {
-			write(WebUtilities.encodeUrl(value));
-		}
-		write('"');
+		appendAttribute(name, value);
 	}
 
 	/**

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/AbstractWebXmlRendererTestCase.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/AbstractWebXmlRendererTestCase.java
@@ -7,7 +7,6 @@ import com.github.bordertech.wcomponents.UIContextHolder;
 import com.github.bordertech.wcomponents.UIContextImpl;
 import com.github.bordertech.wcomponents.WComponent;
 import com.github.bordertech.wcomponents.WebComponent;
-import com.github.bordertech.wcomponents.WebUtilities;
 import com.github.bordertech.wcomponents.layout.UIManager;
 import com.github.bordertech.wcomponents.servlet.WebXmlRenderContext;
 import com.github.bordertech.wcomponents.util.NullWriter;
@@ -195,9 +194,7 @@ public abstract class AbstractWebXmlRendererTestCase extends AbstractWComponentT
 	 */
 	public void assertXpathUrlEvaluatesTo(final String expectedUrlValue, final String xpathExpression,
 			final String xml) throws SAXException, IOException, XpathException {
-		// As XPATH undoes the XML entites, only percentEncode the expected value
-		String encoded = WebUtilities.percentEncodeUrl(expectedUrlValue);
-		XMLAssert.assertXpathEvaluatesTo(encoded, xpathExpression, xml);
+		XMLAssert.assertXpathEvaluatesTo(expectedUrlValue, xpathExpression, xml);
 	}
 
 	/**

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/LinkOptionsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/LinkOptionsExample.java
@@ -77,7 +77,7 @@ public class LinkOptionsExample extends WPanel {
 	/**
 	 * link URL.
 	 */
-	private static final String URL = "http://www.example.com";
+	private static final String URL = "http://www.example.com/&foo=fu%2Fbar";
 
 	private final WTextField tfUrlField = new WTextField();
 


### PR DESCRIPTION
Partial revert URL attribute percent encoding change that was cherry picked from "eddie" via PR #1183. The change caused some URLs to become mal-formed. 
