### PR TITLE
Added JavaScript unit tests for module `wc/ui/label`.

### DIFF
--- a/wcomponents-theme/src/main/js/wc/dom/shed.js
+++ b/wcomponents-theme/src/main/js/wc/dom/shed.js
@@ -630,7 +630,8 @@ define(["wc/Observer",
 			this.isMandatory = function (element) {
 				var result = false;
 
-				if (element.getAttribute(NATIVE_STATE[REQUIRED]) || element.getAttribute(ARIA_STATE[REQUIRED]) === "true" ||
+				if (element.hasAttribute(NATIVE_STATE[REQUIRED]) ||
+					element.getAttribute(ARIA_STATE[REQUIRED]) === "true" ||
 					(element.tagName === tag.FIELDSET && classList.contains(element, CLASS_REQUIRED))) {
 					result = true;
 				}

--- a/wcomponents-theme/src/main/js/wc/ui/label.js
+++ b/wcomponents-theme/src/main/js/wc/ui/label.js
@@ -124,6 +124,8 @@ define(["wc/dom/classList",
 					newLabellingElement = document.createElement("label");
 					if ((input = wrappedInput.getInput(element))) { // should always be found
 						newLabellingElement.setAttribute("for", input.id);
+					} else if (TAGS.indexOf(element.tagName) > -1) {
+						newLabellingElement.setAttribute("for", element.id);
 					}
 				}
 				newLabellingElement.className = label.className;
@@ -288,6 +290,17 @@ define(["wc/dom/classList",
 			this.preInit = function(element) {
 				moveLabels(element);
 			};
+
+			/**
+			 * Public for testing.
+			 * @ignore
+			 */
+			this._convert = convertLabel;
+			/**
+			 * Public for testing.
+			 * @ignore
+			 */
+			this._ajax = ajaxSubscriber;
 		}
 
 		/**

--- a/wcomponents-theme/src/test/intern/resources/domShed.html
+++ b/wcomponents-theme/src/test/intern/resources/domShed.html
@@ -61,6 +61,7 @@
 	<div id="mandatoryTests">
 		<input id="inp7" type="text"/>
 		<input id="inp8" type="text" required="required"/>
+		<input id="inp9" type="text" required/>
 		<fieldset role="radiogroup" class="radiobuttonselect" id="radioButtonGroup1" aria-required="true">
 			<input id="radioButtonGroup1_1" type="radio" required="required" value="0">
 			<input id="radioButtonGroup1_2" type="radio" required="required" value="1">

--- a/wcomponents-theme/src/test/intern/resources/uiLabel.html
+++ b/wcomponents-theme/src/test/intern/resources/uiLabel.html
@@ -1,0 +1,120 @@
+<form action="#" method="get">
+  <p>
+    <label id="wcuilabel-l1" for="wcuilabel-i1">label</label>
+    <input id="wcuilabel-i1" type="text">
+  </p>
+  <p>
+    <label id="wcuilabel-l2" for="wcuilabel-i2">move me</label>
+    <input id="wcuilabel-i2" type="checkbox" class="wc-checkbox">
+  </p>
+  <p>
+    <label id="wcuilabel-l2a" for="wcuilabel-i2a">move me too</label>
+    <input id="wcuilabel-i2a" type="radio" class="wc-radiobutton">
+    <span>Just floating around thanks.</span>
+  </p>
+  <p>
+    <label id="wcuilabel-l2b" for="wcuilabel-i2b">move me as well</label>
+    <button id="wcuilabel-i2b" class="wc-selecttoggle" role="checkbox">select toggle</button>
+  </p>
+  <p>
+    <label id="wcuilabel-l3" for="wcuilabel-i3">don't move me</label>
+    <input id="wcuilabel-i3" type="checkbox">
+  </p>
+  <p>
+    <label id="wcuilabel-l3a" for="wcuilabel-i3a">nor me</label>
+    <input id="wcuilabel-i3a" type="radio">
+  </p>
+  <p>
+    <label id="wcuilabel-l3b" for="wcuilabel-i3b">me neither</label>
+    <button id="wcuilabel-i3b" role="checkbox">not a select toggle</button>
+  </p>
+  <p>
+    <input id="wcuilabel-i4" type="checkbox" class="wc-checkbox"><label id="wcuilabel-l4" for="wcuilabel-i3c">don't move me either I am in the right place</label>
+  </p>
+  <p>
+    <label id="wcuilabel-l5" for="wcuilabel-i5" class="wc_req">make me optional</label>
+    <input id="wcuilabel-i5" type="text" required>
+  </p>
+  <p>
+    <label id="wcuilabel-l5a" for="wcuilabel-i5a" class="wc_req">make me optional too<span class="wc-off">required</span></label>
+    <input id="wcuilabel-i5a" type="text" required>
+  </p>
+  <p>
+    <label id="wcuilabel-l6" for="wcuilabel-i6">mandate me</label>
+    <input id="wcuilabel-i6" type="text">
+  </p>
+  <p>
+    <label id="wcuilabel-l6a" for="wcuilabel-i6a">mandate me without decoration</label>
+    <input id="wcuilabel-i6a" type="radio">
+  </p>
+  <p>
+    <label id="wcuilabel-l7" for="wcuilabel-i7">hide me</label>
+    <input id="wcuilabel-i7" type="text">
+  </p>
+  <p>
+    <label id="wcuilabel-l8" for="wcuilabel-i8" hidden>show me</label>
+    <input id="wcuilabel-i8" type="text" hidden>
+  </p>
+  <p>
+    <label id="wcuilabel-l9" for="wcuilabel-i9">set my hint</label>
+    <input id="wcuilabel-i9" type="text">
+  </p>
+  <p>
+    <label id="wcuilabel-l10" for="wcuilabel-i10">I have a hint <span class="wc-label-hint">this is the hint</span></label>
+    <input id="wcuilabel-i10" type="text">
+  </p>
+  <p>
+    <label id="wcuilabel-l11" for="wcuilabel-i11">I don't have a hint <span>this is not a hint</span></label>
+    <input id="wcuilabel-i11" type="text">
+  </p>
+  <p>
+    <label id="wcuilabel-l12" for="wcuilabel-i12">Convert label to RO</label>
+    <span id="wcuilabel-i12" class="wc-ro-input">read-only version</span>
+  </p>
+  <p>
+    <span id="wcuilabel-l13" data-wc-rofor="wcuilabel-i13">Convert label from RO</span>
+    <input id="wcuilabel-i13" type="text">
+  </p>
+  <div id="wcuilabel-fake-ajax">
+    <p>
+      <span id="wcuilabel-fake-ajax-l1" data-wc-rofor="wcuilabel-fake-ajax-i1" class="wc-label">Convert label from RO</span>
+      <span class="wc-input-wrapper wc-textfield" id="wcuilabel-fake-ajax-i1"><input type="text" id="wcuilabel-fake-ajax-i1_input"></span>
+    </p>
+    <p>
+      <label id="wcuilabel-fake-ajax-l2" for="wcuilabel-fake-ajax-i2_input" class="wc-label">Convert label to RO</label>
+      <span class="wc-ro-input wc-textfield" id="wcuilabel-fake-ajax-i2">value</span>
+    </p>
+    <p>
+      <span id="wcuilabel-fake-ajax-l3" data-wc-rofor="wcuilabel-fake-ajax-i3" class="wc-label">Convert label from RO and hide based on hidden input</span>
+      <span class="wc-input-wrapper wc-textfield" id="wcuilabel-fake-ajax-i3" hidden><input type="text" id="wcuilabel-fake-ajax-i3_input"></span>
+    </p>
+    <p>
+      <label id="wcuilabel-fake-ajax-l4" for="wcuilabel-fake-ajax-i4_input" class="wc-label">Convert label to RO and hide based on input</label>
+      <span class="wc-ro-input wc-textfield" id="wcuilabel-fake-ajax-i4" hidden>value</span>
+    </p>
+    <p>
+      <span id="wcuilabel-fake-ajax-l5" data-wc-rofor="wcuilabel-fake-ajax-i5" class="wc-label">Convert label from RO and optional to mandatory</span>
+      <span class="wc-input-wrapper wc-textfield" id="wcuilabel-fake-ajax-i5"><input type="text" id="wcuilabel-fake-ajax-i5_input" required></span>
+    </p>
+    <p>
+      <label id="wcuilabel-fake-ajax-l6" for="wcuilabel-fake-ajax-i6_input" class="wc-label wc_req">Convert mandatory label to RO</label>
+      <span class="wc-ro-input wc-textfield" id="wcuilabel-fake-ajax-i6">value</span>
+    </p>
+    <p>
+      <label id="wcuilabel-fake-ajax-l7" for="wcuilabel-fake-ajax-i7_input" class="wc-label">replacement input mandatory</label>
+      <span class="wc-input-wrapper wc-textfield" id="wcuilabel-fake-ajax-i7"><input type="text" id="wcuilabel-fake-ajax-i7_input" required></span>
+    </p>
+    <p>
+      <label id="wcuilabel-fake-ajax-l8" for="wcuilabel-fake-ajax-i8_input" class="wc-label wc_req">replacement input optional</label>
+      <span class="wc-input-wrapper wc-textfield" id="wcuilabel-fake-ajax-i8"><input type="text" id="wcuilabel-fake-ajax-i8_input"></span>
+    </p>
+    <p>
+      <label id="wcuilabel-fake-ajax-l9" for="wcuilabel-fake-ajax-i9_input" class="wc-label">replacement input hidden</label>
+      <span class="wc-input-wrapper wc-textfield" id="wcuilabel-fake-ajax-i9" hidden><input type="text" id="wcuilabel-fake-ajax-i9_input"></span>
+    </p>
+    <p>
+      <label id="wcuilabel-fake-ajax-l10" for="wcuilabel-fake-ajax-i10_input" class="wc-label" hidden>replacement input not hidden</label>
+      <span class="wc-input-wrapper wc-textfield" id="wcuilabel-fake-ajax-i10"><input type="text" id="wcuilabel-fake-ajax-i10_input"></span>
+    </p>
+  </div>
+</form>

--- a/wcomponents-theme/src/test/intern/skeleton_js.txt
+++ b/wcomponents-theme/src/test/intern/skeleton_js.txt
@@ -65,13 +65,9 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils"], functi
 		name: suiteName,
 
 		setup: function() {
-			if (!TEST_MODULE) {
-				console.error("Your tests won't work!");
-				return Promise.resolve();
-			}
 			var allDeps = (deps && deps.length) ? deps : [];
 			allDeps.unshift(TEST_MODULE);
-			return testutils.setupHelper(allDeps).then(function(arg) {
+			var result = testutils.setupHelper(allDeps).then(function(arg) {
 
 				// The module to be tested is the controller
 				controller = arg[0];
@@ -87,18 +83,19 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils"], functi
 				if (testContent) {
 					testHolder.innerHTML = testContent;
 				} else if (urlResource) {
-					testutils.setUpExternalHTML(urlResource, testHolder);
-					if (resetBeforeEach || resetAfterEach) {
-						// Hold the initial HTML for future use
-						testContent = testHolder.innerHTML;
-					}
+					return testutils.setUpExternalHTML(urlResource, testHolder);
 				}
 			});
+			return result;
 		},
 
 		beforeEach: function () {
-			if (testHolder && resetBeforeEach) {
-				testHolder.innerHTML = testContent;
+			if (testHolder) {
+				testContent = testContent || testHolder.innerHTML;
+
+				if (testContent && resetBeforeEach) {
+					testHolder.innerHTML = testContent;
+				}
 			}
 		},
 

--- a/wcomponents-theme/src/test/intern/wc.Observer.test.js
+++ b/wcomponents-theme/src/test/intern/wc.Observer.test.js
@@ -910,6 +910,14 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils!"], funct
 				observer.reset(ns);
 			}
 		},
+		testSetFilterNotFalsyStringOrFunctionThrowsError: function() {
+			try {
+				observer.setFilter({});
+				assert.isTrue(false, "should have thrown a TypeError");
+			} catch (e) {
+				assert.strictEqual("arg must be a String or Function", e.message);
+			}
+		},
 		testGetGroupAsWildcardFilter: function() {
 			/* What we are testing here is that foo.*.bar returns true from filter "foo.a.b.c....bar" and
 			 * "foo.bar.somethingelse" does not. */

--- a/wcomponents-theme/src/test/intern/wc.ajax.handleError.test.js
+++ b/wcomponents-theme/src/test/intern/wc.ajax.handleError.test.js
@@ -17,34 +17,9 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils"], functi
 		 * @type arg
 		 */
 		deps = ["wc/i18n/i18n", "wc/config"],
-		// Load test UI content if required: only one of these is needed and testContent will take precedence over urlResource
-		/**
-		 * HTML test UI e.g. "<div>Test HTML</div>". Only needed ig the tests use common HTML. Optionally use urlResource instead if the test HTML
-		 * is complex. If both are set testContent takes precedence and urlResource is ignored.
-		 * @type String
-		 */
-		testContent,
-		/**
-		 * Load test UI froman external resource e.g. "@RESOURCES@/SOME_PAGE.html". Leave undefined if not required. Simple test UIs may be set inline
-		 * using testContent instead. If both are set testContent takes precedence and urlResource is ignored.
-		 * Note that the property `@RESOURCES@` will be mapped to the test/intern/resources directory as a URL.
-		 * @type URL
-		 */
-		urlResource,
-		/**
-		 * If true and either testContent or urlResource is used to set test UI then the test UI will be reset to its original state before each test.
-		 * @type Boolean
-		 */
-		resetBeforeEach = false,
-		/**
-		 * If true and either testContent or urlResource is used to set test UI then the test UI will be reset to its original state after each test.
-		 * @type Boolean
-		 */
-		resetAfterEach = true,
 		// END CONFIGURATION VARS
 		// the next two are not settable.
 		controller, // This will be the actual module named above. Tests of public functions use this e.g. `controller.getSomething()`.
-		testHolder, // This will hold any UI needed for the tests. It is left undefined if testContent & urlResource are both falsey.
 		// Now, if you have extra dependencies you will want a way to reference them.
 		i18n,
 		wcconfig;
@@ -75,23 +50,6 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils"], functi
 				// If you want to have named dependencies the vars are assigned here
 				i18n = arg[1];
 				wcconfig = arg[2];
-
-				// Set up initial test UI if needed
-				if (testContent || urlResource) {
-					testHolder = testutils.getTestHolder();
-				}
-
-				// Set up the test content if required
-				if (testContent) {
-					testHolder.innerHTML = testContent;
-				} else if (urlResource) {
-					testutils.setUpExternalHTML(urlResource, testHolder);
-					if (resetBeforeEach || resetAfterEach) {
-						// Hold the initial HTML for future use
-						testContent = testHolder.innerHTML;
-					}
-				}
-
 				// Custom set up
 				if ((realConfig = wcconfig.get("wc/ui/xhr")) && realConfig.messages) {
 					wcconfig.set({ messages: null}, "wc/ui/xhr");
@@ -100,21 +58,6 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils"], functi
 					wcconfig.set({ messages: null}, "wc/ui/multiFileUploader");
 				}
 			});
-		},
-		beforeEach: function () {
-			if (testHolder && resetBeforeEach) {
-				testHolder.innerHTML = testContent;
-			}
-		},
-		afterEach: function() {
-			if (testHolder && resetAfterEach) {
-				testHolder.innerHTML = testContent;
-			}
-		},
-		teardown: function () {
-			if (testHolder) {
-				testHolder.innerHTML = "";
-			}
 		},
 		testGotController: function () {
 			if (!TEST_MODULE) {

--- a/wcomponents-theme/src/test/intern/wc.array.diff.test.js
+++ b/wcomponents-theme/src/test/intern/wc.array.diff.test.js
@@ -1,17 +1,5 @@
 define(["intern!object", "intern/chai!assert", "./resources/test.utils"], function (registerSuite, assert, testutils) {
 	"use strict";
-	/*
-	 * To create a new Intern unit test file:
-	 *
-	 * 1. Save this as a *.js file.
-	 * 2. Set TEST_MODULE to the name of the module to test, e.g. "wc/ui/foo" and optionally set a suiteName.
-	 * 3. If the test requires other dependencies create the deps array containing these.
-	 * 4. If the controller needs specific UI to test set ONE of testContent (HTML) OR urlResource (from where the test UI will be loaded)
-	 * 5. If there are other dependencies they can be named. This is optional as they _could_ be referenced as arg[n] but that is really ugly.
-	 *    Map setup's then function's arg members to these names. arg[0] is thecontroller.
-	 * 7. Optionally update (or remove if not needed) setup, beforeEach, afterEach and teardown
-	 * 6. Write tests use `controller` as the var name for the module being tested. Review `testGotController` as a simple sample.
-	 */
 
 	var
 		/**

--- a/wcomponents-theme/src/test/intern/wc.dom.shed.test.js
+++ b/wcomponents-theme/src/test/intern/wc.dom.shed.test.js
@@ -453,6 +453,9 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils!"],
 			testIsMandatoryTrue: function() {
 				assert.isTrue(controller.isMandatory(document.getElementById("inp8")));
 			},
+			testIsMandatoryTrueNotXML: function() {
+				assert.isTrue(controller.isMandatory(document.getElementById("inp9")));
+			},
 			testMandatory: function() {
 				var element = document.getElementById("inp7");
 				assert.isFalse(controller.isMandatory(element));

--- a/wcomponents-theme/src/test/intern/wc.ui.label.test.js
+++ b/wcomponents-theme/src/test/intern/wc.ui.label.test.js
@@ -1,0 +1,285 @@
+define(["intern!object", "intern/chai!assert", "./resources/test.utils"], function (registerSuite, assert, testutils) {
+	"use strict";
+
+	/**
+	 * Surprising how often we need to get teh next element sibling.
+	 * @param {Element} el the start element
+	 * @param {boolean} [prev] if `true` get previous element sibling, otherwise get next element sibling
+	 * @returns {? Element} the  element sibling or null.
+	 */
+	function getElSib(el, prev) {
+		var next;
+
+		if (!el || el.nodeType !== Node.ELEMENT_NODE) {
+			throw new TypeError("argument `el` must be an element");
+		}
+		if (prev) {
+			if (typeof el.previousElementSibling !== "undefined") {
+				return el.previousElementSibling;
+			}
+			next = el.previousSibling;
+			while (next) {
+				if (next.nodeType === Node.ELEMENT_NODE) {
+					return next;
+				}
+				next = next.previousSibling;
+			}
+			return null;
+		}
+		if (typeof el.nextElementSibling !== "undefined") {
+			return el.nextElementSibling;
+		}
+		next = el.nextSibling;
+		while (next) {
+			if (next.nodeType === Node.ELEMENT_NODE) {
+				return next;
+			}
+			next = next.nextSibling;
+		}
+		return null;
+	}
+
+	var
+		/**
+		 * The module name of the module being tested eg "wc/ui/foo".
+		 * @type String
+		 */
+		TEST_MODULE = "wc/ui/label",
+		/**
+		 * A human readable name for the suite. This could be as simpl as TEST_MODULE.
+		 * @type String
+		 */
+		suiteName = TEST_MODULE,// .match(/\/([^\/]+)$/)[1],
+		/**
+		 * An options array of dependency names in addition to TEST_MODULE, Define a String Array here and setup will convert it to a module array.
+		 * @type arr
+		 */
+		deps = ["wc/dom/shed", "wc/dom/initialise", "wc/dom/classList", "wc/dom/tag"],
+		/**
+		 * Load test UI froman external resource e.g. "@RESOURCES@/SOME_PAGE.html". Leave undefined if not required. Simple test UIs may be set inline
+		 * using testContent instead. If both are set testContent takes precedence and urlResource is ignored.
+		 * Note that the property `@RESOURCES@` will be mapped to the test/intern/resources directory as a URL.
+		 * @type URL
+		 */
+		urlResource = "@RESOURCES@/uiLabel.html",
+		// If you have extra dependencies you will want a way to reference them.
+		shed,
+		initialise,
+		classList,
+		tag,
+		inited,
+		CLASS_REQ = "wc_req",
+		//
+		// END CONFIGURATION VARS
+		//
+		// the next two are not settable.
+		controller, // This will be the actual module named above. Tests of public functions use this e.g. `controller.getSomething()`.
+		testHolder; // This will hold any UI needed for the tests. It is left undefined if testContent & urlResource are both falsey.
+
+	registerSuite({
+		name: suiteName,
+
+		setup: function() {
+			var allDeps = (deps && deps.length) ? deps : [];
+			allDeps.unshift(TEST_MODULE);
+			var result = testutils.setupHelper(allDeps).then(function(arg) {
+
+				// The module to be tested is the controller
+				controller = arg[0];
+				// The other dependencies
+				// If you want to have named dependencies the vars are assigned here
+				shed = arg[1];
+				initialise = arg[2];
+				classList = arg[3];
+				tag = arg[4];
+				testHolder = testutils.getTestHolder();
+				return testutils.setUpExternalHTML(urlResource, testHolder);
+			});
+			return result;
+		},
+
+		beforeEach: function () {
+			if (!inited) {
+				controller.preInit(testHolder);
+				inited = true;
+			}
+			initialise.go();
+		},
+
+		teardown: function () {
+			if (testHolder) {
+				testHolder.innerHTML = "";
+			}
+		},
+
+		testGotController: function () {
+			if (!TEST_MODULE) {
+				assert.isOk(TEST_MODULE, "Cannot test an undefined module you tailless monkey!");
+			}
+			assert.typeOf(controller, "object", "Expected the test module to be available as an object otherwise the tests won't work.");
+		},
+		testGotShed: function() {
+			assert.typeOf(shed, "object", "Expected to load shed.");
+			assert.isOk(shed.show, "shed is not what you think it is."); // rough but good enough
+		},
+		testMoveLabelTrue: function() {
+			var input,
+				found,
+				inputIds = ["wcuilabel-i2", "wcuilabel-i2a", "wcuilabel-i2b"];
+			inputIds.forEach(function(nextId) {
+				input = document.getElementById(nextId);
+				found = getElSib(input);
+				assert.strictEqual(found.getAttribute("for"), nextId, "label should have been moved in pre-init");
+			});
+		},
+		testMoveLabelFalse: function() {
+			var input,
+				found,
+				inputIds = ["wcuilabel-i3", "wcuilabel-i3a", "wcuilabel-i3b"];
+			inputIds.forEach(function(nextId) {
+				input = document.getElementById(nextId);
+				found = getElSib(input, true);
+				assert.strictEqual(found.getAttribute("for"), nextId, "label should not have been moved in pre-init");
+			});
+		},
+		testGetHint: function() {
+			var label = document.getElementById("wcuilabel-l10"),
+				hint = controller.getHint(label);
+			assert.isOk(hint, "expected to find hint");
+		},
+		testGetHintCorrectContent: function() {
+			var label = document.getElementById("wcuilabel-l10"),
+				expected = "this is the hint",
+				hint = controller.getHint(label);
+			assert.strictEqual(hint.innerHTML, expected, "expected to find hint content");
+		},
+		testGetHintNoHint: function() {
+			var label = document.getElementById("wcuilabel-l11"),
+				hint = controller.getHint(label);
+			assert.isNotOk(hint, "expected to not find hint");
+		},
+		// setHint
+		testSetHint: function() {
+			var hint = "I am the walrus",
+				label = document.getElementById("wcuilabel-l9"),
+				labelHint;
+			assert.isNotOk(controller.getHint(label));
+			controller.setHint(label, hint);
+			labelHint = controller.getHint(label);
+			assert.isOk(labelHint);
+			assert.isTrue(labelHint.innerHTML.indexOf(hint) === 0);
+		},
+		testMandate: function() {
+			var input = document.getElementById("wcuilabel-i6"),
+				label = document.getElementById("wcuilabel-l6");
+			assert.isFalse(classList.contains(label, CLASS_REQ));
+			assert.isFalse(shed.isMandatory(input));
+			shed.mandatory(input);
+			assert.isTrue(classList.contains(label, CLASS_REQ));
+		},
+		testMandateRadio: function() {
+			// note: we do not decorate labels for mandatory radios
+			var input = document.getElementById("wcuilabel-i6a"),
+				label = document.getElementById("wcuilabel-l6a");
+			assert.isFalse(classList.contains(label, CLASS_REQ));
+			assert.isFalse(shed.isMandatory(input));
+			shed.mandatory(input);
+			assert.isFalse(classList.contains(label, CLASS_REQ));
+			assert.isTrue(shed.isMandatory(input));
+		},
+		testOptionalise: function() {
+			var input = document.getElementById("wcuilabel-i5"),
+				label = document.getElementById("wcuilabel-l5");
+			assert.isTrue(classList.contains(label, CLASS_REQ));
+			shed.optional(input);
+			assert.isFalse(classList.contains(label, CLASS_REQ));
+		},
+		testOptionaliseRemovesMessage: function() {
+			var input = document.getElementById("wcuilabel-i5a"),
+				label = document.getElementById("wcuilabel-l5a");
+			assert.isTrue(label.innerHTML.indexOf("wc-off") > 0);
+			shed.optional(input);
+			assert.isTrue(label.innerHTML.indexOf("wc-off") === -1);
+		},
+		testHide: function() {
+			var input = document.getElementById("wcuilabel-i7"),
+				label = document.getElementById("wcuilabel-l7");
+			assert.isFalse(shed.isHidden(label));
+			shed.hide(input);
+			assert.isTrue(shed.isHidden(label));
+		},
+		testShow: function() {
+			var input = document.getElementById("wcuilabel-i8"),
+				label = document.getElementById("wcuilabel-l8");
+			assert.isTrue(shed.isHidden(label));
+			shed.show(input);
+			assert.isFalse(shed.isHidden(label));
+		},
+		testConvertInputToRO: function() {
+			var input = document.getElementById("wcuilabel-i12"),
+				label = document.getElementById("wcuilabel-l12");
+			assert.isTrue(label.tagName === tag.LABEL, "wrong start tagname");
+			assert.isOk(label.getAttribute("for"), "should have for attribute");
+			assert.isNotOk(label.getAttribute("data-wc-rofor"), "should not have data-wc-for attribute");
+			controller._convert(input, label, true);
+			label = document.getElementById("wcuilabel-l12");
+			assert.isTrue(label.tagName === tag.SPAN, "wrong end tagname");
+			assert.isNotOk(label.getAttribute("for"), "for attribute should have been removed");
+			assert.isOk(label.getAttribute("data-wc-rofor"), "data-ro-for should have been added");
+			assert.strictEqual(label.getAttribute("data-wc-rofor"), "wcuilabel-i12");
+		},
+		testConvertROtoInput: function() {
+			var input = document.getElementById("wcuilabel-i13"),
+				label = document.getElementById("wcuilabel-l13");
+			assert.isTrue(label.tagName === tag.SPAN, "wrong start tagname");
+			assert.isNotOk(label.getAttribute("for"), "should not have for attribute");
+			assert.isOk(label.getAttribute("data-wc-rofor"), "should have data-wc-for attribute");
+			assert.strictEqual(label.getAttribute("data-wc-rofor"), "wcuilabel-i13");
+			controller._convert(input, label, false);
+			label = document.getElementById("wcuilabel-l13");
+			assert.isTrue(label.tagName === tag.LABEL, "wrong end tagname");
+			assert.isOk(label.getAttribute("for"), "for attribute should have been added");
+			assert.isNotOk(label.getAttribute("data-wc-rofor"), "data-ro-for should have been removed");
+			assert.strictEqual(label.getAttribute("for"), "wcuilabel-i13");
+		},
+		testAjaxSubscriber: function() {
+			// this is a fake just to test the actual subscriber, not to test AJAX
+			var container = document.getElementById("wcuilabel-fake-ajax"),
+				label;
+			controller._ajax(container);
+
+			label = document.getElementById("wcuilabel-fake-ajax-l1");
+			assert.strictEqual(label.tagName, tag.LABEL);
+			assert.isNotOk(label.getAttribute("data-wc-rofor"), "data-ro-for should have been removed");
+			assert.strictEqual(label.getAttribute("for"), "wcuilabel-fake-ajax-i1_input", "for attribute should have been added");
+
+			label = document.getElementById("wcuilabel-fake-ajax-l2");
+			assert.strictEqual(label.tagName, tag.SPAN);
+			assert.isNotOk(label.getAttribute("for"), "data-ro-for should have been removed");
+			assert.strictEqual(label.getAttribute("data-wc-rofor"), "wcuilabel-fake-ajax-i2", "data-wc-rofor attribute should have been added");
+
+			label = document.getElementById("wcuilabel-fake-ajax-l3");
+			assert.isTrue(shed.isHidden(label), "real label should be hidden");
+
+			label = document.getElementById("wcuilabel-fake-ajax-l4");
+			assert.isTrue(shed.isHidden(label), "fake label should be hidden");
+
+			label = document.getElementById("wcuilabel-fake-ajax-l5");
+			assert.isTrue(classList.contains(label, CLASS_REQ), "real label should be flagged required");
+
+			label = document.getElementById("wcuilabel-fake-ajax-l6");
+			assert.isFalse(classList.contains(label, CLASS_REQ), "fake label should not be flagged required");
+
+			// change of property but not of read-only state
+			// mandatory
+			label = document.getElementById("wcuilabel-fake-ajax-l7");
+			assert.isTrue(classList.contains(label, CLASS_REQ), "label should now be flagged required");
+			label = document.getElementById("wcuilabel-fake-ajax-l8");
+			assert.isFalse(classList.contains(label, CLASS_REQ), "label should no longer be flagged required");
+			label = document.getElementById("wcuilabel-fake-ajax-l9");
+			assert.isTrue(shed.isHidden(label), "label should now be hidden");
+			label = document.getElementById("wcuilabel-fake-ajax-l10");
+			assert.isFalse(shed.isHidden(label), "label should no longer be hidden");
+		}
+	});
+});

--- a/wcomponents-theme/src/test/intern/wc.xml.xmlString.test.js
+++ b/wcomponents-theme/src/test/intern/wc.xml.xmlString.test.js
@@ -3,7 +3,7 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils!"],
 		"use strict";
 		var xmlString, testXmlString;
 		registerSuite({
-			name: "xmlString",
+			name: "wc/xml/xmlString",
 			setup: function() {
 				return testutils.setupHelper(["wc/xml/xmlString"], function(obj) {
 					xmlString = obj;
@@ -32,6 +32,14 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils!"],
 				expected = expected.replace(whitespaceRe, "");
 				expected = expected.replace(xmlHeaderRe, "");
 				assert.strictEqual(expected, result);
+			},
+			testToPretendToBeIE9: function() {
+				var expected = "<p>foo</p>",
+					dummy = {xml: expected};
+				assert.strictEqual(expected, xmlString.to(dummy));
+			},
+			testToWithfalseyNode: function() {
+				assert.isNull(xmlString.to(false));
 			}
 		});
 	});


### PR DESCRIPTION
* Found a flaw in label conversion when inputs are not wrapped
* Found a flaw in module `wc/dom/shed` (yes really):  `isMandatory` was out of step with `isHidden` and `isDisabled` in that it was using getAttrbute(`required`) rather than `hasAttribute("required")`. This leads to false negatives when the mark-up is HTML syntax rather than XML syntax. Added another shed unit test for this condition.

Added new unit tests for modules `wc/Observer`.and `wc/xml/xmlString` just to cover some missing lines.