### PR TITLE
Fix an edge case in Widget

### DIFF
--- a/wcomponents-theme/src/main/js/wc/dom/Widget.js
+++ b/wcomponents-theme/src/main/js/wc/dom/Widget.js
@@ -109,7 +109,10 @@ define(["wc/dom/getAncestorOrSelf", "wc/dom/uid"], /** @param getAncestorOrSelf 
 				if (p1 !== ESC) {
 					res = ESC + res;
 				}
-				return p1 + res;
+				if (typeof p1 !== "undefined") {
+					res = p1 + res;
+				}
+				return res;
 			});
 		}
 		return result;

--- a/wcomponents-theme/src/test/intern/resources/domWidget.html
+++ b/wcomponents-theme/src/test/intern/resources/domWidget.html
@@ -33,7 +33,7 @@
 </div>
 <div class="foo" id="cantThinkOfMoreIds">
 	<div class="loo">
-		<a href="#" rel="static" name="a4" class="barn" id="a4"><em id="omfg2">Foo</em>Hello</a>
+		<a href="#dd33" rel="static" name="a4" class="barn" id="a4"><em id="omfg2">Foo</em>Hello</a>
 		<div class="moo" id="moo3">
 			<a href="#" rel="static" name="a2" class="bard bart" id="a2"><em id="omfg3">Hello</em></a>
 			<span class="bar" id="ss44">

--- a/wcomponents-theme/src/test/intern/wc.dom.WidgetDescriptor.test.js
+++ b/wcomponents-theme/src/test/intern/wc.dom.WidgetDescriptor.test.js
@@ -205,6 +205,13 @@ define(["intern!object", "intern/chai!assert", "./resources/test.utils!"], funct
 			assert.strictEqual(result.id, expectedId);
 		},
 
+		testDescendantWithHrefAtrributeMatch: function() {
+			var result, expectedId = "a4", widget = new Widget("a");
+			widget = widget.extend("", { href: "#dd33" });
+			result = widget.findDescendant(testHolder);
+			assert.strictEqual(result.id, expectedId);
+		},
+
 		testDescendantWithId: function() {
 			var result = matchId.findDescendant(testHolder),
 				expectedId = "greg";


### PR DESCRIPTION
Widget should be able to match the href attribute of an anchor like the below:

```<a href="#foo">Foo</a>```