### PR TITLE
Improvements for QC170915

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 ### API Changes
 
 ### Enhancements
+* Client side: wc/config now caters for common "fetch, test, override" pattern of module configuration.
+* Client side: imageEditor can now be configured through the "wc/config" module.
 
 ### Bug Fixes
+* Client side: wc/dom/initialise could theoretically reset its observer instance before all subscribers had been called, this is now resolved.
 
 ## Release 1.4.14
 

--- a/wcomponents-theme/src/main/js/wc/config.js
+++ b/wcomponents-theme/src/main/js/wc/config.js
@@ -3,7 +3,7 @@
  * Do you use a global object? A loader specific mechanism like RequireJS configuration?
  * The aim of this module is to encapsulate the underlying mechanism and present a simple configuration API to other modules.
  */
-define(["module"], function(module) {
+define(["wc/mixin", "module"], function(mixin, module) {
 	var instance = new Config();
 	initialise();
 
@@ -21,11 +21,17 @@ define(["module"], function(module) {
 
 	/**
 	 * @constructor
-	 * @returns {undefined}
 	 */
 	function Config() {
 		var configObject = {};
 
+		/**
+		 * Register a configuration object for a given id or completely replace the entire registry with the given object.
+		 *
+		 * @param {Object} config The configuration object to set.
+		 * @param {string} [id] The ID against which to register this configuration. If falsey will replace the entire registery with the
+		 *    configuration (did this ever seem like a good idea?).
+		 */
 		this.set = function(config, id) {
 			if (id) {
 				configObject[id] = config || configObject[id];
@@ -34,8 +40,22 @@ define(["module"], function(module) {
 			}
 		};
 
-		this.get = function(id) {
-			return configObject[id];
+		/**
+		 * Get the config registered for this id.
+		 * @param {string} id Specify which configuration you want to get.
+		 * @param {Object} [defaults] Optionally provide a default configuration, the result will contain the result of the defaults overriden by any
+		 *    registered configuration.
+		 *    Note that object properties will be recursively mixed in, anything else (arrays, strings, numbers etc) will be overriden.
+		 *    With this argument provided the result will never be null.
+		 * @returns {Object} A configuration object.
+		 */
+		this.get = function(id, defaults) {
+			var defaultConfig, result = configObject[id];
+			if (defaults) {
+				defaultConfig = mixin(defaults);  // make a copy of defaults;
+				result = mixin(result, defaultConfig);  // override defaults with explicit settings (mixin can handle result being null)
+			}
+			return result;
 		};
 	}
 	return instance;

--- a/wcomponents-theme/src/main/js/wc/dom/initialise.js
+++ b/wcomponents-theme/src/main/js/wc/dom/initialise.js
@@ -110,10 +110,8 @@ define(["wc/Observer", "wc/timers", "wc/global", "lib/requirejs/domReady"],
 			* @param {Function} [callback] Function which will be called after all the routines are executed.
 			*/
 			this.go = function(element, callback) {
-				var goingObserver = observer;
-				if (goingObserver) {
-					observer = null;  // any calls to add while executing will be placed into a new observer
-					goingObserver.notify(element).then(function() {
+				var goingObserver = observer,
+					gone = function() {
 						try {
 							if (callback && typeof callback === "function") {
 								callback();
@@ -124,7 +122,10 @@ define(["wc/Observer", "wc/timers", "wc/global", "lib/requirejs/domReady"],
 								observer = goingObserver;  // put the empty observer instance back ready for new subscribers
 							}
 						}
-					});
+					};
+				if (goingObserver) {
+					observer = null;  // any calls to add while executing will be placed into a new observer
+					goingObserver.notify(element).then(gone, gone);
 				}
 			};
 

--- a/wcomponents-theme/src/main/js/wc/dom/initialise.js
+++ b/wcomponents-theme/src/main/js/wc/dom/initialise.js
@@ -111,19 +111,20 @@ define(["wc/Observer", "wc/timers", "wc/global", "lib/requirejs/domReady"],
 			*/
 			this.go = function(element, callback) {
 				var goingObserver = observer;
-				try {
-					if (goingObserver) {
-						observer = null;  // any calls to add while executing will be placed into a new observer
-						goingObserver.notify(element);
-						if (callback && typeof callback === "function") {
-							callback();
+				if (goingObserver) {
+					observer = null;  // any calls to add while executing will be placed into a new observer
+					goingObserver.notify(element).then(function() {
+						try {
+							if (callback && typeof callback === "function") {
+								callback();
+							}
+						} finally {
+							if (observer === null) {  // if no new subscribers were added while were were executing the existing subscribers
+								goingObserver.reset();  // clear all the subscribers we have just finished calling
+								observer = goingObserver;  // put the empty observer instance back ready for new subscribers
+							}
 						}
-					}
-				} finally {
-					if (observer === null) {  // if no new subscribers were added while were were executing the existing subscribers
-						goingObserver.reset();  // clear all the subscribers we have just finished calling
-						observer = goingObserver;  // put the empty observer instance back ready for new subscribers
-					}
+					});
 				}
 			};
 

--- a/wcomponents-theme/src/main/js/wc/mixin.js
+++ b/wcomponents-theme/src/main/js/wc/mixin.js
@@ -13,7 +13,7 @@ define(function() {
 		if (source) {
 			for (var prop in source) {
 				if (source.hasOwnProperty(prop)) {
-					if (source[prop].constructor === Object) {
+					if (source[prop] && source[prop].constructor === Object) {
 						if (!result[prop] || result[prop].constructor === Object) {
 							result[prop] = mixin(source[prop], result[prop]);
 						} else {

--- a/wcomponents-theme/src/main/js/wc/ui/ImageCapture.js
+++ b/wcomponents-theme/src/main/js/wc/ui/ImageCapture.js
@@ -213,13 +213,10 @@ define(["wc/has", "wc/dom/classList", "wc/dom/event", "wc/ui/prompt", "wc/config
 			var play = function() {
 					gumWithFallback(currentOptions, playCb, errCb);
 				},
-				globalOptions, globalConf = wcconfig.get("wc/ui/imageEdit");
-			if (globalConf && globalConf.options) {
-				globalOptions = globalConf.options;
-			} else {
-				globalOptions = {};
-			}
-			currentOptions = Object.assign({}, defaultOptions, globalOptions, options);
+				globalConf = wcconfig.get("wc/ui/imageEdit", {
+					options: {}
+				});
+			currentOptions = Object.assign({}, defaultOptions, globalConf.options, options);
 			currentOptions.width *= 1;
 			currentOptions.height *= 1;
 			window.webcam = currentOptions;  // Needed for flash fallback

--- a/wcomponents-theme/src/main/js/wc/ui/backToTop.js
+++ b/wcomponents-theme/src/main/js/wc/ui/backToTop.js
@@ -176,10 +176,10 @@ define(["wc/i18n/i18n", "wc/dom/event", "wc/dom/focus", "wc/dom/initialise", "wc
 			this.setEnabled = function(enable) {
 				isEnabled = !!enable;
 				if (enable) {
-					config = config || wcconfig.get("wc/ui/backToTop");
-					if (config) {
-						MIN_SCROLL_BEFORE_SHOW = config.scroll || MIN_SCROLL_BEFORE_SHOW;
-					}
+					config = config || wcconfig.get("wc/ui/backToTop", {
+						scroll: MIN_SCROLL_BEFORE_SHOW
+					});
+					MIN_SCROLL_BEFORE_SHOW = config.scroll;
 				} else {
 					toggle(false); // just in case the link is showing at the time it is turned off.
 				}

--- a/wcomponents-theme/src/main/js/wc/ui/calendar.js
+++ b/wcomponents-theme/src/main/js/wc/ui/calendar.js
@@ -58,9 +58,10 @@ function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthNam
 			refocusId,
 			MIN_ATTRIB = "min",
 			MAX_ATTRIB = "max",
-			conf = wcconfig.get("wc/ui/calendar"),
-			MIN_YEAR = ((conf && conf.min) ? conf.min : 1000),
-			MAX_YEAR = ((conf && conf.max) ? conf.max : 9999);
+			conf = wcconfig.get("wc/ui/calendar", {
+				min: 1000,
+				max: 9999
+			});
 
 
 		function findMonthSelect() {
@@ -279,8 +280,8 @@ function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthNam
 		 * @param {Element} yearElement The input element holding the year.
 		 */
 		function yearChanged(yearElement) {
-			var min = yearElement.getAttribute(MIN_ATTRIB) || MIN_YEAR,
-				max = yearElement.getAttribute(MAX_ATTRIB) || MAX_YEAR;
+			var min = yearElement.getAttribute(MIN_ATTRIB) || conf.min,
+				max = yearElement.getAttribute(MAX_ATTRIB) || conf.max;
 			timers.clearTimeout(yearChangedTimeout);
 			yearChangedTimeout = timers.setTimeout(function() {
 				var value = getYearValueAsNumber(yearElement);
@@ -719,7 +720,7 @@ function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthNam
 						year.setAttribute(MIN_ATTRIB, xfrObj.year);
 					}
 				} else {
-					year.setAttribute(MIN_ATTRIB, MIN_YEAR);
+					year.setAttribute(MIN_ATTRIB, conf.min);
 				}
 
 				if (max) {
@@ -728,7 +729,7 @@ function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthNam
 						year.setAttribute(MAX_ATTRIB, xfrObj.year);
 					}
 				} else {
-					year.setAttribute(MAX_ATTRIB, MAX_YEAR);
+					year.setAttribute(MAX_ATTRIB, conf.max);
 				}
 			}
 		}
@@ -926,8 +927,8 @@ function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthNam
 		function clearMinMaxYear() {
 			var year = document.getElementById(YEAR_ELEMENT_ID);
 			if (year) {
-				year.setAttribute(MIN_ATTRIB, MIN_YEAR);
-				year.setAttribute(MAX_ATTRIB, MAX_YEAR);
+				year.setAttribute(MIN_ATTRIB, conf.min);
+				year.setAttribute(MAX_ATTRIB, conf.max);
 			}
 		}
 

--- a/wcomponents-theme/src/main/js/wc/ui/comboBox.js
+++ b/wcomponents-theme/src/main/js/wc/ui/comboBox.js
@@ -40,21 +40,10 @@ define(["wc/has",
 				CLASS_CHATTY = "wc_combo_dyn",
 				CHATTY_COMBO = COMBO.extend(CLASS_CHATTY),
 				updateTimeout,
-				conf = wcconfig.get("wc/ui/comboBox"),
-				/**
-				 * Wait this long before updating the list on keydown.
-				 * @var
-				 * @type Number
-				 * @private
-				 */
-				DELAY = (conf ? (conf.delay || 250) : 250),
-				/**
-				 * Only update the list if the user has entered at least this number of characters.
-				 * @var
-				 * @type Number
-				 * @private
-				 */
-				DEFAULT_CHARS = (conf ? (conf.min || 3) : 3),
+				conf = wcconfig.get("wc/ui/comboBox", {
+					delay: 250,  // Wait this long before updating the list on keydown
+					min: 3  // Only update the list if the user has entered at least this number of characters.
+				}),
 				CHAR_KEYS,  // used in the keydown event handler if we cannot use the input event
 				nothingLeftReg = {};  // last search returned no match, keep the search term for future reference
 
@@ -170,7 +159,7 @@ define(["wc/has",
 				}
 
 				if (!(_delay || delay === 0)) {
-					_delay = DELAY;
+					_delay = conf.delay;
 				}
 				if (filterTimer) {
 					timers.clearTimeout(filterTimer);
@@ -223,7 +212,7 @@ define(["wc/has",
 			}
 
 			/**
-			 * Updates the datalist for a given combo element if the element's content is at least DEFAULT_CHARS.
+			 * Updates the datalist for a given combo element if the element's content is at least conf.min.
 			 * @function
 			 * @private
 			 * @param {Element} element The input element we are interested in.
@@ -236,12 +225,12 @@ define(["wc/has",
 					return;
 				}
 
-				min = list.getAttribute("data-wc-minchars") || DEFAULT_CHARS;
+				min = list.getAttribute("data-wc-minchars") || conf.min;
 				if (element.value.length >= min) {
 					if (!shed.isExpanded(combo)) {
 						shed.expand(combo);
 					}
-					updateTimeout = timers.setTimeout(getNewOptions, DELAY, combo, element);
+					updateTimeout = timers.setTimeout(getNewOptions, conf.delay, combo, element);
 				}
 			}
 

--- a/wcomponents-theme/src/main/js/wc/ui/dialogFrame.js
+++ b/wcomponents-theme/src/main/js/wc/ui/dialogFrame.js
@@ -81,10 +81,12 @@ define(["wc/dom/event",
 			 * @returns {Boolean} true is move/resize are supportable.
 			 */
 			function canMoveResize() {
-				var conf,
+				var conf = wcconfig.get("wc/ui/dialogFrame", {
+						vpUtil: null
+					}),
 					func = "isPhoneLike";
 
-				if ((conf = wcconfig.get("wc/ui/dialogFrame")) && conf.vpUtil && viewportUtils[conf.vpUtil]) {
+				if (conf.vpUtil && viewportUtils[conf.vpUtil]) {
 					func = conf.vpUtil;
 				}
 				return !viewportUtils[func]();
@@ -352,10 +354,10 @@ define(["wc/dom/event",
 			}
 
 			function getResizeConfig(width, height) {
-				var globalConf = wcconfig.get("wc/ui/dialogFrame"),
+				var globalConf = wcconfig.get("wc/ui/dialogFrame", {}),
 					offset = INITIAL_TOP_PROPORTION;
 
-				if (globalConf && globalConf.offset) {
+				if (globalConf.offset) {
 					if (isNaN(globalConf.offset)) {
 						console.log("Offset must be a number, what are you playing at?");
 					} else if (globalConf.offset <= 0) {
@@ -366,7 +368,7 @@ define(["wc/dom/event",
 						offset = globalConf.offset;
 					}
 				}
-				return {width: width, height: height, topOffsetPC: offset};
+				return { width: width, height: height, topOffsetPC: offset };
 			}
 
 			/**

--- a/wcomponents-theme/src/main/js/wc/ui/draggable.js
+++ b/wcomponents-theme/src/main/js/wc/ui/draggable.js
@@ -30,8 +30,9 @@ define(["wc/dom/attribute",
 				dragging,
 				offsetX = {},
 				offsetY = {},
-				conf = wcconfig.get("wc/ui/draggable"),
-				KEY_MOVE = ((conf && conf.step) ? conf.step : 8),  // the number of pixels by which a draggable is moved by keyboard
+				conf = wcconfig.get("wc/ui/draggable", {
+					step: 8  // the number of pixels by which a draggable is moved by keyboard
+				}),
 				BS = ns + ".inited";
 
 			/**
@@ -125,16 +126,16 @@ define(["wc/dom/attribute",
 				if (!$event.defaultPrevented && (element = DRAGGABLE.findAncestor(target))) {
 					switch (keyCode) {
 						case KeyEvent.DOM_VK_RIGHT:
-							x = KEY_MOVE;
+							x = conf.step;
 							break;
 						case KeyEvent.DOM_VK_LEFT:
-							x = 0 - KEY_MOVE;
+							x = 0 - conf.step;
 							break;
 						case KeyEvent.DOM_VK_DOWN:
-							y = KEY_MOVE;
+							y = conf.step;
 							break;
 						case KeyEvent.DOM_VK_UP:
-							y = 0 - KEY_MOVE;
+							y = 0 - conf.step;
 							break;
 					}
 				}

--- a/wcomponents-theme/src/main/js/wc/ui/imageEdit.js
+++ b/wcomponents-theme/src/main/js/wc/ui/imageEdit.js
@@ -1,6 +1,6 @@
-define(["wc/has", "wc/mixin", "wc/dom/Widget", "wc/dom/event", "wc/dom/uid", "wc/dom/classList", "wc/timers", "wc/ui/prompt",
+define(["wc/has", "wc/mixin", "wc/config", "wc/dom/Widget", "wc/dom/event", "wc/dom/uid", "wc/dom/classList", "wc/timers", "wc/ui/prompt",
 	"wc/i18n/i18n", "fabric", "wc/ui/dialogFrame", "wc/template", "wc/ui/ImageCapture", "wc/ui/ImageUndoRedo", "wc/file/getMimeType"],
-function(has, mixin, Widget, event, uid, classList, timers, prompt, i18n, fabric, dialogFrame, template, ImageCapture, ImageUndoRedo, getMimeType) {
+function(has, mixin, wcconfig, Widget, event, uid, classList, timers, prompt, i18n, fabric, dialogFrame, template, ImageCapture, ImageUndoRedo, getMimeType) {
 	var timer,
 		imageEdit = new ImageEdit();
 
@@ -144,24 +144,23 @@ function(has, mixin, Widget, event, uid, classList, timers, prompt, i18n, fabric
 		 * @returns {Object} configuration
 		 */
 		this.getConfig = function(obj) {
-			var editorId, result, defaultConfig;
+			var editorId, instanceConfig, result = wcconfig.get("wc/ui/imageEdit", this.defaults);
 			if (obj) {
-				result = registeredIds[obj.id] || registeredIds[obj.name];
-				if (!result) {
+				instanceConfig = registeredIds[obj.id] || registeredIds[obj.name];
+				if (!instanceConfig) {
 					if ("getAttribute" in obj) {
 						editorId = obj.getAttribute("data-wc-editor");
 					} else {
 						editorId = obj.editorId;
 					}
 					if (editorId) {
-						result = registeredIds[editorId];
+						instanceConfig = registeredIds[editorId];
 					}
 				}
-			}
-			if (!result || !result.__wcmixed) {
-				defaultConfig = mixin(this.defaults);  // make a copy of defaults;
-				result = mixin(result, defaultConfig);  // override defaults with explicit settings
-				result.__wcmixed = true;  // flag that we have mixed in the defaults so it doesn't need to happen again
+				if (instanceConfig && !instanceConfig.__wcmixed) {
+					result = mixin(instanceConfig, result);  // override defaults with explicit settings
+					result.__wcmixed = true;  // flag that we have mixed in the defaults so it doesn't need to happen again
+				}
 			}
 			return result;
 		};

--- a/wcomponents-theme/src/main/js/wc/ui/multiFileUploader.js
+++ b/wcomponents-theme/src/main/js/wc/ui/multiFileUploader.js
@@ -301,7 +301,9 @@ define(["wc/dom/attribute",
 			 */
 			function checkMaxFiles(element, newFileCount) {
 				var message,
-					config = wcconfig.get("wc/ui/multiFileUploader"),
+					config = wcconfig.get("wc/ui/multiFileUploader", {
+						overwrite: false
+					}),
 					currentFiles,
 					container,
 					result = {
@@ -332,7 +334,7 @@ define(["wc/dom/attribute",
 							result.before = currentFiles.length;
 							result.after = result.before + newFileCount;
 							if (result.after > result.max) {
-								if (config && config.overwrite && newFileCount <= result.max) {
+								if (config.overwrite && newFileCount <= result.max) {
 									message = i18n.get("file_confirmoverwrite", newFileCount, result.max, result.before);
 									if (message) {
 										if (prompt.confirm(message)) {

--- a/wcomponents-theme/src/main/js/wc/ui/onloadFocusControl.js
+++ b/wcomponents-theme/src/main/js/wc/ui/onloadFocusControl.js
@@ -8,9 +8,10 @@ define(["wc/dom/focus", "wc/dom/initialise", "wc/ui/ajax/processResponse", "wc/t
 		 */
 		function OnloadFocusControl() {
 			var focusId,
-				conf = wcconfig.get("wc/ui/onloadFocusControl"),
-				SCROLL_TO_TOP = (conf ? conf.rescroll : false),  // true to turn on scroll to top of viewport on load focus, false will apply user agent default (usually scroll to just in view)
-				FOCUS_DELAY = null; // if set to a non-negstive integer this will delay focus requests to allow native autofocus to work. Native autofocus is currently problematic since it does not fire a focus event.
+				conf = wcconfig.get("wc/ui/onloadFocusControl", {
+					rescroll: false,  // true to turn on scroll to top of viewport on load focus, false will apply user agent default (usually scroll to just in view),
+					focusDelay: null  // if set to a non-negstive integer this will delay focus requests to allow native autofocus to work. Native autofocus is currently problematic since it does not fire a focus event.
+				});
 
 			/**
 			 * Set focus request on page load.
@@ -38,7 +39,7 @@ define(["wc/dom/focus", "wc/dom/initialise", "wc/ui/ajax/processResponse", "wc/t
 			 * @param {Element} focusElement The element being focused.
 			 */
 			function focusCallback(focusElement) {
-				if (SCROLL_TO_TOP) {
+				if (conf.rescroll) {
 					focusElement.scrollIntoView();
 				}
 			}
@@ -102,7 +103,7 @@ define(["wc/dom/focus", "wc/dom/initialise", "wc/ui/ajax/processResponse", "wc/t
 				if (focusId) {
 					instance.requestFocus(focusId, null, true);
 				} else if (triggerId) {
-					instance.requestFocus(triggerId, FOCUS_DELAY, null, true);
+					instance.requestFocus(triggerId, conf.focusDelay, null, true);
 				}
 			}
 
@@ -134,7 +135,7 @@ define(["wc/dom/focus", "wc/dom/initialise", "wc/ui/ajax/processResponse", "wc/t
 			 * @param {Boolean} val True for scroll to top, otherwise false.
 			 */
 			this.setScrollToTop = function(val) {
-				SCROLL_TO_TOP = val;
+				conf.rescroll = val;
 			};
 
 			/**

--- a/wcomponents-theme/src/main/js/wc/ui/resizeable.js
+++ b/wcomponents-theme/src/main/js/wc/ui/resizeable.js
@@ -67,10 +67,13 @@ define(["wc/dom/attribute",
 			}
 
 			function getNotifyTimeout() {
-				var conf = wcconfig.get("wc/ui/resizeable"),
-					result = DEFAULT_NOTIFY_TIMEOUT;
-				if (conf && (conf.delay || conf.delay === 0) && !isNaN(conf.delay) && conf.delay >= 0) {
+				var result, conf = wcconfig.get("wc/ui/resizeable", {
+						delay: DEFAULT_NOTIFY_TIMEOUT
+					});
+				if ((conf.delay || conf.delay === 0) && !isNaN(conf.delay) && conf.delay >= 0) {
 					result = conf.delay;
+				} else {
+					result = DEFAULT_NOTIFY_TIMEOUT;
 				}
 				return result;
 			}
@@ -231,13 +234,16 @@ define(["wc/dom/attribute",
 			 * `end-of-event` handler like mouseup or touchend.
 			 */
 			function resize(element, deltaX, deltaY, notify) {
-				var box, min, _notify, width, height, conf,
-					minSize = DEFAULT_MIN_SIZE;
+				var box, min, _notify, width, height, conf, minSize;
 				try {
 					if (element && (box = getSize(element))) {
-						conf = wcconfig.get("wc/ui/resizeable");
-						if (conf && conf.min && !isNaN(conf.min) && conf.min > 0) {
+						conf = wcconfig.get("wc/ui/resizeable", {
+							min: DEFAULT_MIN_SIZE
+						});
+						if (conf.min && !isNaN(conf.min) && conf.min > 0) {
 							minSize = conf.min;
+						} else {
+							minSize = DEFAULT_MIN_SIZE;
 						}
 						if (deltaX) {
 							min = getSizeContraint(element);
@@ -338,8 +344,10 @@ define(["wc/dom/attribute",
 				}
 
 				allowed =  getAllowedDirections(resizeTarget);
-				conf = wcconfig.get("wc/ui/resizeable");
-				if (conf && conf.step && !isNaN(conf.step) && conf.step > 0) {
+				conf = wcconfig.get("wc/ui/resizeable", {
+					step: DEFAULT_KEY_RESIZE
+				});
+				if (conf.step && !isNaN(conf.step) && conf.step > 0) {
 					step = conf.step;
 				}
 				switch (keyCode) {

--- a/wcomponents-theme/src/main/js/wc/ui/rtf.js
+++ b/wcomponents-theme/src/main/js/wc/ui/rtf.js
@@ -12,8 +12,8 @@
  * @requires module:wc/mixin
  * @requires external:tinyMCE
  */
-define(["wc/dom/initialise", "wc/config", "wc/loader/style", "wc/mixin", "tinyMCE"],
-	function(initialise, wcconfig, styleLoader, mixin, tinyMCE) {
+define(["wc/dom/initialise", "wc/config", "wc/loader/style", "tinyMCE"],
+	function(initialise, wcconfig, styleLoader, tinyMCE) {
 		"use strict";
 
 		/**
@@ -25,26 +25,21 @@ define(["wc/dom/initialise", "wc/config", "wc/loader/style", "wc/mixin", "tinyMC
 		 */
 		function processNow(idArr) {
 			var id,
-				initObj = {
-					content_css: styleLoader.getMainCss(true),
-					plugins: "autolink link lists print preview paste"
-				},
-				config = wcconfig.get("wc/ui/rtf"),
-				setupFunc = function (editor) {
-					editor.on("change", function () {
-						editor.save();
-					});
-				};
-			if (config && config.initObj) {
-				mixin(config.initObj, initObj);  // config values overwrite defaults coded here.
-			}
+				config = wcconfig.get("wc/ui/rtf", {
+					initObj: {
+						content_css: styleLoader.getMainCss(true),
+						plugins: "autolink link lists print preview paste"
+					},
+					setup: function (editor) {
+						editor.on("change", function () {
+							editor.save();
+						});
+					}
+				});
 
 			while ((id = idArr.shift())) {
-				initObj["selector"] = "textarea#" + id + "_input";
-				if (!initObj["setup"]) {
-					initObj["setup"] = setupFunc;
-				}
-				tinyMCE.init(initObj);
+				config.initObj["selector"] = "textarea#" + id + "_input";
+				tinyMCE.init(config.initObj);
 			}
 		}
 

--- a/wcomponents-theme/src/main/js/wc/ui/selectboxSearch.js
+++ b/wcomponents-theme/src/main/js/wc/ui/selectboxSearch.js
@@ -373,10 +373,7 @@ define(["wc/string/escapeRe",
 					return;
 				}
 				try {
-					var configOveride = wcconfig.get("wc/ui/selectboxSearch");
-					if (configOveride) {
-						mixin(configOveride, config);
-					}
+					config = wcconfig.get("wc/ui/selectboxSearch", config);
 				} finally {
 					config.inited = true;
 				}

--- a/wcomponents-theme/src/main/js/wc/ui/timeoutWarn.js
+++ b/wcomponents-theme/src/main/js/wc/ui/timeoutWarn.js
@@ -10,8 +10,9 @@ define(["lib/sprintf", "wc/dom/event", "wc/dom/Widget", "wc/i18n/i18n", "wc/load
 		function TimeoutWarner() {
 			var expiresAt,
 				WARN_AT = 20000,  // warn user when this many milliseconds remaining, this default is the WCAG 2.0 minimum of 20 seconds
-				conf = wcconfig.get("wc/ui/timeoutWarn"),
-				MIN_TIMEOUT = (conf ? (conf.min || 30) : 30),
+				conf = wcconfig.get("wc/ui/timeoutWarn", {
+					min: 30
+				}),
 				timerWarn,
 				timerExpired,
 				CONTAINER_ID = "wc_session_container",
@@ -168,7 +169,7 @@ define(["lib/sprintf", "wc/dom/event", "wc/dom/Widget", "wc/i18n/i18n", "wc/load
 				var millis,
 					warning = (warnAt) ? Math.max((warnAt * 1000), WARN_AT) : WARN_AT;  // never let the timeout be less than the default
 
-				if (seconds >= MIN_TIMEOUT) {
+				if (seconds >= conf.min) {
 					millis = seconds * 1000;
 
 					if (timerWarn) {

--- a/wcomponents-theme/src/main/js/wc/ui/validation/textField.js
+++ b/wcomponents-theme/src/main/js/wc/ui/validation/textField.js
@@ -88,8 +88,10 @@ define(["wc/dom/initialise",
 					// pattern (first email)
 					if (EMAIL.isOneOfMe(element)) {
 						if (RX_STRING === "") {
-							conf = wcconfig.get("wc/ui/validation/textField");
-							RX_STRING = conf && conf.rx ? conf.rx : null;
+							conf = wcconfig.get("wc/ui/validation/textField", {
+								rx: null
+							});
+							RX_STRING = conf.rx;
 						}
 
 						regexp = RX_STRING ? new RegExp(RX_STRING) : DEFAULT_RX;

--- a/wcomponents-theme/src/main/js/wc/ui/viewportUtils.js
+++ b/wcomponents-theme/src/main/js/wc/ui/viewportUtils.js
@@ -10,15 +10,16 @@ define(["wc/dom/getViewportSize", "wc/config"], function (getViewportSize, wccon
 	function VpUtils() {
 		// For device limits in Sass see _common.scss.
 
-		var phoneLimit = 773, // The size of the largest device considered a phone: currently 773px of a Nexus 6.
-			// What is the upper limit of a small screen? This could be the 768 of a iPad in portrait orientation,
-			// the 1024 of an old-school monitor or an iPad in landscape orientation or something aribrary. The default
-			// 1000 was chosen as we find some things are quite usable on a tablet in landscape but are less usable in
-			// portrait. We prefer to use min/max-width as a media query rather than orientation for a variety of
-			// reasons.
-			smallScreenLimit = 1000,
-			// A large screen is bigger than 1080p.
-			largeScreenLimit = 1981,
+		var defaultConf = {
+				large: 1981,  // A large screen is bigger than 1080p.
+				// What is the upper limit of a small screen? This could be the 768 of a iPad in portrait orientation,
+				// the 1024 of an old-school monitor or an iPad in landscape orientation or something aribrary. The default
+				// 1000 was chosen as we find some things are quite usable on a tablet in landscape but are less usable in
+				// portrait. We prefer to use min/max-width as a media query rather than orientation for a variety of
+				// reasons.
+				small: 1000,
+				phone: 773  // The size of the largest device considered a phone: currently 773px of a Nexus 6.
+			},
 			medDefinition = 1.5,
 			highDefinition = 2,
 			pixelRatio = window.devicePixelRation || 1;
@@ -53,12 +54,8 @@ define(["wc/dom/getViewportSize", "wc/config"], function (getViewportSize, wccon
 		 * @returns {Boolean} true if the viewport width is no bigger than the configured limit for a phone.
 		 */
 		this.isPhoneLike = function() {
-			var conf = wcconfig.get("wc/ui/viewportUtils"),
-				limit = phoneLimit;
-			if (conf && conf.phone && !isNaN(conf.phone)) {
-				limit = conf.phone;
-			}
-			return testViewportSize(limit);
+			var conf = getConfig();
+			return testViewportSize(conf.phone);
 		};
 
 		/**
@@ -70,12 +67,8 @@ define(["wc/dom/getViewportSize", "wc/config"], function (getViewportSize, wccon
 		 * @returns {Boolean} true if the viewport width is no bigger than the configured limit for a small screen.
 		 */
 		this.isSmallScreen = function() {
-			var conf = wcconfig.get("wc/ui/viewportUtils"),
-				limit = smallScreenLimit;
-			if (conf && conf.small && !isNaN(conf.small)) {
-				limit = conf.small;
-			}
-			return testViewportSize(limit);
+			var conf = getConfig();
+			return testViewportSize(conf.small);
 		};
 
 		/**
@@ -87,13 +80,19 @@ define(["wc/dom/getViewportSize", "wc/config"], function (getViewportSize, wccon
 		 * @returns {Boolean} true if the viewport width is at least that of the configured limit for a big screen.
 		 */
 		this.isLargeScreen = function() {
-			var conf = wcconfig.get("wc/ui/viewportUtils"),
-				limit = largeScreenLimit;
-			if (conf && conf.large && !isNaN(conf.large)) {
-				limit = conf.large;
-			}
-			return testViewportSize(limit, true);
+			var conf = getConfig();
+			return testViewportSize(conf.large, true);
 		};
+
+		function getConfig() {
+			var conf = wcconfig.get("wc/ui/viewportUtils", defaultConf);
+			Object.keys(defaultConf).forEach(function(prop) {
+				if (!conf[prop] || isNaN(conf[prop])) {
+					conf[prop] = defaultConf[prop];
+				}
+			});
+			return conf;
+		}
 
 		/**
 		 * Is the current screen a high definition screen?

--- a/wcomponents-theme/src/test/intern/wc.config.test.js
+++ b/wcomponents-theme/src/test/intern/wc.config.test.js
@@ -1,0 +1,65 @@
+define(["intern!object", "intern/chai!assert", "./resources/test.utils!"],
+	function (registerSuite, assert, testutils) {
+		"use strict";
+
+		var wcconfig;
+
+		registerSuite({
+			name: "wc/config",
+			setup: function() {
+				return testutils.setupHelper(["wc/config"], function(obj) {
+					wcconfig = obj;
+				});
+			},
+			testGetUnregistered: function() {
+				var id = "wc/config/testGetUnregistered",
+					actual = wcconfig.get(id);
+				assert.isFalse(!!actual, "Should not return a value when not found in registry");
+			},
+			testGetUnregisteredWithDefaults: function() {
+				var id = "wc/config/testGetUnregisteredWithDefaults",
+					expected = {
+						foo: "foo",
+						bar: { baa: "baa" },
+						fubar: ["f", "u", "b", "a", "r"]
+					},
+					actual = wcconfig.get(id, expected);
+				assert.deepEqual(actual, expected, "Should return a clone of defaults when not found in registry");
+			},
+			testGetRegistered: function() {
+				var id = "wc/config/testGetRegistered", actual,
+					expected = {
+						foo: "foo",
+						bar: { baa: "baa" },
+						fubar: ["f", "u", "b", "a", "r"]
+					};
+				wcconfig.set(expected, id);
+				actual = wcconfig.get(id);
+				assert.deepEqual(actual, expected, "Should return the registered configuration");
+			},
+			testGetRegisteredWithOverrides: function() {
+				var id = "wc/config/testGetRegisteredWithOverrides", actual,
+					defaults = {
+						foo: 0,
+						bar: { baa: "baa" },
+						fubar: ["f", "u", "b", "a", "r"],
+						boo: null
+					},
+					overrides = {
+						test: "icicles",
+						bar: { kung: "fu" },
+						fubar: ["bart"]
+					},
+					expected = {
+						foo: 0,
+						test: "icicles",
+						bar: { baa: "baa", kung: "fu" },
+						fubar: ["bart"],
+						boo: null
+					};
+				wcconfig.set(overrides, id);
+				actual = wcconfig.get(id, defaults);
+				assert.deepEqual(actual, expected, "Should return the registered configuration with overrides applied to defaults");
+			}
+		});
+	});


### PR DESCRIPTION
**Configuration Module Enhancement**
It is extremely common to mix configuration overrides with configuration defaults. Each module currently has to perform this "fetch, test, override" cycle individually. This pull request enhances the configuration module to provide this basic functionality so that it is implemented in one central place. More complicated tests (is the property numeric, greater than 0, etc) still needs to be done on a case by case basis.

**ImageEditor Enhancement**
There has been no "official" way for the imageEditor to be configured and this has lead to problematic hacks. It can now be configured through `wc/config`

**wc/dom/initialise fix**
initialise could possibly reset its observer instance before all subscribers had been called. This is now resolved. (Maybe observer should build a static work list?)
