### PR TITLE
Fix XML inter-element whitespace problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### Bug Fixes
 
-* Fixed regressions from 1.4.12 which could result in messages not benig rendered correctly #1370.
+* Fixed regressions from 1.4.12 which could result in messages not being rendered correctly #1370.
+* Fixed an issue which could result in unexpected element alignment due to an error in the whitespace filter #1381.
 
 ## Release 1.4.13
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/XmlStringBuilder.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/XmlStringBuilder.java
@@ -20,21 +20,6 @@ import java.util.Locale;
 public final class XmlStringBuilder extends PrintWriter {
 
 	/**
-	 * If true, format XML content by indenting nested tags.
-	 */
-	private boolean indentingOn = true;
-
-	/**
-	 * The current indent level.
-	 */
-	private int indentLevel = -1;
-
-	/**
-	 * Indicates whether an indent has been performed on the current line.
-	 */
-	private boolean newIndentDone = false;
-
-	/**
 	 * The translator used to translate messages.
 	 */
 	private final Locale locale;
@@ -70,8 +55,6 @@ public final class XmlStringBuilder extends PrintWriter {
 	 * @param name the name of the tag to be added.
 	 */
 	public void appendTag(final String name) {
-		incrementIndent();
-		indent();
 		write('<');
 		write(name);
 		write('>');
@@ -88,13 +71,10 @@ public final class XmlStringBuilder extends PrintWriter {
 	 * @param name the name of the ending tag to be added.
 	 */
 	public void appendEndTag(final String name) {
-		indent();
 		write('<');
 		write('/');
 		write(name);
 		write('>');
-
-		decrementIndent();
 	}
 
 	/**
@@ -108,8 +88,6 @@ public final class XmlStringBuilder extends PrintWriter {
 	 * @param name the name of the tag to be added.
 	 */
 	public void appendTagOpen(final String name) {
-		incrementIndent();
-		indent();
 		write('<');
 		write(name);
 	}
@@ -136,59 +114,27 @@ public final class XmlStringBuilder extends PrintWriter {
 	 */
 	public void appendEnd() {
 		write(" />");
-		decrementIndent();
 	}
 
 	// === start formatting routines ===
 	/**
 	 * Turns indenting off for further content written to this XmlStringBuilder.
+	 * @deprecated 1.4.13 No longer used: no replacement, will be removed in v2.0.0.
 	 */
+	@Deprecated
 	public void turnIndentingOff() {
-		indentingOn = false;
+		// no op
 	}
 
 	/**
 	 * Turns indenting on for further content written to this XmlStringBuilder.
+	 * @deprecated 1.4.13 No longer used: no replacement, will be removed in v2.0.0.
 	 */
+	@Deprecated
 	public void turnIndentingOn() {
-		indentingOn = true;
+		// no op
 	}
 
-	/**
-	 * Increments the indenting level if indenting is active.
-	 */
-	private void incrementIndent() {
-		if (indentingOn) {
-			indentLevel++;
-			newIndentDone = false;
-		}
-	}
-
-	/**
-	 * Decrements the indenting level if indenting is active.
-	 */
-	private void decrementIndent() {
-		if (indentingOn) {
-			newIndentDone = false;
-
-			if (indentLevel > 0) {
-				indentLevel--;
-			}
-		}
-	}
-
-	/**
-	 * If indenting, outputs an indent for the current indenting level.
-	 */
-	private void indent() {
-		if (indentingOn && !newIndentDone) {
-			println();
-			for (int i = 0; i < indentLevel; i++) {
-				write('\t');
-			}
-			newIndentDone = true;
-		}
-	}
 
 	// === end formatting routines ===
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/container/WhitespaceFilterInterceptor.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/container/WhitespaceFilterInterceptor.java
@@ -37,7 +37,6 @@ public class WhitespaceFilterInterceptor extends InterceptorComponent {
 
 			WebXmlRenderContext filteredContext = new WebXmlRenderContext(writer, UIContextHolder.
 					getCurrent().getLocale());
-			filteredContext.getWriter().turnIndentingOff();
 			super.paint(filteredContext);
 		} else {
 			super.paint(renderContext);

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/DiagnosticRenderUtil.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/DiagnosticRenderUtil.java
@@ -56,7 +56,6 @@ public final class DiagnosticRenderUtil {
 		}
 
 		XmlStringBuilder xml = renderContext.getWriter();
-		xml.turnIndentingOff();
 		xml.appendTagOpen(TAG_NAME);
 		xml.appendAttribute("type", getLevel(severity));
 		xml.appendClose();
@@ -67,7 +66,6 @@ public final class DiagnosticRenderUtil {
 			xml.appendEndTag(MESSAGE_TAG_NAME);
 		}
 		xml.appendEndTag(TAG_NAME);
-		xml.turnIndentingOn();
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/ConfigurationProperties.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/ConfigurationProperties.java
@@ -1066,7 +1066,7 @@ public final class ConfigurationProperties {
 	 * @return the parameter value if set, or true if not set.
 	 */
 	public static boolean getWhitespaceFilter() {
-		return get().getBoolean(WHITESPACE_FILTER, false);
+		return get().getBoolean(WHITESPACE_FILTER, true);
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/ConfigurationProperties.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/ConfigurationProperties.java
@@ -1066,7 +1066,7 @@ public final class ConfigurationProperties {
 	 * @return the parameter value if set, or true if not set.
 	 */
 	public static boolean getWhitespaceFilter() {
-		return get().getBoolean(WHITESPACE_FILTER, true);
+		return get().getBoolean(WHITESPACE_FILTER, false);
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/validation/AbstractWFieldIndicator.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/validation/AbstractWFieldIndicator.java
@@ -71,7 +71,7 @@ public abstract class AbstractWFieldIndicator extends AbstractWComponent {
 	 * Provide subclasses with access to the related field.
 	 *
 	 * @return The Related Field.
-	 * @deprecated use {@link #getTargetComponent() instead.
+	 * @deprecated use {@link #getTargetComponent()} instead.
 	 */
 	@Deprecated
 	protected WComponent getRelatedField() {


### PR DESCRIPTION
Resolve  #1381 

Removed XML indentation between component root elements. Indentation is unnecessary as the XML is not for humans and can be formatted using a decent XML formatter anyway if required.

The render and alignment issues caused by the whitespace filter leaving inter-node whitespace where it is not appropriate are alleviated for inter-element spaces. These inter-element spaces are the ones which cause layout problems under some transform scenarios.

@jonathanaustin PTAL

NOTE: also fixed a JavaDoc error I caused in a previous PR.