### PR TITLE
selectboxSearch fires change immediately a value is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix an error in the wcomponent-theme POM #1390.
 * Fixed regressions from 1.4.12 which could result in messages not being rendered correctly #1370.
 * Fixed an issue which could result in unexpected element alignment due to an error in the whitespace filter #1381.
+* Change the way dropdown typeahead (selectboxSearch) works to better align with the way most modern browsers fire the change event QC169945.
 
 ## Release 1.4.13
 

--- a/wcomponents-theme/src/main/js/wc/ui/ajaxRegion.js
+++ b/wcomponents-theme/src/main/js/wc/ui/ajaxRegion.js
@@ -1,4 +1,5 @@
 define(["wc/dom/event",
+	"wc/debounce",
 	"wc/dom/attribute",
 	"wc/dom/isSuccessfulElement",
 	"wc/dom/tag",
@@ -11,7 +12,7 @@ define(["wc/dom/event",
 	"wc/dom/classList",
 	"wc/mixin",
 	"wc/timers"],
-	function(event, attribute, isSuccessfulElement, tag, Trigger, triggerManager, shed, Widget, initialise, processResponse, classList, mixin, timers) {
+	function(event, debounce, attribute, isSuccessfulElement, tag, Trigger, triggerManager, shed, Widget, initialise, processResponse, classList, mixin, timers) {
 		"use strict";
 
 		/**
@@ -146,7 +147,7 @@ define(["wc/dom/event",
 				var element = $event.target;
 				if (!$event.defaultPrevented && !attribute.get(element, INITED_FLAG) && triggersOnChange(element)) {
 					attribute.set(element, INITED_FLAG, true);
-					event.add(element, event.TYPE.change, changeEvent, 100);
+					event.add(element, event.TYPE.change, debounce(changeEvent, 250), 100);
 				}
 			}
 

--- a/wcomponents-theme/src/main/js/wc/ui/selectboxSearch.js
+++ b/wcomponents-theme/src/main/js/wc/ui/selectboxSearch.js
@@ -26,9 +26,22 @@ define(["wc/string/escapeRe",
 					textTrumpsValue: true,
 					minLenSubstring: 3,
 					minLenVal: 1,
-					debounceDelay: 250
+					debounceDelay: 125  // making this too long can be counter-productive
 				},
-				fireOnchange = false,
+				selectionChanged = debounce(function(element) {
+					// programatically changing the select will not fire change so we gots to do it ourselves
+					/*
+					 * Note that we used to fire the change event only when the dropdown lost focus,
+					 * in other words, as per any traditional change event.
+					 * Nowadays this is not consistent with the native behaviour of many browsers (Chrome, IE11) which
+					 * fire change as the selection changes. Only Firefox maintains the traditional behaviour.
+					 * This inconsistency can lead to unexpected behaviour since the native typeahead will be firing changes
+					 * while this typeahead will not. If there are side effects (e.g. an AJAX update is triggered) then the
+					 * dropdown may be displaying a value that is not appropriate for the current state (only resolved when the user
+					 * moves on in the form).
+					 */
+					event.fire(element, event.TYPE.change);
+				}, 0),
 				debouncedSearch,
 				NO_ENDS_WITH_STRING_RE = /[^ ]$/,
 				/* NOTE: moved the initialisation of ALLOWED to initialise because
@@ -39,7 +52,11 @@ define(["wc/string/escapeRe",
 				searchElementId,
 				regexCache = { starts: {}, contains: {} };
 
-
+			/**
+			 * Determine if this element needs the typeahead, i.e. it is a dropdown.
+			 * @param {Element} element An element that may potentially require typeahead.
+			 * @returns {Element} The element that requires typeahead, or null.
+			 */
 			function needsSelectSearch(element) {
 				var result = null;
 				if (element.tagName === tag.SELECT && !element.multiple) {
@@ -53,12 +70,8 @@ define(["wc/string/escapeRe",
 				if (needsSelectSearch(element)) {
 					initConfig();
 					initSelect(element);
-					closeSearch(element);
+					closeSearch();
 				}
-			}
-
-			function blurEvent(evt) {
-				closeSearch(evt.currentTarget);
 			}
 
 			function keydownEvent(evt) {
@@ -148,7 +161,7 @@ define(["wc/string/escapeRe",
 				if (!inited) {
 					attribute.set(element, ns, true);
 					event.add(element, event.TYPE.click, focusEvent);
-					event.add(element, event.TYPE.blur, blurEvent);
+					event.add(element, event.TYPE.blur, closeSearch);
 					event.add(element, event.TYPE.keydown, keydownEvent);
 					event.add(element, event.TYPE.keypress, keypressEvent);
 				}
@@ -192,7 +205,6 @@ define(["wc/string/escapeRe",
 			 */
 			function highlightSearch(element, search) {
 				var match;
-				// fireOnchange = true;
 				if (search) {
 					if (config.textTrumpsValue) {
 						match = getMatchByText(element, search) || getMatchByValue(element, search);
@@ -222,12 +234,11 @@ define(["wc/string/escapeRe",
 			function selectMatch(element, match) {
 				timers.setTimeout(function() {
 					if (match) {
-						fireOnchange = true;
 						element.selectedIndex = match.index;
 					} else {
-						fireOnchange = true;
 						element.selectedIndex = 0;
 					}
+					selectionChanged(element);
 					element = null;
 					match = null;
 				}, 0);
@@ -331,19 +342,13 @@ define(["wc/string/escapeRe",
 
 			/**
 			 * "Close" the little box thingy that shows what you have typed so far
-			 * @param {Element} element The SELECT element the search box is attached to.
 			 */
-			function closeSearch(element) {
+			function closeSearch() {
 				var search = getSearchElement();
 				textContent.set(search, "");
 				if (!shed.isHidden(search, true)) {
 					hideSearch(search);
-					if (fireOnchange && element) {
-						// programatically changing the select will not fire change so we gots to do it ourselves
-						timers.setTimeout(event.fire, 0, element, event.TYPE.change);
-					}
 				}
-				fireOnchange = false;
 			}
 
 			function hideSearch(search) {


### PR DESCRIPTION
In days of yore browsers would fire the change event when a field lost focus.
Firefox still behaves this way, even for dropdowns.
Other browsers now fire change every time a dropdown value is changed.

Since browsers today also have a native typeahead the value of the dropdown will change as the user types, triggering any side effects on change, e.g. as an AJAX trigger. Our custom typeahead will then change the value of the dropdown (but currently not fire the change event) meaning the side effects will not correspond to the current value of the dropdown (until the user moves focus).
