### PR TITLE
No big deal, just moving SHED from observer to custom events

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/ajaxRegion.js
+++ b/wcomponents-theme/src/main/js/wc/ui/ajaxRegion.js
@@ -85,8 +85,9 @@ define(["wc/dom/event",
 				return result;
 			}
 
-			function shedSubscriber(element) {
-				var type = element.type;
+			function shedSubscriber($event) {
+				var element = $event.target,
+					type = element.type;
 
 				if (element && element.tagName === tag.INPUT && (type === "radio" || type === "checkbox")) {
 					checkActivateTrigger(element);
@@ -228,8 +229,8 @@ define(["wc/dom/event",
 			this.postInit = function() {
 				setControlsAttribute();
 				processResponse.subscribe(setControlsAttribute, true);
-				shed.subscribe(shed.actions.SELECT, shedSubscriber);
-				shed.subscribe(shed.actions.DESELECT, shedSubscriber);
+				event.add(document.body, shed.events.SELECT, shedSubscriber);
+				event.add(document.body, shed.events.DESELECT, shedSubscriber);
 			};
 
 			/**

--- a/wcomponents-theme/src/main/js/wc/ui/comboBox.js
+++ b/wcomponents-theme/src/main/js/wc/ui/comboBox.js
@@ -283,15 +283,16 @@ define(["wc/has",
 			}
 
 			/**
-			 * Subscriber to SHED pseudo-event publisher.
+			 * Event listener for shed custom events.
 			 *
 			 * @function
 			 * @private
-			 * @param {Element} element the element SHED has acted upon.
-			 * @param {String} action the SHED action.
+			 * @param {Event} $event The shed event that fired.
 			 */
-			function shedSubscriber(element, action) {
-				var textbox, opener;
+			function shedSubscriber($event) {
+				var textbox, opener,
+					element = $event.target,
+					action = $event.type;
 
 				if (!(element && COMBO.isOneOfMe(element))) {
 					return;
@@ -299,7 +300,7 @@ define(["wc/has",
 
 				textbox = TEXTBOX.findDescendant(element);
 
-				if (action === shed.actions.EXPAND) {
+				if (action === shed.events.EXPAND) {
 					if (shed.isExpanded(element)) {
 						onchangeSubmit.ignoreNextChange();
 						ajaxRegion.ignoreNextChange();
@@ -312,7 +313,7 @@ define(["wc/has",
 					return;
 				}
 
-				if (action === shed.actions.COLLAPSE) {
+				if (action === shed.events.COLLAPSE) {
 					if (!shed.isExpanded(element)) {
 						onchangeSubmit.clearIgnoreChange();
 						ajaxRegion.clearIgnoreChange();
@@ -329,7 +330,7 @@ define(["wc/has",
 					return;
 				}
 
-				if (action === shed.actions.DISABLE) {
+				if (action === shed.events.DISABLE) {
 					shed.disable(textbox, true);
 					if ((opener = OPENER_BUTTON.findDescendant(element))) {
 						shed.disable(opener, true);
@@ -338,7 +339,7 @@ define(["wc/has",
 					return;
 				}
 
-				if (action === shed.actions.ENABLE) {
+				if (action === shed.events.ENABLE) {
 					shed.enable(textbox, true);
 					if ((opener = OPENER_BUTTON.findDescendant(element))) {
 						shed.enable(opener, true);
@@ -346,7 +347,7 @@ define(["wc/has",
 					return;
 				}
 
-				if (action === shed.actions.HIDE && shed.isExpanded(element)) {
+				if (action === shed.events.HIDE && shed.isExpanded(element)) {
 					shed.collapse(element, true);
 				}
 			}
@@ -356,10 +357,11 @@ define(["wc/has",
 			 *
 			 * @function
 			 * @private
-			 * @param {Element} element The element being selected.
+			 * @param {Event} $event Fired when an element is selected.
 			 */
-			function shedSelectSubscriber(element) {
-				var listbox, combo;
+			function shedSelectSubscriber($event) {
+				var listbox, combo,
+					element = $event.target;
 				if (element && OPTION.isOneOfMe(element) && (listbox = getListBox(element)) && (combo = getCombo(listbox))) {
 					setValue(combo, element);
 				}
@@ -855,12 +857,12 @@ define(["wc/has",
 			 * @public
 			 */
 			this.postInit = function() {
-				shed.subscribe(shed.actions.EXPAND, shedSubscriber);
-				shed.subscribe(shed.actions.COLLAPSE, shedSubscriber);
-				shed.subscribe(shed.actions.HIDE, shedSubscriber);
-				shed.subscribe(shed.actions.DISABLE, shedSubscriber);
-				shed.subscribe(shed.actions.ENABLE, shedSubscriber);
-				shed.subscribe(shed.actions.SELECT, shedSelectSubscriber);
+				event.add(document.body, shed.events.EXPAND, shedSubscriber);
+				event.add(document.body, shed.events.COLLAPSE, shedSubscriber);
+				event.add(document.body, shed.events.HIDE, shedSubscriber);
+				event.add(document.body, shed.events.DISABLE, shedSubscriber);
+				event.add(document.body, shed.events.ENABLE, shedSubscriber);
+				event.add(document.body, shed.events.SELECT, shedSelectSubscriber);
 				processResponse.subscribe(postAjaxSubscriber, true);
 			};
 

--- a/wcomponents-theme/src/test/intern/wc.dom.event.test.js
+++ b/wcomponents-theme/src/test/intern/wc.dom.event.test.js
@@ -124,6 +124,42 @@ define(["intern!object", "intern/chai!assert", "intern/resources/test.utils!"],
 				}
 			},
 
+			testFireCustomEvent: function() {
+				var handle,
+					kungActual,
+					dataExpected = { kung: "fu" },
+					element = document.getElementById(ids.TXTAREA);
+				try {
+					handle = event.add(element, "kungfu", function($event) {
+						kungActual = $event.detail.kung;
+					});
+					event.fire(element, "kungfu", { detail: dataExpected });
+					assert.strictEqual(kungActual, dataExpected.kung);
+				} finally {
+					event.remove(handle);
+				}
+			},
+
+			testRemoveCustomEvent: function() {
+				var handle,
+					kungActual,
+					dataExpected = { kung: "fu" },
+					element = document.getElementById(ids.TXTAREA);
+				try {
+					handle = event.add(element, "kungfu", function($event) {
+						kungActual = $event.detail.kung;
+					});
+					event.fire(element, "kungfu", { detail: dataExpected });
+					assert.strictEqual(kungActual, dataExpected.kung);
+					kungActual = null;
+					event.remove(handle);
+					event.fire(element, "kungfu", { detail: dataExpected });
+					assert.isNull(kungActual);
+				} finally {
+					event.remove(handle);
+				}
+			},
+
 			testAddFireEventButtonInput: function() {
 				var element = document.getElementById(ids.BUTTONINP);
 				try {


### PR DESCRIPTION
SHED was always meant to be custom events but they were not available
on older browsers.

This change is backwards compatible with the old API and for now is
hidden behind it. I ported some code to the new API to prove it.