### PR TITLE
Release 1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## Release in-progress
 
 ### API Changes
+
+### Bug Fixes
+
+### Enhancements
+
+## Release 1.4.4
+
+### API Changes
 * JS only: deprecated the use of wc/i18n/i18n as a loader plugin (in favor of async methods).
 
 ### Bug Fixes

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.github.bordertech.wcomponents</groupId>
 	<artifactId>wcomponents-parent</artifactId>
-	<version>1.4.4-SNAPSHOT</version>
+	<version>1.4.4</version>
 
 	<packaging>pom</packaging>
 
@@ -58,7 +58,7 @@
 		<url>https://github.com/bordertech/wcomponents</url>
 		<connection>scm:git:https://github.com/bordertech/wcomponents.git</connection>
 		<developerConnection>scm:git:https://github.com/bordertech/wcomponents.git</developerConnection>
-		<tag>wcomponents-1.0.0</tag>
+		<tag>wcomponents-parent-1.4.4</tag>
 	</scm>
 
 	<issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.github.bordertech.wcomponents</groupId>
 	<artifactId>wcomponents-parent</artifactId>
-	<version>1.4.4</version>
+	<version>1.4.5-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 
@@ -58,7 +58,7 @@
 		<url>https://github.com/bordertech/wcomponents</url>
 		<connection>scm:git:https://github.com/bordertech/wcomponents.git</connection>
 		<developerConnection>scm:git:https://github.com/bordertech/wcomponents.git</developerConnection>
-		<tag>wcomponents-parent-1.4.4</tag>
+		<tag>wcomponents-1.0.0</tag>
 	</scm>
 
 	<issueManagement>

--- a/wcomponents-app-archetype/pom.xml
+++ b/wcomponents-app-archetype/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4-SNAPSHOT</version>
+		<version>1.4.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-app-archetype/pom.xml
+++ b/wcomponents-app-archetype/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4</version>
+		<version>1.4.5-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-bundle/pom.xml
+++ b/wcomponents-bundle/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4-SNAPSHOT</version>
+		<version>1.4.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-bundle/pom.xml
+++ b/wcomponents-bundle/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4</version>
+		<version>1.4.5-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-core/pom.xml
+++ b/wcomponents-core/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4-SNAPSHOT</version>
+		<version>1.4.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-core/pom.xml
+++ b/wcomponents-core/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4</version>
+		<version>1.4.5-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-examples-lde/pom.xml
+++ b/wcomponents-examples-lde/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4-SNAPSHOT</version>
+		<version>1.4.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-examples-lde/pom.xml
+++ b/wcomponents-examples-lde/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4</version>
+		<version>1.4.5-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-examples/pom.xml
+++ b/wcomponents-examples/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4-SNAPSHOT</version>
+		<version>1.4.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-examples/pom.xml
+++ b/wcomponents-examples/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4</version>
+		<version>1.4.5-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-findbugs-plugin/pom.xml
+++ b/wcomponents-findbugs-plugin/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4-SNAPSHOT</version>	
+		<version>1.4.4</version>	
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-findbugs-plugin/pom.xml
+++ b/wcomponents-findbugs-plugin/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4</version>	
+		<version>1.4.5-SNAPSHOT</version>	
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-i18n/pom.xml
+++ b/wcomponents-i18n/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4-SNAPSHOT</version>
+		<version>1.4.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-i18n/pom.xml
+++ b/wcomponents-i18n/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4</version>
+		<version>1.4.5-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-lde/pom.xml
+++ b/wcomponents-lde/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4-SNAPSHOT</version>
+		<version>1.4.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-lde/pom.xml
+++ b/wcomponents-lde/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4</version>
+		<version>1.4.5-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-test-lib/pom.xml
+++ b/wcomponents-test-lib/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.github.bordertech.wcomponents</groupId>
         <artifactId>wcomponents-parent</artifactId>
-        <version>1.4.4</version>
+        <version>1.4.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wcomponents-test-lib/pom.xml
+++ b/wcomponents-test-lib/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.github.bordertech.wcomponents</groupId>
         <artifactId>wcomponents-parent</artifactId>
-        <version>1.4.4-SNAPSHOT</version>
+        <version>1.4.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wcomponents-theme-parent/pom.xml
+++ b/wcomponents-theme-parent/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4-SNAPSHOT</version>
+		<version>1.4.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-theme-parent/pom.xml
+++ b/wcomponents-theme-parent/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.4.4</version>
+		<version>1.4.5-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-theme/pom.xml
+++ b/wcomponents-theme/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-theme-parent</artifactId>
-		<version>1.4.4</version>
+		<version>1.4.5-SNAPSHOT</version>
 		<relativePath>../wcomponents-theme-parent/pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-theme/pom.xml
+++ b/wcomponents-theme/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-theme-parent</artifactId>
-		<version>1.4.4-SNAPSHOT</version>
+		<version>1.4.4</version>
 		<relativePath>../wcomponents-theme-parent/pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
## Release 1.4.4

### API Changes
 * JS only: deprecated the use of wc/i18n/i18n as a loader plugin (in favor of async methods).
 
 ### Bug Fixes
 * Fix flaw which caused WButton with a message to not stop ajax submit if the button was an ajax trigger **and** the user chooses to cancel the button action # 1266.
 * Fix flaw which prevented WShuffler acting as an ajax trigger #1267.
 
 ### Enhancements
 * Better handling of rejected promises in Subscribers to the Observer module.
 * Upgraded FabricJS 1.7.11 -> 1.7.14 to fix issues in Internet Explorer 11.
 * Allow custom AJAX error handlers so that we can handle *any* response format conceivable, e.g. XML, JSON, protobuf, binary.