### PR TITLE
WImageEditor - can now render inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   - Deprecated the unused members `setShowHeadOnly` and `isShowHeadOnly` which have never been implemented and which were a hangover from a very old and rather poor design concept. No replacement: never implemented.
   - Deprecated `setActionOnChange` and `getActionOnChange` as changing tabs should not have a side effect _and_ these actions are inconsistent unless the (no longer supported) `TabMode.SERVER` is used for **all** tabs in the tabset. No replacement: a tabset should not have an action on tab change other than show the relevant tab.
   - Added `protected addTab(WTab)` as a replacement for the deprecated `public add(WTab)`.
+* WImageEditor:
+  - Can now render the editor controls inline (as opposed to the default, in a popup).
 
 ## Release 1.4.6
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WImageEditor.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WImageEditor.java
@@ -70,6 +70,23 @@ public class WImageEditor extends AbstractWComponent {
 	}
 
 	/**
+	 * Determine if the image editor will render inline.
+	 * @return true if it will render inline, otherwise false (will render in popup)
+	 */
+	public boolean getRenderInline() {
+		return getComponentModel().renderInline;
+	}
+
+	/**
+	 * If true then the image editor will render where it is added in the tree instead of in a popup.
+	 * @param renderInline Set to true to render inline.
+	 */
+	public void setRenderInline(final boolean renderInline) {
+		ImageEditModel model = getOrCreateComponentModel();
+		model.renderInline = renderInline;
+	}
+
+	/**
 	 * Retrieve the editor size.
 	 * <p>
 	 * Returns the size set via {@link #setSize(Dimension)}.
@@ -123,5 +140,6 @@ public class WImageEditor extends AbstractWComponent {
 		private Dimension size;
 		private boolean useCamera;
 		private boolean isFace;
+		private boolean renderInline;
 	}
 }

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WImageEditorRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WImageEditorRenderer.java
@@ -32,6 +32,7 @@ final class WImageEditorRenderer extends AbstractWebXmlRenderer {
 		xml.appendOptionalUrlAttribute("overlay", editorComponent.getOverlayUrl());
 		xml.appendOptionalAttribute("camera", editorComponent.getUseCamera());
 		xml.appendOptionalAttribute("face", editorComponent.getIsFace());
+		xml.appendOptionalAttribute("inline", editorComponent.getRenderInline());
 
 		// Check for size information on the image
 		Dimension size = editorComponent.getSize();

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WMultiFileWidgetAjaxExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WMultiFileWidgetAjaxExample.java
@@ -46,6 +46,7 @@ public class WMultiFileWidgetAjaxExample extends WContainer {
 	private final WNumberField maxfiles = new WNumberField();
 	private final WNumberField previewHeight = new WNumberField();
 	private final WCheckBox showThumnails = new WCheckBox();
+	private final WCheckBox renderInline = new WCheckBox();
 	private final WCheckBox mandatory = new WCheckBox();
 	private final WCheckBox readonly = new WCheckBox();
 	private final WCheckBox imageEditorShowOverlay = new WCheckBox();
@@ -92,7 +93,9 @@ public class WMultiFileWidgetAjaxExample extends WContainer {
 		imageEditorFieldSet.setMargin(new Margin(null, null, Size.XL, null));
 
 		showThumnails.setSelected(true);
-		paramsLayout.addField("show thumbnails", showThumnails);
+		paramsLayout.addField("Show thumbnails", showThumnails);
+
+		paramsLayout.addField("Render inline", renderInline);
 
 		paramsLayout.addField("Mandatory", mandatory);
 
@@ -184,6 +187,13 @@ public class WMultiFileWidgetAjaxExample extends WContainer {
 			@Override
 			public void execute(final ActionEvent event) {
 				widget.setUseThumbnails(showThumnails.isSelected());
+			}
+		});
+
+		renderInline.setActionOnChange(new Action() {
+			@Override
+			public void execute(final ActionEvent event) {
+				editor.setRenderInline(renderInline.isSelected());
 			}
 		});
 
@@ -348,6 +358,7 @@ public class WMultiFileWidgetAjaxExample extends WContainer {
 		add(new WAjaxControl(cols, layout));
 		add(new WAjaxControl(previewHeight, widget));
 		add(new WAjaxControl(showThumnails, widget));
+		add(new WAjaxControl(renderInline, widget));
 		add(new WAjaxControl(mandatory, layout));
 		add(new WAjaxControl(readonly, layout));
 		add(new WAjaxControl(maxfiles, layout));

--- a/wcomponents-theme/src/main/sass/wc.image-edit.scss
+++ b/wcomponents-theme/src/main/sass/wc.image-edit.scss
@@ -71,6 +71,11 @@
     display: none;
   }
 
+  .wc_img_editpane, .wc_img_controls {
+    @include border;
+    padding: $wc-panel-feature-padding;
+  }
+
   .wc_img_controls {
     > div,
     > fieldset {

--- a/wcomponents-theme/src/main/xslt/wc.ui.imageEdit.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.imageEdit.xsl
@@ -1,8 +1,16 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" 
 	xmlns:html="http://www.w3.org/1999/xhtml" version="2.0">
 
-	<!-- Currently has no direct UI artefact -->
-	<xsl:template match="html:wc-imageedit"/>
+	<xsl:template match="html:wc-imageedit">
+		<xsl:element name="div">
+			<xsl:attribute name="id">
+				<xsl:value-of select="@id"/>
+			</xsl:attribute>
+			<xsl:attribute name="class">
+				<xsl:text>wc-imageedit</xsl:text>
+			</xsl:attribute>
+		</xsl:element>
+	</xsl:template>
 
 	<!--
 		Builds the imageEditor description JSON object.
@@ -35,6 +43,10 @@
 			<xsl:text>,"overlay":"</xsl:text>
 			<xsl:value-of select="@overlay"/>
 			<xsl:text>"</xsl:text>
+		</xsl:if>
+		<xsl:if test="@inline">
+			<xsl:text>,"inline":</xsl:text>
+			<xsl:value-of select="@inline"/>
 		</xsl:if>
 		<xsl:text>}</xsl:text>
 		<xsl:if test="position() ne last()">


### PR DESCRIPTION
This enhancement allows the image editor to render inline (where it is added to the component tree). The default behavior remains opening in a popup.
