### PR TITLE
minor Sass fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@
 ### Bug Fixes
 
 * Debounce / throttle rapidly repeated requests for the same theme resources to prevent superfluous network requests #1274
+* Fixed a flaw which caused WPartialDateField's calendar to render poorly on some mobile devices #1280.
 
 ### Enhancements
 
 * Added Sass to allow re-implementation of support for WField.inputWidth from 1 - 99 in sub-themes based only on Sass variables #1278.
+* Added a close icon to the header of the timeout warnings. These warnings can be closed by clicking anywhere (or pressing ESCAPE) but that is not immediately obvious and the close icon is merely a visual queue to indicate the box may be dismissed. Note that for screenreaders etc the box is exposed as an alert which has implicit ESCAPE to dismiss.
 
 ## Release 1.4.4
 

--- a/wcomponents-theme/src/main/resource/wc.ui.timeoutWarn.handlebars
+++ b/wcomponents-theme/src/main/resource/wc.ui.timeoutWarn.handlebars
@@ -1,7 +1,8 @@
-<section class="wc-messagebox wc-messagebox-type-warn wc_msgbox">
+<section class="wc-messagebox wc-messagebox-type-warn wc_msgbox wc-timeoutwarning">
 	<h1>
 		<span aria-hidden="true" class="fa fa-exclamation-triangle"></span>
 		<span>%s</span>
+		<span aria-hidden="true" class="fa fa-window-close-o" style="float:right;"></span>
 	</h1>
 	<div class="wc_messages">
 		<strong>%s</strong>

--- a/wcomponents-theme/src/main/sass/wc.datefield.scss
+++ b/wcomponents-theme/src/main/sass/wc.datefield.scss
@@ -98,6 +98,27 @@
         position: fixed;
         right: 0;
       }
+
+      > .wc-row {
+        display: block;
+
+        button {
+          margin-left: $wc-phone-gap-normal;
+
+          &:first-of-type {
+            margin-left: 0;
+          }
+        }
+
+        > :first-child {
+          margin-bottom: $wc-phone-gap-small;
+        }
+
+        > .wc-column + .wc-column {
+          display: inline-block;
+          width: 50%;
+        }
+      }
     }
 
     #wc_calendar {

--- a/wcomponents-theme/src/main/sass/wc.datefield.scss
+++ b/wcomponents-theme/src/main/sass/wc.datefield.scss
@@ -110,13 +110,22 @@
           }
         }
 
-        > :first-child {
-          margin-bottom: $wc-phone-gap-small;
-        }
+        // button columns
+        > .wc-column {
+          &:first-child {
+            @include flex($justify: space-between);
+            margin-bottom: $wc-phone-gap-small;
 
-        > .wc-column + .wc-column {
-          display: inline-block;
-          width: 50%;
+            // year input
+            > input {
+              margin-right: 0;
+            }
+          }
+
+          + .wc-column {
+            display: table-cell;
+            width: 100%;
+          }
         }
       }
     }

--- a/wcomponents-theme/src/main/sass/wc.fieldlayout.scss
+++ b/wcomponents-theme/src/main/sass/wc.fieldlayout.scss
@@ -37,9 +37,9 @@ $wc-fieldlayout-input-width: 100% - $wc-fieldlayout-default-label-width;
 .wc_inputwidth {
   > .wc-input {
     > .wc-input-wrapper,
-    > .wc-input-wrapper input,
-    > .wc-input-wrapper textarea,
-    > .wc-input-wrapper select,
+    > .wc-input-wrapper > input,
+    > .wc-input-wrapper > textarea,
+    > .wc-input-wrapper > select,
     > fieldset {
       @include border-box;
       width: 100%;

--- a/wcomponents-theme/src/main/sass/wc.messagebox.scss
+++ b/wcomponents-theme/src/main/sass/wc.messagebox.scss
@@ -9,6 +9,12 @@
     @include offscreen;
   }
 
+  &.wc-timeoutwarning > h1 > span:first-child {
+    // override offscreen
+    // sass-lint:disable no-important
+    position: static !important;
+  }
+
   > div {
     @include flex-align-self(center);
 


### PR DESCRIPTION
* Fixed an issue which caused calendar in WPartialDateField to render
poorly on mobiles. Fix #1280.
* Added an icon to the timeout warning to give it the appearance of a
close icon as clicking anywhere on the dialog will close it but this is
not apparent.
* Fix missing status icon on the timeout warning/error dialogs.