### PR TITLE
Default tab mode, deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ### Enhancements
 
+* WTabSet:
+  - Added methods to WTabSet to allow easier/less verbose creation of tabs by making the TabMode argument optional.
+  - Deprecated the unused members `setShowHeadOnly` and `isShowHeadOnly` which have never been implemented and which were a hangover from a very old and rather poor design concept. No replacement: never implemented.
+  - Deprecated `setActionOnChange` and `getActionOnChange` as changing tabs should not have a side effect _and_ these actions are inconsistent unless the (no longer supported) `TabMode.SERVER` is used for **all** tabs in the tabset. No replacement: a tabset should not have an action on tab change other than show the relevant tab.
+
 ## Release 1.4.6
 
 ### API Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Added methods to WTabSet to allow easier/less verbose creation of tabs by making the TabMode argument optional.
   - Deprecated the unused members `setShowHeadOnly` and `isShowHeadOnly` which have never been implemented and which were a hangover from a very old and rather poor design concept. No replacement: never implemented.
   - Deprecated `setActionOnChange` and `getActionOnChange` as changing tabs should not have a side effect _and_ these actions are inconsistent unless the (no longer supported) `TabMode.SERVER` is used for **all** tabs in the tabset. No replacement: a tabset should not have an action on tab change other than show the relevant tab.
+  - Added `protected addTab(WTab)` as a replacement for the deprecated `public add(WTab)`.
 
 ## Release 1.4.6
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
@@ -212,7 +212,7 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * @return the tab which was added to the tab set.
 	 */
 	public WTab addTab(final WComponent content, final String tabName) {
-		WTab tab = new WTab(content, tabName, TabMode.LAZY);
+		WTab tab = new WTab(content, tabName, TabMode.LAZY, (char) 0);
 		add(tab);
 
 		return tab;
@@ -227,7 +227,7 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * @return the tab which was added to the tab set.
 	 */
 	public WTab addTab(final WComponent content, final WDecoratedLabel label) {
-		WTab tab = new WTab(content, label, TabMode.LAZY);
+		WTab tab = new WTab(content, label, TabMode.LAZY, (char) 0);
 		add(tab);
 
 		return tab;
@@ -242,7 +242,7 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * @return the tab which was added to the tab set.
 	 */
 	public WTab addTab(final WComponent content, final String tabName, final TabMode mode) {
-		WTab tab = new WTab(content, tabName, mode);
+		WTab tab = new WTab(content, tabName, mode, (char) 0);
 		add(tab);
 
 		return tab;
@@ -289,7 +289,7 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * @return the tab which was added to the tab set.
 	 */
 	public WTab addTab(final WComponent content, final WDecoratedLabel label, final TabMode mode) {
-		WTab tab = new WTab(content, label, mode);
+		WTab tab = new WTab(content, label, mode, (char) 0);
 		add(tab);
 
 		return tab;
@@ -304,8 +304,7 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * @param accessKey the access key used to activate the tab.
 	 * @return the tab which was added to the tab set.
 	 */
-	public WTab addTab(final WComponent content, final WDecoratedLabel label, final TabMode mode,
-			final char accessKey) {
+	public WTab addTab(final WComponent content, final WDecoratedLabel label, final TabMode mode, final char accessKey) {
 		WTab tab = new WTab(content, label, mode, accessKey);
 		add(tab);
 
@@ -771,7 +770,9 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * Sets the action to be executed when the tab selection of this <code>tabset</code> changes.
 	 *
 	 * @param action the action to execute
+	 * @deprecated an action on changing tab is a side-effect and should not be implemented.
 	 */
+	@Deprecated
 	public void setActionOnChange(final Action action) {
 		getOrCreateComponentModel().action = action;
 	}
@@ -780,7 +781,9 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * Gets the action that is executed when the tab selection of this <code>tabset</code> changes.
 	 *
 	 * @return The <code>action</code> associated with this <code>tabset</code>.
+	 * @deprecated an action on changing tab is a side-effect and should not be implemented.
 	 */
+	@Deprecated
 	public Action getActionOnChange() {
 		return getComponentModel().action;
 	}
@@ -790,7 +793,9 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * visible effect on {@link TabSetType#APPLICATION} tab sets.
 	 *
 	 * @param showHeadOnly true if only the "head" part of the tab label should be shown.
+	 * @deprecated 1.4.7 an irrelevant hangover from a bad design decision - never implemented.
 	 */
+	@Deprecated
 	public void setShowHeadOnly(final boolean showHeadOnly) {
 		getOrCreateComponentModel().showHeadOnly = showHeadOnly;
 	}
@@ -800,7 +805,9 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * a visible effect on {@link TabSetType#APPLICATION} tab sets.
 	 *
 	 * @return true if only the "head" part of the tab label should be shown.
+	 * @deprecated 1.4.7 an irrelevant hangover from a bad design decision - never implemented.
 	 */
+	@Deprecated
 	public boolean isShowHeadOnly() {
 		return getComponentModel().showHeadOnly;
 	}
@@ -897,7 +904,9 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 
 		/**
 		 * Show head only flag.
+		 * @deprecated 1.4.7 an irrelevant hangover from a bad design decision - never implemented.
 		 */
+		@Deprecated
 		private boolean showHeadOnly;
 
 		/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
@@ -205,7 +205,7 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	}
 
 	/**
-	 * Adds a tab to the tab set with a TabMode of LAZY
+	 * Adds a tab to the tab set with a TabMode of LAZY.
 	 *
 	 * @param content the tab set content.
 	 * @param tabName the tab name.

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
@@ -205,6 +205,35 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	}
 
 	/**
+	 * Adds a tab to the tab set with a TabMode of LAZY
+	 *
+	 * @param content the tab set content.
+	 * @param tabName the tab name.
+	 * @return the tab which was added to the tab set.
+	 */
+	public WTab addTab(final WComponent content, final String tabName) {
+		WTab tab = new WTab(content, tabName, TabMode.LAZY);
+		add(tab);
+
+		return tab;
+	}
+
+
+	/**
+	 * Adds a LAZY mode tab to the tab set.
+	 *
+	 * @param content the tab set content.
+	 * @param label the tab's label, which can contain rich content (images or other components).
+	 * @return the tab which was added to the tab set.
+	 */
+	public WTab addTab(final WComponent content, final WDecoratedLabel label) {
+		WTab tab = new WTab(content, label, TabMode.LAZY);
+		add(tab);
+
+		return tab;
+	}
+
+	/**
 	 * Adds a tab to the tab set.
 	 *
 	 * @param content the tab set content.
@@ -237,6 +266,21 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	}
 
 	/**
+	 * Adds a LAZY tab with a given access key to the tab set.
+	 *
+	 * @param content the tab set content.
+	 * @param tabName the tab name.
+	 * @param accessKey the access key used to activate the tab.
+	 * @return the tab which was added to the tab set.
+	 */
+	public WTab addTab(final WComponent content, final String tabName, final char accessKey) {
+		WTab tab = new WTab(content, tabName, TabMode.LAZY, accessKey);
+		add(tab);
+
+		return tab;
+	}
+
+	/**
 	 * Adds a tab to the tab set.
 	 *
 	 * @param content the tab set content.
@@ -263,6 +307,21 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	public WTab addTab(final WComponent content, final WDecoratedLabel label, final TabMode mode,
 			final char accessKey) {
 		WTab tab = new WTab(content, label, mode, accessKey);
+		add(tab);
+
+		return tab;
+	}
+
+	/**
+	 * Adds a LAZY tab with a given access key to the tab set.
+	 *
+	 * @param content the tab set content.
+	 * @param label the tab's label, which can contain rich content (images or other components).
+	 * @param accessKey the access key used to activate the tab.
+	 * @return the tab which was added to the tab set.
+	 */
+	public WTab addTab(final WComponent content, final WDecoratedLabel label, final char accessKey) {
+		WTab tab = new WTab(content, label, TabMode.LAZY, accessKey);
 		add(tab);
 
 		return tab;

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
@@ -212,10 +212,7 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * @return the tab which was added to the tab set.
 	 */
 	public WTab addTab(final WComponent content, final String tabName) {
-		WTab tab = new WTab(content, tabName, TabMode.LAZY, (char) 0);
-		add(tab);
-
-		return tab;
+		return addTab(new WTab(content, tabName, TabMode.LAZY, (char) 0));
 	}
 
 
@@ -227,10 +224,7 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * @return the tab which was added to the tab set.
 	 */
 	public WTab addTab(final WComponent content, final WDecoratedLabel label) {
-		WTab tab = new WTab(content, label, TabMode.LAZY, (char) 0);
-		add(tab);
-
-		return tab;
+		return addTab(new WTab(content, label, TabMode.LAZY, (char) 0));
 	}
 
 	/**
@@ -242,10 +236,7 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * @return the tab which was added to the tab set.
 	 */
 	public WTab addTab(final WComponent content, final String tabName, final TabMode mode) {
-		WTab tab = new WTab(content, tabName, mode, (char) 0);
-		add(tab);
-
-		return tab;
+		return addTab(new WTab(content, tabName, mode, (char) 0));
 	}
 
 	/**
@@ -257,12 +248,8 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * @param accessKey the access key used to activate the tab.
 	 * @return the tab which was added to the tab set.
 	 */
-	public WTab addTab(final WComponent content, final String tabName, final TabMode mode,
-			final char accessKey) {
-		WTab tab = new WTab(content, tabName, mode, accessKey);
-		add(tab);
-
-		return tab;
+	public WTab addTab(final WComponent content, final String tabName, final TabMode mode, final char accessKey) {
+		return addTab(new WTab(content, tabName, mode, accessKey));
 	}
 
 	/**
@@ -274,10 +261,7 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * @return the tab which was added to the tab set.
 	 */
 	public WTab addTab(final WComponent content, final String tabName, final char accessKey) {
-		WTab tab = new WTab(content, tabName, TabMode.LAZY, accessKey);
-		add(tab);
-
-		return tab;
+		return addTab(new WTab(content, tabName, TabMode.LAZY, accessKey));
 	}
 
 	/**
@@ -289,10 +273,7 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * @return the tab which was added to the tab set.
 	 */
 	public WTab addTab(final WComponent content, final WDecoratedLabel label, final TabMode mode) {
-		WTab tab = new WTab(content, label, mode, (char) 0);
-		add(tab);
-
-		return tab;
+		return addTab(new WTab(content, label, mode, (char) 0));
 	}
 
 	/**
@@ -305,10 +286,7 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * @return the tab which was added to the tab set.
 	 */
 	public WTab addTab(final WComponent content, final WDecoratedLabel label, final TabMode mode, final char accessKey) {
-		WTab tab = new WTab(content, label, mode, accessKey);
-		add(tab);
-
-		return tab;
+		return addTab(new WTab(content, label, mode, accessKey));
 	}
 
 	/**
@@ -320,10 +298,7 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * @return the tab which was added to the tab set.
 	 */
 	public WTab addTab(final WComponent content, final WDecoratedLabel label, final char accessKey) {
-		WTab tab = new WTab(content, label, TabMode.LAZY, accessKey);
-		add(tab);
-
-		return tab;
+		return addTab(new WTab(content, label, TabMode.LAZY, accessKey));
 	}
 
 	/**
@@ -339,11 +314,22 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * Adds a tab to the tab set.
 	 *
 	 * @param tab the tab to add.
-	 * @deprecated use {@link #addTab(WComponent, String, TabMode)}
+	 * @deprecated use {@link #addTab(WComponent, String)} or overloaded version.
 	 */
 	@Deprecated
 	public void add(final WTab tab) {
+		addTab(tab);
+	}
+
+	/**
+	 * Adds a {@link WTab} to the tab set.
+	 *
+	 * @param tab the tab to add.
+	 * @return the tab which was added to the tab set.
+	 */
+	private WTab addTab(final WTab tab) {
 		super.add(tab);
+		return tab;
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
@@ -327,7 +327,7 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 	 * @param tab the tab to add.
 	 * @return the tab which was added to the tab set.
 	 */
-	private WTab addTab(final WTab tab) {
+	protected WTab addTab(final WTab tab) {
 		super.add(tab);
 		return tab;
 	}


### PR DESCRIPTION
* Added methods to WTabSet to allow easier/less verbose creation of tabs.
  - updated calls to WTab constructors to ensure the only constructor called from within WTabSet is the one with all args. This should allow us to remove the other package protected constructors
* Deprecated the unused members
* Deprecated action on change as its application is inconsistent and these actions are conceptually wrong: an action on tab change is a side-effect.