### PR TITLE
Allow travis ci to pass without secure env vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,8 @@ jdk:
 install:
  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -DskipOptionalQA=true -Dwc.pmd.verbose=false
 
-## Activate skipThemeOptionalTests until Intern and Saucelabs integration fixed
 script:
- - mvn package sonar:sonar -Dsonar.projectKey="bordertech-wcomponents" -PskipThemeOptionalTests -PskipCoreOptionalTests
+ - ./travis.sh
 
 ## Send Coverage to Codacy
 after_success:

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+## Activate skipThemeOptionalTests until Intern and Saucelabs integration fixed
+
+if [[ -n ${TRAVIS_SECURE_ENV_VARS+x} && ${TRAVIS_SECURE_ENV_VARS} == true && ! -z ${SONAR_TOKEN} ]]; then
+	echo "Travis secure variables ARE available"
+	mvn --batch-mode package sonar:sonar -Dsonar.projectKey="bordertech-wcomponents" -PskipThemeOptionalTests -PskipCoreOptionalTests
+else
+	echo "Travis secure variables not available"
+	mvn --batch-mode package -PskipThemeOptionalTests -PskipCoreOptionalTests
+fi


### PR DESCRIPTION
Related to [this](https://travis-ci.org/SonarSource/sonar-scanner-api/builds/563844342#L456):

>Encrypted environment variables have been removed for security reasons.
See https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions

Fixes #1651
