### PR TITLE
Make the option/optgroup apply-templates explicit. 

### DIFF
--- a/wcomponents-theme/src/main/xslt/wc.ui.dropdown.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.dropdown.xsl
@@ -28,7 +28,7 @@
 								<xsl:value-of select="@autocomplete"/>
 							</xsl:attribute>
 						</xsl:if>
-						<xsl:apply-templates mode="selectableList"/>
+						<xsl:apply-templates select="ui:option|ui:optgroup" mode="selectableList"/>
 					</select>
 					<xsl:apply-templates select="ui:fieldindicator"/>
 				</span>
@@ -96,7 +96,7 @@
 						<xsl:text>true</xsl:text>
 					</xsl:attribute>
 				</xsl:if>
-				<xsl:apply-templates mode="comboDataList" />
+				<xsl:apply-templates select="ui:option|ui:optgroup" mode="comboDataList" />
 			</span>
 			<xsl:apply-templates select="ui:fieldindicator"/>
 		</span>

--- a/wcomponents-theme/src/main/xslt/wc.ui.listbox.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.listbox.xsl
@@ -55,7 +55,7 @@
 								<xsl:value-of select="@autocomplete"/>
 							</xsl:attribute>
 						</xsl:if>
-						<xsl:apply-templates mode="selectableList"/>
+						<xsl:apply-templates select="ui:option|ui:optgroup" mode="selectableList"/>
 					</select>
 					<xsl:call-template name="hField"/>
 					<xsl:apply-templates select="ui:fieldindicator"/>

--- a/wcomponents-theme/src/main/xslt/wc.ui.shuffler.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.shuffler.xsl
@@ -32,7 +32,7 @@
 							</xsl:attribute>
 						</xsl:if>
 						<xsl:call-template name="isInvalid"/>
-						<xsl:apply-templates mode="selectableList"/>
+						<xsl:apply-templates select="ui:option|ui:optgroup" mode="selectableList"/>
 					</select>
 					<xsl:call-template name="listSortControls">
 						<xsl:with-param name="id" select="$listId"/>


### PR DESCRIPTION
In these cases the fieldinciators were applied but did not have a mode match. This was rather dangerous.