### PR TITLE
Throttle resource loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### API Changes
 
 ### Bug Fixes
+* Debounce / throttle rapidly repeated requests for the same theme resources to prevent superfluous network requests #1274
 
 ### Enhancements
 

--- a/wcomponents-theme/src/test/intern/wc.loader.resource.test.js
+++ b/wcomponents-theme/src/test/intern/wc.loader.resource.test.js
@@ -1,0 +1,68 @@
+define(["intern!object", "intern/chai!assert", "./resources/test.utils!"],
+	function (registerSuite, assert, testutils) {
+		"use strict";
+		var resourceLoader;
+
+		registerSuite({
+			name: "ResourceLoader",
+			setup: function() {
+				var result = testutils.setupHelper(["wc/loader/resource"]).then(function(arr) {
+					resourceLoader = arr[0];
+				});
+				return result;
+			},
+			beforeEach: function() {
+				resourceLoader._theRealFetch = resourceLoader._fetch;
+			},
+			afterEach: function() {
+				resourceLoader._fetch = resourceLoader._theRealFetch;
+			},
+			testLoader: function() {
+				var resolvers = [], promises = [],
+					i, fetchCount = {
+						foo: 0,
+						bar: 0
+					}, called = {
+						foo: 0,
+						bar: 0
+					}, calledExpected = {
+						foo: 4,
+						bar: 2
+					};
+				resourceLoader._fetch = function(name) {
+					var simpleName;
+					if (name.indexOf("foo") > 0) {
+						simpleName = "foo";
+					} else if (name.indexOf("bar") > 0) {
+						simpleName = "bar";
+					}
+					fetchCount[simpleName]++;
+					return new Promise(function(win) {
+						resolvers.push(function() {
+							win(simpleName);
+						});
+					});
+				};
+				function callback(reponse) {
+					return called[reponse]++;
+				}
+				for (i = 0; i < calledExpected.foo; i++) {
+					promises.push(resourceLoader.load("foo", true, true).then(callback));
+				}
+				for (i = 0; i < calledExpected.bar; i++) {
+					promises.push(resourceLoader.load("bar", true, true).then(callback));
+				}
+				window.setTimeout(function() {
+					for (i = 0; i < resolvers.length; i++) {
+						resolvers[i]();
+					}
+				}, 100);
+				return Promise.all(promises).then(function() {
+					assert.strictEqual(1, fetchCount.foo, "Should have throttled AJAX calls foo");
+					assert.strictEqual(1, fetchCount.bar, "Should have throttled AJAX calls bar");
+					assert.strictEqual(calledExpected.foo, called.foo, "Should have called every subscriber foo");
+					assert.strictEqual(calledExpected.bar, called.bar, "Should have called every subscriber bar");
+				});
+			}
+		});
+	});


### PR DESCRIPTION
The module `wc/loader/resource` is being used with increasing frequency and in ways not originally imagined when it was created. In its current state it simply fetches a resource every time it is requested. This can lead to multiple parallel network requests for the same resource - unnecessary noise for the server to deal with.

This change adds some smarts to ensure that there is only one in-flight request for any given resource at any given time. It is essentially "debounce" or "throttle" logic.
