### PR TITLE
move "community" docs from wiki to root

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at bordertech@border.gov.au. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to WComponents
+
+Contributions are welcome. Please use the standard
+[Fork and Pull](https://help.github.com/articles/using-pull-requests/) workflow. Note that your pull
+request will not be against `master` see [Our Branches](https://github.com/BorderTech/wcomponents/wiki/Branches).
+
+## Before you start
+
+We ask that you read our **CODE OF CONDUCT** before you do anything else.
+
+Proposed changes should have an issue raised doing any work. Bugs should go straight to
+[our issues](https://github.com/BorderTech/wcomponents/issues).
+
+## Mandatory requirements
+
+We will not pull any changes unless these requirements are met.
+
+- Your change must make sense within a generic, abstract framework. Special cases and specific
+  components should form part a higher layer, not the core framework itself. Useful composite or
+  specific purpose components my be better in the [WComponents samples](https://github.com/BorderTech/wcomponents-samples)
+  or [BorderTech/java-common](https://github.com/BorderTech/java-common) projects.
+- Your change must be covered by unit tests.
+- The [CI build](https://travis-ci.org/BorderTech/wcomponents) must pass.
+- Your code must follow our [coding conventions](https://github.com/BorderTech/wcomponents/wiki/Coding=conventions).
+- Theme/front-end code must be [accessible](https://github.com/BorderTech/wcomponents/wiki/Accessibility).
+
+## Changelog
+
+In general changes will require a CHANGELOG entry (there will be exceptions, for example if you are
+reverting a previous change that had not yet been released) and be sure to reference the issue
+number that the change addresses.
+
+For example: `Fix WKittenLocator not finding tabbies (#999)`.


### PR DESCRIPTION
@ricksbrown these are two new markdown files to replace former wiki content. No merge issues will arise as they will not exist in development branches until after the next merge to master and creation of `georgie` 
