### PR TITLE
Allow custom XHR error handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 ### Enhancements
+* Allow custom AJAX error handlers so that we can handle *any* response format conceivable, e.g. XML, JSON, protobuf, binary.
 
 ## Release 1.4.3
 

--- a/wcomponents-theme/src/main/js/wc/ajax/handleError.js
+++ b/wcomponents-theme/src/main/js/wc/ajax/handleError.js
@@ -4,17 +4,20 @@ define(["wc/config", "wc/i18n/i18n", "wc/mixin"], function(wcconfig, i18n, mixin
 	 * Allows for customized error messages based on HTTP status code by setting a config object like so:
 	 * @example
 	 require(["wc/config"], function(wcconfig){
-	 wcconfig.set({ messages: {
-	 403:"Oh noes! A 403 occurred!",
-	 404: "I can't find it!",
-	 200: "Some gateway proxies don't know basic HTTP",
-	 error: "An error occurred and I have not set a specific message for it!"
+	  wcconfig.set({ messages: {
+	  403:"Oh noes! A 403 occurred!",
+	  404: "I can't find it!",
+	  418: function(response) { return "Short and stout"; },
+	  200: "Some gateway proxies don't know basic HTTP",
+	  error: "An error occurred and I have not set a specific message for it!"
 	 }
 	 },"wc/ui/xhr");
 	 });
+	 * Note that you can provide either a string or function that will be passed the raw XHR response
+	 * and is expected to return a string.
 	 *
 	 * @param {XHR} response An XHR response.
-	 * @param {Object} [messages] Optionsally provide the messages object directly to this function.
+	 * @param {Object} [messages] Optionally provide the messages object directly to this function.
 	 * @returns {string} An error message, in order of preference:
 	 * - A custom message specific to the status code, provided in the module configuration
 	 * - A custom default error message
@@ -29,6 +32,14 @@ define(["wc/config", "wc/i18n/i18n", "wc/mixin"], function(wcconfig, i18n, mixin
 				message = msgs[response.status];
 				if (!message) {
 					message = msgs.error;
+				}
+				if (message && typeof message === "function") {
+					// a message override has been provided and it's a function which will provide the actual message.
+					try {
+						message = message(response);
+					} catch (ex) {
+						console.warn(ex);  // consume this error and continue
+					}
 				}
 			}
 			/*
@@ -51,7 +62,7 @@ define(["wc/config", "wc/i18n/i18n", "wc/mixin"], function(wcconfig, i18n, mixin
 	/**
 	 * Gets application specific message overrides, if configured.
 	 * @returns {Object} Message overrides for specific status codes, if set.
-	 * If there is a conflict then the message set in the messages aregument takes precedence over those in module config.
+	 * If there is a conflict then the message set in the messages argument takes precedence over those in module config.
 	 */
 	function getMessageOverrides() {
 		var result = {}, config = wcconfig.get("wc/ui/xhr"),

--- a/wcomponents-theme/src/test/intern/wc.ajax.handleError.test.js
+++ b/wcomponents-theme/src/test/intern/wc.ajax.handleError.test.js
@@ -146,6 +146,17 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils"], functi
 				wcconfig.set({ messages: {
 					403: "Oh noes! A 403 occurred!",
 					404: "I can't find it!",
+					418: function(response) {
+						// this is an example of handling a JSON response body
+						var data;
+						try {
+							data = JSON.parse(response.responseText);
+							data = data.message;
+						} catch (ex) {
+							data = response.responseText;
+						}
+						return data + " " + response.status;
+					},
 					200: "Some gateway proxies don't know basic HTTP",
 					error: "An error occurred and I have not set a specific message for it!"
 				}}, "wc/ui/xhr");
@@ -157,6 +168,11 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils"], functi
 				// 404
 				expected = "I can't find it!";
 				response = new MockResponse(404, "foo", "bar");
+				actual = controller.getErrorMessage(response);
+				assert.strictEqual(actual, expected);
+				// 418
+				expected = "Short and stout 418";
+				response = new MockResponse(418, "{ \"message\": \"Short and stout\" }", "I'm a teapot");
 				actual = controller.getErrorMessage(response);
 				assert.strictEqual(actual, expected);
 				// 200


### PR DESCRIPTION
This simple change allows WComponents AJAX error handling to process any conceivable response format and puts the control in the hands of the application developers should they need it.
