### PR TITLE
Travis Builds - Precise is deprecated enable Trusty build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ language: Java
 jdk:
   - oraclejdk7
 
-dist: precise
-
 env:
   global:
    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
 
 language: Java
 jdk:
-  - oraclejdk7
+  - openjdk7
 
 env:
   global:


### PR DESCRIPTION
**Background**
"Precise" is a version of Ubuntu which used to be the default on Travis
"Trusty" is the new default version of Ubuntu used by Travis.

When the default changed our builds broke (because of the issues below).
We temporarily opted in to building on Precise using a deprecated flag. This was not a long term solution and I believe we should not wait until the eleventh hour to resolve it, hence this PR.

**Issues**
A few issues prevented building on trusty:
* A [travis bug](https://github.com/travis-ci/travis-ci/issues/8581)
* removal of oracle jdk7 from the available JDKs

**Solutions**
The travis issue has been resolved it would seem.

Regarding Java 7, I see no reason why it **must** be oracle java on travis because:
* We run builds on CircleCI 
* We build locally using oracle java

So I have switched it to OpenJDK 7 (for now anyway).
