### PR TITLE
Fix ServletUtil.extractCookie NPE with no cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ If you explicitly depend on core and theme separately then you must now also add
 ### Enhancements
 ### Bug Fixes
 
+* Fix ServletUtil.extractCookie throws exception when no cookies on the request (which normally never happens) #1683
+
 ## Release 1.5.17
 
 ### API Changes

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/servlet/ServletUtil.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/servlet/ServletUtil.java
@@ -655,9 +655,12 @@ public final class ServletUtil {
 	 * @return The value of the cookie, if present, otherwise null.
 	 */
 	public static String extractCookie(final HttpServletRequest request, final String name) {
-		for (Cookie cookie : request.getCookies()) {
-			if (cookie.getName().equals(name)) {
-				return cookie.getValue();
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals(name)) {
+					return cookie.getValue();
+				}
 			}
 		}
 		return null;

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/mock/servlet/MockHttpServletRequest.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/mock/servlet/MockHttpServletRequest.java
@@ -83,6 +83,10 @@ public class MockHttpServletRequest implements HttpServletRequest {
 	@Override
 	public Cookie[] getCookies() {
 		Collection<Cookie> entries = cookies.values();
+		if (entries.size() < 1) {
+			// see https://javaee.github.io/javaee-spec/javadocs/javax/servlet/http/HttpServletRequest.html#getCookies--
+			return null;  // NOTE: initially incorrectly implemented, must return null when no cookies set.
+		}
 		return entries.toArray(new Cookie[0]);
 	}
 


### PR DESCRIPTION
HttpServletRequest.getCookies returns null when no cookies are set but
ServletUtil.extractCookie did not perform a null check and therefore
threw a NPE. While this was tested the tests assumed that the mock http
request MockHttpServletRequest was spec compliant. It was not since it
returned an empty collection instead of null. Fixes #1682