### PR TITLE
Update event manager to allow recursive firing

### DIFF
--- a/wcomponents-theme/src/test/intern/wc.dom.event.test.js
+++ b/wcomponents-theme/src/test/intern/wc.dom.event.test.js
@@ -124,6 +124,45 @@ define(["intern!object", "intern/chai!assert", "intern/resources/test.utils!"],
 				}
 			},
 
+			/**
+			 * This tests that events fire synchronously even if another event is firing.
+			 */
+			testAddFireEventFromAnotherEvent: function() {
+				var handles = [],
+					element = document.getElementById(ids.TXTAREA);
+				try {
+					handles.push(event.add(element, "kungfu", function($event) {
+						handles.push(event.add(element, EVENT, clickEvent));
+						event.fire($event.target, EVENT);
+					}));
+					assert.isFalse(called, "tear down is not cleaning up called as expected");
+					event.fire(element, "kungfu", { detail: "foo" });
+					assert.isTrue(called);
+				} finally {
+					event.remove(handles);
+				}
+			},
+
+			/**
+			 * This tests that events fire synchronously even if THE SAME event is firing.
+			 * This would fail on all versions of event manager before Sep 2019.
+			 */
+			testAddFireEventFromSameEvent: function() {
+				var handles = [],
+					element = document.getElementById(ids.TXTAREA);
+				try {
+					handles.push(event.add(element, "kungfu", function($event) {
+						handles.push(event.add(element, "kungfu", clickEvent));
+						event.fire($event.target, "kungfu");
+					}));
+					assert.isFalse(called, "tear down is not cleaning up called as expected");
+					event.fire(element, "kungfu", { detail: "foo" });
+					assert.isTrue(called);
+				} finally {
+					event.remove(handles);
+				}
+			},
+
 			testFireCustomEvent: function() {
 				var handle,
 					kungActual,


### PR DESCRIPTION
The event manager used to only allow one event of any kind to fire
at a time, e.g. "click" would not fire while "change" was processing.
Then we relaxed it so that click, for example, would only prevent other clicks from
firing. Subsequent calls would be queued until the next event loop.
This was to prevent infinite event recursion but it comes at a cost.
I think we could completely do away with this protection but there is
a chance that bad code exists since we have been guarding it forever.
This change allows some recursion and I'm pretty sure it will allow
100% of legitimate cases to process synchronously whilst only pushing
potentially buggy code to the next event loop.