### PR TITLE
Replace anonymous inner classes with lambdas

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractInput.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractInput.java
@@ -303,17 +303,13 @@ public abstract class AbstractInput extends WBeanComponent implements Input {
 		if (getActionOnChange() != null) {
 			final ActionEvent event = new ActionEvent(this, getActionCommand(), getActionObject());
 			final boolean isCAT = isCurrentAjaxTrigger();
-			Runnable later = new Runnable() {
-				@Override
-				public void run() {
-					getActionOnChange().execute(event);
-					if (isCAT && UIContextHolder.getCurrent().getFocussed() == null) {
-						setFocussed();
-					}
-				}
-			};
 
-			invokeLater(later);
+			invokeLater(() -> {
+				getActionOnChange().execute(event);
+				if (isCAT && UIContextHolder.getCurrent().getFocussed() == null) {
+					setFocussed();
+				}
+			});
 		} else if (AjaxHelper.isCurrentAjaxTrigger(this) && UIContextHolder.getCurrent().getFocussed() == null) {
 			setFocussed();
 		}

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWComponent.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/AbstractWComponent.java
@@ -488,12 +488,9 @@ public abstract class AbstractWComponent implements WComponent {
 	 */
 	@Override
 	public void forward(final String url) {
-		invokeLater(new Runnable() {
-			@Override
-			public void run() {
-				throw new ForwardException(url);
-			}
-		});
+		invokeLater(() -> {
+            throw new ForwardException(url);
+        });
 	}
 
 	// ================================

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WButton.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WButton.java
@@ -210,28 +210,17 @@ public class WButton extends WBeanComponent implements Container, Disableable, A
 				// Reset focus only if the current Request is an Ajax request.
 				if (AjaxHelper.isCurrentAjaxTrigger(this)) {
 					// Need to run the "afterActionExecute" as late as possible.
-					Runnable later = new Runnable() {
-						@Override
-						public void run() {
-							focusMe();
-						}
-					};
-					invokeLater(later);
+					invokeLater(() -> focusMe());
 				}
 			} else {
 				final ActionEvent event = new ActionEvent(this, getActionCommand(),
 						getActionObject());
 
-				Runnable later = new Runnable() {
-					@Override
-					public void run() {
-						beforeActionExecute(request);
-						action.execute(event);
-						afterActionExecute(request);
-					}
-				};
-
-				invokeLater(later);
+				invokeLater(() -> {
+					beforeActionExecute(request);
+					action.execute(event);
+					afterActionExecute(request);                    
+                });
 			}
 		}
 	}

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WDialog.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WDialog.java
@@ -339,13 +339,7 @@ public class WDialog extends AbstractWComponent implements Container {
 		final Action action = getTriggerOpenAction();
 		if (action != null) {
 			final ActionEvent event = new ActionEvent(this, OPEN_DIALOG_ACTION);
-			Runnable later = new Runnable() {
-				@Override
-				public void run() {
-					action.execute(event);
-				}
-			};
-			invokeLater(later);
+			invokeLater(() -> action.execute(event));
 		}
 	}
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WLink.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WLink.java
@@ -392,15 +392,7 @@ public class WLink extends WBeanComponent implements Container, Disableable, Aja
 
 		if (pressed && action != null) {
 			final ActionEvent event = new ActionEvent(this, getActionCommand(), getActionObject());
-
-			Runnable later = new Runnable() {
-				@Override
-				public void run() {
-					action.execute(event);
-				}
-			};
-
-			invokeLater(later);
+			invokeLater(() -> action.execute(event));
 		}
 	}
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WMenuItem.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WMenuItem.java
@@ -448,15 +448,7 @@ public class WMenuItem extends AbstractContainer implements Disableable, AjaxTri
 				if (action != null) {
 					final ActionEvent event = new ActionEvent(this, this.getActionCommand(), this.
 							getActionObject());
-
-					Runnable later = new Runnable() {
-						@Override
-						public void run() {
-							action.execute(event);
-						}
-					};
-
-					invokeLater(later);
+					invokeLater(() -> action.execute(event));
 				}
 			}
 		}

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WMultiFileWidget.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WMultiFileWidget.java
@@ -673,14 +673,7 @@ public class WMultiFileWidget extends AbstractInput implements Targetable, AjaxI
 
 		// Set the selected file id as the action object
 		final ActionEvent event = new ActionEvent(this, "fileajax", fileId);
-		Runnable later = new Runnable() {
-			@Override
-			public void run() {
-				action.execute(event);
-			}
-		};
-
-		invokeLater(later);
+		invokeLater(() -> action.execute(event));
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WSelectToggle.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WSelectToggle.java
@@ -104,12 +104,7 @@ public class WSelectToggle extends AbstractWComponent implements Disableable, Aj
 				// We need to change the selections *after* all components
 				// Have updated themselves from the request, as they may change
 				// their values when their handleRequest methods are called.
-				invokeLater(new Runnable() {
-					@Override
-					public void run() {
-						setSelections(model.target, State.ALL.equals(newValue));
-					}
-				});
+				invokeLater(() -> setSelections(model.target, State.ALL.equals(newValue)));
 			}
 		}
 	}

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WSubMenu.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WSubMenu.java
@@ -535,15 +535,7 @@ public class WSubMenu extends AbstractNamingContextContainer implements Disablea
 				if (action != null) {
 					final ActionEvent event = new ActionEvent(this, this.getActionCommand(),
 							this.getActionObject());
-
-					Runnable later = new Runnable() {
-						@Override
-						public void run() {
-							action.execute(event);
-						}
-					};
-
-					invokeLater(later);
+					invokeLater(() -> action.execute(event));
 				}
 			}
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WSuggestions.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WSuggestions.java
@@ -108,14 +108,7 @@ public class WSuggestions extends AbstractWComponent implements AjaxInternalTrig
 		}
 
 		final ActionEvent event = new ActionEvent(this, AJAX_REFRESH_ACTION_COMMAND, getAjaxFilter());
-		Runnable later = new Runnable() {
-			@Override
-			public void run() {
-				action.execute(event);
-			}
-		};
-
-		invokeLater(later);
+		invokeLater(() -> action.execute(event));
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTabSet.java
@@ -669,15 +669,7 @@ public class WTabSet extends AbstractNamingContextContainer implements Disableab
 
 			if (action != null && !changes.isEmpty()) {
 				final ActionEvent event = new ActionEvent(this, changes.toString(), null);
-
-				Runnable later = new Runnable() {
-					@Override
-					public void run() {
-						action.execute(event);
-					}
-				};
-
-				invokeLater(later);
+				invokeLater(() -> action.execute(event));
 			}
 		}
 

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTree.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTree.java
@@ -933,13 +933,7 @@ public class WTree extends AbstractInput
 		final Action action = getOpenAction();
 		if (action != null) {
 			final ActionEvent event = new ActionEvent(this, "openItem");
-			Runnable later = new Runnable() {
-				@Override
-				public void run() {
-					action.execute(event);
-				}
-			};
-			invokeLater(later);
+			invokeLater(() -> action.execute(event));
 		}
 
 	}

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/layout/UIManager.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/layout/UIManager.java
@@ -62,15 +62,7 @@ public final class UIManager implements PropertyChangeListener {
 	/**
 	 * Marker Layout instance for when no layout was found.
 	 */
-	private static final Renderer NULL_RENDERER = new Renderer() {
-		/**
-		 * {@inheritDoc}
-		 */
-		@Override
-		public void render(final WComponent component, final RenderContext renderContext) {
-			// NO-OP
-		}
-	};
+	private static final Renderer NULL_RENDERER = (component, renderContext) -> { /* NO-OP */ };
 
 	/**
 	 * A cache of component Renderers keyed by WComponent classes. This cache must be flushed if the

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/monitor/UicStatsAsHtml.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/monitor/UicStatsAsHtml.java
@@ -67,26 +67,9 @@ public final class UicStatsAsHtml {
 		// Copy all the stats into a list so we can sort and cull.
 		List<UicStats.Stat> statList = new ArrayList<>(treeStats.values());
 
-		Comparator<UicStats.Stat> comparator = new Comparator<UicStats.Stat>() {
-			@Override
-			public int compare(final UicStats.Stat stat1, final UicStats.Stat stat2) {
-				if (stat1.getModelState() > stat2.getModelState()) {
-					return -1;
-				} else if (stat1.getModelState() < stat2.getModelState()) {
-					return 1;
-				} else {
-					int diff = stat1.getClassName().compareTo(stat2.getClassName());
-
-					if (diff == 0) {
-						diff = stat1.getName().compareTo(stat2.getName());
-					}
-
-					return diff;
-				}
-			}
-		};
-
-		Collections.sort(statList, comparator);
+		Collections.sort(statList,
+            Comparator.comparing(UicStats.Stat::getModelState)
+                .thenComparing(UicStats.Stat::getClassName));
 
 		for (int i = 0; i < statList.size(); i++) {
 			UicStats.Stat stat = statList.get(i);

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/DebugUtil.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/util/DebugUtil.java
@@ -1,8 +1,5 @@
 package com.github.bordertech.wcomponents.util;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
-
 /**
  * Utility class used by WComponents for accessing {@link Config configuration} parameters used in debug features.
  *
@@ -24,16 +21,8 @@ public final class DebugUtil {
 	 * When this class is loaded by the application, register a property change listener.
 	 */
 	static {
-		PropertyChangeListener paramChange = new PropertyChangeListener() {
-			@Override
-			public void propertyChange(final PropertyChangeEvent evt) {
-				retrieveDebugParameters();
-			}
-		};
-
 		// register the change listener with the configuration.
-		Config.addPropertyChangeListener(paramChange);
-
+		Config.addPropertyChangeListener(evt -> retrieveDebugParameters());
 		// set current values
 		retrieveDebugParameters();
 	}


### PR DESCRIPTION
Replaced most usages of inner classes with lambdas. This addresses the
sonar issue "Anonymous inner classes containing only one method should
become lambdas". Lambdas are usually much more concise and easier to
read.