### PR TITLE
Readonly messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Restored WFieldWarningIndicator and WFieldErrorIndicator to WField for backwards compatibility.
+
 ## Release 1.4.15
 
 ### Enhancements

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WField.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WField.java
@@ -24,6 +24,14 @@ public class WField extends AbstractContainer implements AjaxTarget, Subordinate
 	 * The component for the field.
 	 */
 	private final WComponent field;
+	/**
+	 * The warning indicator for the field.
+	 */
+	private final WFieldWarningIndicator warningIndicator;
+	/**
+	 * The error indicator for the field.
+	 */
+	private final WFieldErrorIndicator errorIndicator;
 
 	/**
 	 * Creates a WField with the specified label text and field.
@@ -67,6 +75,17 @@ public class WField extends AbstractContainer implements AjaxTarget, Subordinate
 				((AbstractWComponent) labelField).setLabel(origLabel);
 			}
 		}
+
+		// If there is a label field, and it is not nested in another WField, then set the error indicators
+		if (labelField != null && WebUtilities.getAncestorOfClass(WField.class, labelField) == this) {
+			warningIndicator = new WFieldWarningIndicator(labelField);
+			add(warningIndicator, "warningIndicator");
+			errorIndicator = new WFieldErrorIndicator(labelField);
+			add(errorIndicator, "errorIndicator");
+		} else {
+			warningIndicator = null;
+			errorIndicator = null;
+	}
 	}
 
 	/**
@@ -135,20 +154,16 @@ public class WField extends AbstractContainer implements AjaxTarget, Subordinate
 
 	/**
 	 * @return the field's error indicator
-	 * @deprecated never used, no replacement
 	 */
-	@Deprecated
 	public WFieldErrorIndicator getErrorIndicator() {
-		return null;
+		return errorIndicator;
 	}
 
 	/**
 	 * @return the field's warning indicator
-	 * @deprecated output as part of diagnosable, not used, no replacement
 	 */
-	@Deprecated
 	public WFieldWarningIndicator getWarningIndicator() {
-		return null;
+		return warningIndicator;
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/AbstractWFieldIndicatorRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/AbstractWFieldIndicatorRenderer.java
@@ -1,9 +1,9 @@
 package com.github.bordertech.wcomponents.render.webxml;
 
+import com.github.bordertech.wcomponents.Diagnosable;
 import com.github.bordertech.wcomponents.Input;
 import com.github.bordertech.wcomponents.Renderer;
 import com.github.bordertech.wcomponents.WComponent;
-import com.github.bordertech.wcomponents.WFieldSet;
 import com.github.bordertech.wcomponents.XmlStringBuilder;
 import com.github.bordertech.wcomponents.servlet.WebXmlRenderContext;
 import com.github.bordertech.wcomponents.util.SystemException;
@@ -34,7 +34,7 @@ abstract class AbstractWFieldIndicatorRenderer extends AbstractWebXmlRenderer {
 
 		// no need to render an indicator for nothing.
 		// Diagnosables takes care of thieir own  messaging.
-		if (validationTarget == null || validationTarget instanceof WFieldSet) {
+		if (validationTarget == null || (validationTarget instanceof Diagnosable && !(validationTarget instanceof Input))) {
 			return;
 		}
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WFieldRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WFieldRenderer.java
@@ -45,6 +45,15 @@ final class WFieldRenderer extends AbstractWebXmlRenderer {
 		if (field.getField() != null) {
 			xml.appendTag("ui:input");
 			field.getField().paint(renderContext);
+
+			if (field.getErrorIndicator() != null) {
+				field.getErrorIndicator().paint(renderContext);
+			}
+
+			if (field.getWarningIndicator() != null) {
+				field.getWarningIndicator().paint(renderContext);
+			}
+
 			xml.appendEndTag("ui:input");
 		}
 


### PR DESCRIPTION
The render of WFieldErrorIndicator and WFieldWarningIndicator was removed in error as part of the messaging clean up in 1.4.12. They got cleaned up too far. This restores the previous functionality for WFieldWarningIndicator and fixes the missing WFieldErrorIndicator.

