### PR TITLE
Use oraclejdk8 on travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
 
 language: Java
 jdk:
-  - openjdk7
+  - oraclejdk8
 
 env:
   global:


### PR DESCRIPTION
So after merging #1408 I realised that it would make more sense to use Travis for Java 8 and Circle for Java 7.

While we could do multiple JDK versions on Travis it would make the build take much longer.
This way we hit two important JDK versions without introducing a longer wait. 