### PR TITLE
Mustache Factory Memory Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ language: Java
 jdk:
   - oraclejdk7
 
+dist: precise
+
 env:
   global:
    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
    #   via the "travis encrypt" command using the project repo's public key
    - secure: "MAirt38nl74gOmupg6oWoghoXT8YDgjMJmPzrv6YcMLJ92tS8kv7PGtSfdM+BlxXwlvvXIlqXNwb2R+U4CnjsZUsL+28RGqFiKReAbDUON55Cucb/Yy0ZB+QC9NpCxM5LfC4BycDPI6HStx7ZmDy61/U9alogrbhiqomD/LlMTQ="
-  
+
 addons:
   coverity_scan:
     project:
@@ -18,4 +20,4 @@ addons:
     build_command: "mvn -DskipTests=true compile"
     branch_pattern: coverity_scan
 
-script: "mvn verify"
+script: "mvn -pl '!wcomponents-theme-parent,!wcomponents-theme' verify"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### API Changes
 
 ### Bug Fixes
+* MoustacheFactory cannot switch off caching which can have adverse memory usage.
+  As per the issue http://spullara/mustache.java#117 the recommended way to provide this functionality is to create
+  a new MustacheFactory on every call to compile the template thus implicitly getting a clean cache every time #1290.
 
 ### Enhancements
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/container/TemplateRenderInterceptor.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/container/TemplateRenderInterceptor.java
@@ -29,8 +29,6 @@ public class TemplateRenderInterceptor extends InterceptorComponent {
 
 	private static final Map<String, ResourceBundle> RESOURCES = new HashMap<>();
 
-	private static final MustacheFactory MF = new DefaultMustacheFactory();
-
 	/**
 	 * {@inheritDoc}
 	 */
@@ -49,7 +47,10 @@ public class TemplateRenderInterceptor extends InterceptorComponent {
 
 		// Only process TEMPLATE if has I18N brackets
 		if (html.contains("{{#i18n")) {
-			Mustache mustache = MF.compile(new StringReader(html), UUID.randomUUID().toString());
+			// Create a new instance of factory to avoid caching the page.
+			// https://github.com/spullara/mustache.java/issues/117
+			final MustacheFactory mf = new DefaultMustacheFactory();
+			Mustache mustache = mf.compile(new StringReader(html), UUID.randomUUID().toString());
 			StringWriter templateWriter = new StringWriter();
 			mustache.execute(templateWriter, new I18NContext(getResourceBundle()));
 			html = templateWriter.toString();


### PR DESCRIPTION
Fix #1290.

MustacheFactory cannot switch off caching which can have adverse memory usage. As per the issue http://spullara/mustache.java#117 the recommended way to provide this functionality is to create a new MustacheFactory on every call to compile the template thus implicitly getting a clean cache every time.