### PR TITLE
imageedit click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Enhancements
 
+* ImageEdit press buttons now also respond to clicks.
+
 ### Bug Fixes
 
 * Fixed a bug which could result in incorrect determination of selected items using module wc/dom/getFilteredGroup #943.


### PR DESCRIPTION
Currently many of the image editor controls are "press and hold" buttons much like the volume  button on a TV remote.

This is not immediately obvious and users will naturally try to click these buttons instead of holding them pressed. Previously this may result in no action at all because the press interval is not reached.

This change ensures that a click on a press button will also perform the button action.
