### PR TITLE
browsers should always honor EXIF data

### DIFF
--- a/wcomponents-theme/.eslintrc
+++ b/wcomponents-theme/.eslintrc
@@ -27,6 +27,7 @@
 	},
 	"globals": {
 		"KeyEvent": true,
-		"Promise": true
+		"Promise": true,
+		"DataView": true
 	}
 }

--- a/wcomponents-theme/build-import.xml
+++ b/wcomponents-theme/build-import.xml
@@ -182,7 +182,8 @@
 	},
 	"globals": {
 		"KeyEvent": true,
-		"Promise": true
+		"Promise": true,
+		"DataView": true
 	}
 }
 </echo>

--- a/wcomponents-theme/src/main/sass/wc.image.scss
+++ b/wcomponents-theme/src/main/sass/wc.image.scss
@@ -2,6 +2,7 @@
 
 img {
   border: 0;
+  image-orientation: from-image;  // no-brainer, browsers should do this by default
 
   @if ($wc-image-valign-button != -1) {
     a &,


### PR DESCRIPTION
Main change is `image-orientation: from-image;` 
Only FF supports this at the moment.

While writing complex EXIF reading functions (that I eventually threw out when I realised this is really a browser bug) I needed to add `DataView` to eslintrc - may as well keep it.