### PR TITLE
#1602 - allow client to request debug resources

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/servlet/ServletUtil.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/servlet/ServletUtil.java
@@ -59,6 +59,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -645,6 +646,21 @@ public final class ServletUtil {
 		} else {
 			parameters.putAll(request.getParameterMap());
 		}
+	}
+
+	/**
+	 * Find the value of a cookie on the request, by name.
+	 * @param request The request on which to check for the cookie.
+	 * @param name The name of the cookie we want the value of.
+	 * @return The value of the cookie, if present, otherwise null.
+	 */
+	public static String extractCookie(final HttpServletRequest request, final String name) {
+		for (Cookie cookie : request.getCookies()) {
+			if (cookie.getName().equals(name)) {
+				return cookie.getValue();
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/mock/servlet/MockHttpServletRequest.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/mock/servlet/MockHttpServletRequest.java
@@ -5,6 +5,7 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.security.Principal;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -30,6 +31,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 	private final Map parameters = new HashMap();
 	private final Map attributes = new HashMap();
 	private final Map headers = new HashMap();
+	private final Map<String, Cookie> cookies = new HashMap<>();
 	private int localPort;
 	private int remotePort;
 	private boolean secure;
@@ -75,11 +77,25 @@ public class MockHttpServletRequest implements HttpServletRequest {
 	}
 
 	/**
-	 * @return null, as this is unimplemented.
+	 * Get all the cookies on this request.
+	 * @return An array of all Cookie objects associated with this request.
 	 */
 	@Override
 	public Cookie[] getCookies() {
-		return null;
+		Collection<Cookie> entries = cookies.values();
+		return entries.toArray(new Cookie[0]);
+	}
+
+	/**
+	 * Sets a cookie on this request instance.
+	 * @param name The cookie name.
+	 * @param value The value of the cookie to set.
+	 */
+	public void setCookie(final String name, final String value) {
+		if (name != null) {
+			Cookie cookie = new Cookie(name, value);
+			cookies.put(name, cookie);
+		}
 	}
 
 	/**

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/servlet/ServletUtilTest.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/servlet/ServletUtilTest.java
@@ -1,0 +1,46 @@
+package com.github.bordertech.wcomponents.servlet;
+
+import com.github.bordertech.wcomponents.util.mock.servlet.MockHttpServletRequest;
+import junit.framework.Assert;
+import org.junit.Test;
+
+/**
+ * ServletUtil - unit tests for {@link ServletUtil}.
+ *
+ * @author Rick Brown
+ */
+public class ServletUtilTest {
+
+	@Test
+	public void testExtractCookie() {
+		String cookieName = "mycookiename";
+		String cookieValue = "mycookievalue";
+
+		MockHttpServletRequest httpServletRequest = new MockHttpServletRequest();
+		httpServletRequest.setCookie(cookieName, cookieValue);
+
+		Assert.assertEquals("Got cookie value by name", cookieValue, ServletUtil.extractCookie(httpServletRequest, cookieName));
+	}
+
+	@Test
+	public void testExtractCookieAmongstMany() {
+		String cookieName = "mycookiename";
+		String cookieValue = "mycookievalue";
+
+		MockHttpServletRequest httpServletRequest = new MockHttpServletRequest();
+		for (byte i = 0; i < 10; i++) {
+			httpServletRequest.setCookie(cookieName + i, cookieValue + 1);
+		}
+		httpServletRequest.setCookie(cookieName, cookieValue);
+
+		Assert.assertEquals("Got cookie value by name", cookieValue, ServletUtil.extractCookie(httpServletRequest, cookieName));
+	}
+
+	@Test
+	public void testExtractCookieNoneFound() {
+		String cookieName = "mycookiename";
+
+		MockHttpServletRequest httpServletRequest = new MockHttpServletRequest();
+		Assert.assertNull("Got cookie value by name", ServletUtil.extractCookie(httpServletRequest, cookieName));
+	}
+}

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/servlet/Servlet_Suite.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/servlet/Servlet_Suite.java
@@ -14,6 +14,7 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({
 	ServletRequest_Test.class,
 	ServletResponse_Test.class,
+	ServletUtilTest.class,
 	ServletUtilDeviceType_Test.class,
 	ThemeServlet_Test.class,
 	WServlet_Test.class,


### PR DESCRIPTION
@marksreeves the implementation I settled on here is inspired by:
* your comments above
* the discussion we had
* **the practicalities integrating this into the existing implementation**

I went with a cookie but it could easily be changed, enhanced etc...

I envisage the usage like so:

1. Open dev tools
2. Enable debug mode:

```javascript
// Enable for one day - nice touch on another person's machine in case you forget to clean up
require(["wc/dom/cookie"], function(cookie) {
    cookie.create("wcforcedebug", true, 1);
})
```

```javascript
// Enable indefinitely - useful on a dev machine
require(["wc/dom/cookie"], function(cookie) {
    cookie.create("wcforcedebug", true);
})
```
3. Disable debug mode
```javascript
// Disable
require(["wc/dom/cookie"], function(cookie) {
    cookie.create("wcforcedebug", false);
})
```