### PR TITLE
Unify Alignment enums into a common CellAlignment

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WColumn.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WColumn.java
@@ -1,30 +1,78 @@
 package com.github.bordertech.wcomponents;
 
+import com.github.bordertech.wcomponents.layout.CellAlignment;
+
 /**
  * This is a layout component to be used in conjunction with WRow.
  *
  * @author Ming Gao
  * @author Mark Reeves
+ * @author John McGuinness
  * @since 1.0.0
  */
 public class WColumn extends AbstractMutableContainer implements AjaxTarget {
 
 	/**
 	 * Describes how content within a column should be aligned.
+	 *
+	 * @deprecated Use {@link CellAlignment} instead.
 	 */
 	public enum Alignment {
 		/**
 		 * Indicates that content should be left-aligned. This is the default alignment.
 		 */
-		LEFT,
+		LEFT(CellAlignment.LEFT),
 		/**
 		 * Indicates that content should be horizontally centered in the column.
 		 */
-		CENTER,
+		CENTER(CellAlignment.CENTER),
 		/**
 		 * Indicates that content should be right-aligned.
 		 */
-		RIGHT
+		RIGHT(CellAlignment.RIGHT);
+
+		/**
+		 * Alignment constructor.
+		 *
+		 * @param cellAlignment the {@link CellAlignment} corresponding to this {@link Alignment}.
+		 */
+		Alignment(final CellAlignment cellAlignment) {
+			this.cellAlignment = cellAlignment;
+		}
+
+		/**
+		 * The {@link CellAlignment} that corresponds to this {@link Alignment}.
+		 */
+		private final CellAlignment cellAlignment;
+
+		/**
+		 * Converts a {@link CellAlignment} to an {@link Alignment}.
+		 *
+		 * @param cellAlignment the {@link CellAlignment} to convert from.
+		 * @return alignment the converted {@link Alignment} value.
+		 */
+		private static Alignment fromCellAlignment(final CellAlignment cellAlignment) {
+
+			if (cellAlignment == null) {
+				return null;
+			}
+
+			switch (cellAlignment) {
+				case LEFT: return Alignment.LEFT;
+				case CENTER: return Alignment.CENTER;
+				case RIGHT: return Alignment.RIGHT;
+				default: return null;
+			}
+		}
+
+		/**
+		 * Converts this {@link Alignment} to a {@link CellAlignment}.
+		 * @return the converted {@link CellAlignment} value.
+		 */
+		private CellAlignment toCellAlignment() {
+			return this.cellAlignment;
+		}
+
 	}
 
 	/**
@@ -65,15 +113,33 @@ public class WColumn extends AbstractMutableContainer implements AjaxTarget {
 	/**
 	 * @return Returns the alignment.
 	 */
-	public Alignment getAlignment() {
+	public CellAlignment getCellAlignment() {
 		return getComponentModel().alignment;
+	}
+
+	/**
+	 * @return Returns the alignment.
+	 *
+	 * @deprecated Use {@link WColumn#getCellAlignment() } instead.
+	 */
+	public Alignment getAlignment() {
+		return Alignment.fromCellAlignment(getCellAlignment());
 	}
 
 	/**
 	 * @param alignment The alignment to set.
 	 */
+	public void setCellAlignment(final CellAlignment alignment) {
+		getOrCreateComponentModel().alignment = alignment == null ? CellAlignment.LEFT : alignment;
+	}
+
+	/**
+	 * @param alignment The alignment to set.
+	 *
+	 * @deprecated Use {@link WColumn#setCellAlignment(CellAlignment) } instead.
+	 */
 	public void setAlignment(final Alignment alignment) {
-		getOrCreateComponentModel().alignment = alignment == null ? Alignment.LEFT : alignment;
+		setCellAlignment(alignment == null ? null : alignment.toCellAlignment());
 	}
 
 	/**
@@ -89,7 +155,7 @@ public class WColumn extends AbstractMutableContainer implements AjaxTarget {
 		/**
 		 * The alignment of content within the column.
 		 */
-		private Alignment alignment = Alignment.LEFT;
+		private CellAlignment alignment = CellAlignment.LEFT;
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTableColumn.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WTableColumn.java
@@ -1,5 +1,7 @@
 package com.github.bordertech.wcomponents;
 
+import com.github.bordertech.wcomponents.layout.CellAlignment;
+
 /**
  * WTableColumn represents a column in a {@link WDataTable}. It only holds configuration and state information relating
  * to the UI, and does not know about the data model.
@@ -30,21 +32,67 @@ public final class WTableColumn extends AbstractContainer {
 	private final WComponent footerRender;
 
 	/**
-	 * An enumeration of possible values for horizontal alignment of table column content.
+	 * An enumeration of possible values for horizontal alignment of column content.
+	 *
+	 * @deprecated Use {@link com.github.bordertech.wcomponents.layout.CellAlignment}
+	 *             instead of {@link com.github.bordertech.wcomponents.WTableColumn.Alignment}.
 	 */
 	public enum Alignment {
 		/**
 		 * Indicates that content should be left-aligned. This is the default alignment.
 		 */
-		LEFT,
+		LEFT(CellAlignment.LEFT),
 		/**
 		 * Indicates that content should be horizontally centered in the column.
 		 */
-		CENTER,
+		CENTER(CellAlignment.CENTER),
 		/**
 		 * Indicates that content should be right-aligned.
 		 */
-		RIGHT
+		RIGHT(CellAlignment.RIGHT);
+
+		/**
+		 * Alignment constructor.
+		 *
+		 * @param cellAlignment the corresponding {@link CellAlignment}
+		 */
+		Alignment(final CellAlignment cellAlignment) {
+			this.cellAlignment = cellAlignment;
+		}
+
+		/**
+		 * The {@link CellAlignment} that corresponds to this {@link Alignment}.
+		 */
+		private final CellAlignment cellAlignment;
+
+		/**
+		 * Converts a {@link CellAlignment} to an {@link Alignment}.
+		 *
+		 * @param cellAlignment the {@link CellAlignment} to convert from.
+		 * @return alignment the converted {@link Alignment} value.
+		 */
+		private static Alignment fromCellAlignment(final CellAlignment cellAlignment) {
+
+			if (cellAlignment == null) {
+				return null;
+			}
+
+			switch (cellAlignment) {
+				case LEFT: return Alignment.LEFT;
+				case CENTER: return Alignment.CENTER;
+				case RIGHT: return Alignment.RIGHT;
+				default: return null;
+			}
+		}
+
+		/**
+		 * Converts this {@link Alignment} to a {@link CellAlignment}.
+		 * @return the converted {@link CellAlignment} value.
+		 */
+		private CellAlignment toCellAlignment() {
+			return this.cellAlignment;
+		}
+
 	}
 
 	/**
@@ -197,7 +245,7 @@ public final class WTableColumn extends AbstractContainer {
 	 *
 	 * @return the column alignment
 	 */
-	public Alignment getAlign() {
+	public CellAlignment getCellAlignment() {
 		return getComponentModel().align;
 	}
 
@@ -206,8 +254,30 @@ public final class WTableColumn extends AbstractContainer {
 	 *
 	 * @param align the column alignment.
 	 */
-	public void setAlign(final Alignment align) {
+	public void setCellAlignment(final CellAlignment align) {
 		getOrCreateComponentModel().align = align;
+	}
+
+	/**
+	 * Retrieves the column alignment.
+	 *
+	 * @return the column alignment
+	 * 
+	 * @deprecated Use {@link WTableColumn#getCellAlignment() } instead.
+	 */
+	public Alignment getAlign() {
+		return Alignment.fromCellAlignment(getCellAlignment());
+	}
+
+	/**
+	 * Sets the column alignment.
+	 *
+	 * @param align the column alignment.
+	 * 
+	 * @deprecated Use {@link WTableColumn#setCellAlignment(CellAlignment) } instead.
+	 */
+	public void setAlign(final Alignment align) {
+		setCellAlignment(align == null ? null : align.toCellAlignment());
 	}
 
 	/**
@@ -261,6 +331,6 @@ public final class WTableColumn extends AbstractContainer {
 	public static class WTableColumnModel extends ComponentModel {
 
 		private int width;
-		private Alignment align;
+		private CellAlignment align;
 	}
 }

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/layout/CellAlignment.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/layout/CellAlignment.java
@@ -1,0 +1,21 @@
+package com.github.bordertech.wcomponents.layout;
+
+/**
+ * This is used to control the horizontal alignment of components.
+ *
+ * @author John McGuinness
+ */
+public enum CellAlignment {
+	/**
+	 * Components should be left aligned.
+	 */
+	LEFT,
+	/**
+	 * Components should be center aligned.
+	 */
+	CENTER,
+	/**
+	 * Components should be right aligned.
+	 */
+	RIGHT
+};

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/layout/ColumnLayout.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/layout/ColumnLayout.java
@@ -9,26 +9,86 @@ import java.util.Arrays;
  *
  * @author Yiannis Paschalidis
  * @author Mark Reeves
+ * @author John McGuinness
  * @since 1.0.0
  */
 public class ColumnLayout implements LayoutManager {
 
 	/**
 	 * An enumeration of possible values for horizontal alignment of column content.
+	 *
+	 * @deprecated Use {@link com.github.bordertech.wcomponents.layout.CellAlignment}
+	 *             instead of {@link com.github.bordertech.wcomponents.layout.ColumnLayout.Alignment}.
 	 */
 	public enum Alignment {
 		/**
 		 * Indicates that content should be left-aligned. This is the default alignment.
 		 */
-		LEFT,
+		LEFT(CellAlignment.LEFT),
 		/**
 		 * Indicates that content should be horizontally centered in the column.
 		 */
-		CENTER,
+		CENTER(CellAlignment.CENTER),
 		/**
 		 * Indicates that content should be right-aligned.
 		 */
-		RIGHT
+		RIGHT(CellAlignment.RIGHT);
+
+		/**
+		 * Alignment constructor.
+		 *
+		 * @param cellAlignment the corresponding {@link CellAlignment}
+		 */
+		Alignment(final CellAlignment cellAlignment) {
+			this.cellAlignment = cellAlignment;
+		}
+
+		/**
+		 * The {@link CellAlignment} that corresponds to this {@link Alignment}.
+		 */
+		private final CellAlignment cellAlignment;
+
+		/**
+		 * Converts an array of {@link Alignment}s to an array of {@link CellAlignment}s.
+		 * @param alignments the array of {@link Alignment}s to convert.
+		 * @return cellAlignments an array of {@link CellAlignment}s corresponding
+		 *         to the passed in {@link Alignment} values
+		 */
+		private static CellAlignment[] toCellAlignments(final Alignment[] alignments) {
+
+			final CellAlignment[] cellAlignemnts = alignments == null ? null : new CellAlignment[alignments.length];
+
+			if (cellAlignemnts != null) {
+				for (int i = 0; i < alignments.length; i++) {
+					cellAlignemnts[i] = alignments[i].toCellAlignment();
+				}
+			}
+
+			return cellAlignemnts;
+		}
+
+		/**
+		 * Converts a {@link CellAlignment} to an {@link Alignment}.
+		 *
+		 * @param cellAlignment the {@link CellAlignment} to convert from.
+		 * @return alignment the converted {@link Alignment} value.
+		 */
+		private static Alignment fromCellAlignment(final CellAlignment cellAlignment) {
+			switch (cellAlignment) {
+				case LEFT: return Alignment.LEFT;
+				case CENTER: return Alignment.CENTER;
+				case RIGHT: return Alignment.RIGHT;
+				default: return null;
+			}
+		}
+
+		/**
+		 * Converts this {@link Alignment} to a {@link CellAlignment}.
+		 * @return the converted {@link CellAlignment} value.
+		 */
+		private CellAlignment toCellAlignment() {
+			return this.cellAlignment;
+		}
 	}
 
 	/**
@@ -39,7 +99,7 @@ public class ColumnLayout implements LayoutManager {
 	/**
 	 * The column alignments.
 	 */
-	private final Alignment[] columnAlignments;
+	private final CellAlignment[] columnAlignments;
 
 	/**
 	 * The horizontal gap between the columns.
@@ -63,7 +123,7 @@ public class ColumnLayout implements LayoutManager {
 	@Deprecated
 	private final int vgap;
 
-	/**
+/**
 	 * For temporary backwards compatibility only.
 	 * @param columnWidths the column widths
 	 * @param columnAlignments the column alignments
@@ -74,6 +134,21 @@ public class ColumnLayout implements LayoutManager {
 	 */
 	@Deprecated
 	private ColumnLayout(final int[] columnWidths, final Alignment[] columnAlignments, final Size hSpace, final Size vSpace,
+			final int hgap, final int vgap) {
+		this(columnWidths, Alignment.toCellAlignments(columnAlignments), hSpace, vSpace, hgap, vgap);
+	}
+
+	/**
+	 * For temporary backwards compatibility only.
+	 * @param columnWidths the column widths
+	 * @param columnAlignments the column alignments
+	 * @param hSpace the real horizontal space between columns
+	 * @param vSpace the real vertical space between rows
+	 * @param hgap the requested horizontal space between columns
+	 * @param vgap  the requested vertical space between rows
+	 */
+	@Deprecated
+	private ColumnLayout(final int[] columnWidths, final CellAlignment[] columnAlignments, final Size hSpace, final Size vSpace,
 			final int hgap, final int vgap) {
 		if (columnWidths == null || columnWidths.length == 0) {
 			throw new IllegalArgumentException("ColumnWidths must be provided");
@@ -93,13 +168,13 @@ public class ColumnLayout implements LayoutManager {
 		}
 
 		this.columnWidths = columnWidths;
-		this.columnAlignments = new Alignment[columnWidths.length];
+		this.columnAlignments = new CellAlignment[columnWidths.length];
 
 		if (columnAlignments == null) {
-			Arrays.fill(this.columnAlignments, Alignment.LEFT);
+			Arrays.fill(this.columnAlignments, CellAlignment.LEFT);
 		} else {
 			for (int i = 0; i < columnAlignments.length; i++) {
-				this.columnAlignments[i] = columnAlignments[i] == null ? Alignment.LEFT : columnAlignments[i];
+				this.columnAlignments[i] = columnAlignments[i] == null ? CellAlignment.LEFT : columnAlignments[i];
 			}
 		}
 
@@ -116,7 +191,19 @@ public class ColumnLayout implements LayoutManager {
 	 * @param columnWidths the column widths, in percent units, 0 for undefined.
 	 */
 	public ColumnLayout(final int[] columnWidths) {
-		this(columnWidths, null, null, null);
+		this(columnWidths, (Alignment[]) null, null, null);
+	}
+
+	/**
+	 * Creates a ColumnLayout with the specified percentage column widths and column alignments.
+	 *
+	 * @param columnWidths the column widths, in percent units, 0 for undefined
+	 * @param columnAlignments the column alignments
+	 * 
+	 * @deprecated use {@link #ColumnLayout(int[], CellAlignment[])}
+	 */
+	public ColumnLayout(final int[] columnWidths, final Alignment[] columnAlignments) {
+		this(columnWidths, columnAlignments, null, null);
 	}
 
 	/**
@@ -125,7 +212,7 @@ public class ColumnLayout implements LayoutManager {
 	 * @param columnWidths the column widths, in percent units, 0 for undefined
 	 * @param columnAlignments the column alignments
 	 */
-	public ColumnLayout(final int[] columnWidths, final Alignment[] columnAlignments) {
+	public ColumnLayout(final int[] columnWidths, final CellAlignment[] columnAlignments) {
 		this(columnWidths, columnAlignments, null, null);
 	}
 
@@ -139,7 +226,7 @@ public class ColumnLayout implements LayoutManager {
 	 */
 	@Deprecated
 	public ColumnLayout(final int[] columnWidths, final int hgap, final int vgap) {
-		this(columnWidths, null, SpaceUtil.intToSize(hgap), SpaceUtil.intToSize(vgap), hgap, vgap);
+		this(columnWidths, (CellAlignment[]) null, SpaceUtil.intToSize(hgap), SpaceUtil.intToSize(vgap), hgap, vgap);
 	}
 
 	/**
@@ -150,7 +237,7 @@ public class ColumnLayout implements LayoutManager {
 	 * @param vSpace the space between the rows
 	 */
 	public ColumnLayout(final int[] columnWidths, final Size hSpace, final Size vSpace) {
-		this(columnWidths, null, hSpace, vSpace);
+		this(columnWidths, (CellAlignment[]) null, hSpace, vSpace);
 	}
 
 	/**
@@ -160,7 +247,7 @@ public class ColumnLayout implements LayoutManager {
 	 * @param columnAlignments the column alignments
 	 * @param hgap the horizontal gap between the columns
 	 * @param vgap the vertical gap between the rows
-	 * @deprecated use {@link #ColumnLayout(int[], Alignment[], Size, Size)}
+	 * @deprecated use {@link #ColumnLayout(int[], CellAlignment[], Size, Size)}
 	 */
 	@Deprecated
 	public ColumnLayout(final int[] columnWidths, final Alignment[] columnAlignments, final int hgap, final int vgap) {
@@ -174,8 +261,21 @@ public class ColumnLayout implements LayoutManager {
 	 * @param columnAlignments the column alignments
 	 * @param hSpace the space between the columns
 	 * @param vSpace the space between the rows
+	 * @deprecated use {@link #ColumnLayout(int[], CellAlignment[], Size, Size)}
 	 */
 	public ColumnLayout(final int[] columnWidths, final Alignment[] columnAlignments, final Size hSpace, final Size vSpace) {
+		this(columnWidths, columnAlignments, hSpace, vSpace, -1, -1);
+	}
+
+	/**
+	 * Creates a ColumnLayout with the specified percentage column widths.
+	 *
+	 * @param columnWidths the column widths, in percent units, 0 for undefined.
+	 * @param columnAlignments the column alignments
+	 * @param hSpace the space between the columns
+	 * @param vSpace the space between the rows
+	 */
+	public ColumnLayout(final int[] columnWidths, final CellAlignment[] columnAlignments, final Size hSpace, final Size vSpace) {
 		this(columnWidths, columnAlignments, hSpace, vSpace, -1, -1);
 	}
 
@@ -184,9 +284,21 @@ public class ColumnLayout implements LayoutManager {
 	 *
 	 * @param col the index of the column to set the alignment of.
 	 * @param alignment the alignment to set.
+	 *
+	 * @deprecated Use {@link ColumnLayout#setCellAlignment(int, CellAlignment)} instead.
 	 */
 	public void setAlignment(final int col, final Alignment alignment) {
-		columnAlignments[col] = alignment == null ? Alignment.LEFT : alignment;
+		setCellAlignment(col, alignment == null ? null : alignment.toCellAlignment());
+	}
+
+	/**
+	 * Sets the alignment of the given column. An IndexOutOfBoundsException will be thrown if col is out of bounds.
+	 *
+	 * @param col the index of the column to set the alignment of.
+	 * @param alignment the alignment to set.
+	 */
+	public void setCellAlignment(final int col, final CellAlignment alignment) {
+		columnAlignments[col] = alignment == null ? CellAlignment.LEFT : alignment;
 	}
 
 	/**
@@ -233,8 +345,18 @@ public class ColumnLayout implements LayoutManager {
 	 * @param columnIndex the index of the column to retrieve the alignment for.
 	 * @return the alignment of the given column.
 	 */
-	public Alignment getColumnAlignment(final int columnIndex) {
+	public CellAlignment getColumnCellAlignment(final int columnIndex) {
 		return columnAlignments[columnIndex];
+	}
+
+	/**
+	 * @param columnIndex the index of the column to retrieve the alignment for.
+	 * @return the alignment of the given column.
+	 *
+	 * @deprecated Use {@link ColumnLayout#getColumnCellAlignment(int)} instead.
+	 */
+	public Alignment getColumnAlignment(final int columnIndex) {
+		return Alignment.fromCellAlignment(getColumnCellAlignment(columnIndex));
 	}
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/ColumnLayoutRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/ColumnLayoutRenderer.java
@@ -46,7 +46,7 @@ final class ColumnLayoutRenderer extends AbstractWebXmlRenderer {
 			int width = layout.getColumnWidth(col);
 			xml.appendOptionalAttribute("width", width > 0, width);
 
-			switch (layout.getColumnAlignment(col)) {
+			switch (layout.getColumnCellAlignment(col)) {
 				case LEFT:
 					// left is assumed if omitted
 					break;
@@ -61,7 +61,7 @@ final class ColumnLayoutRenderer extends AbstractWebXmlRenderer {
 
 				default:
 					throw new IllegalArgumentException("Invalid alignment: " + layout.
-							getColumnAlignment(col));
+							getColumnCellAlignment(col));
 			}
 
 			xml.appendEnd();

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WColumnRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WColumnRenderer.java
@@ -32,7 +32,7 @@ final class WColumnRenderer extends AbstractWebXmlRenderer {
 		int width = col.getWidth();
 		xml.appendOptionalAttribute("width", width > 0, width);
 
-		switch (col.getAlignment()) {
+		switch (col.getCellAlignment()) {
 			case LEFT:
 				// left is assumed if omitted
 				break;
@@ -46,7 +46,7 @@ final class WColumnRenderer extends AbstractWebXmlRenderer {
 				break;
 
 			default:
-				throw new IllegalArgumentException("Invalid alignment: " + col.getAlignment());
+				throw new IllegalArgumentException("Invalid alignment: " + col.getCellAlignment());
 		}
 
 		xml.appendClose();

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WTableRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WTableRenderer.java
@@ -13,8 +13,8 @@ import com.github.bordertech.wcomponents.WTable.SelectMode;
 import com.github.bordertech.wcomponents.WTable.TableModel;
 import com.github.bordertech.wcomponents.WTable.TableRepeater;
 import com.github.bordertech.wcomponents.WTableColumn;
-import com.github.bordertech.wcomponents.WTableColumn.Alignment;
 import com.github.bordertech.wcomponents.XmlStringBuilder;
+import com.github.bordertech.wcomponents.layout.CellAlignment;
 import com.github.bordertech.wcomponents.servlet.WebXmlRenderContext;
 import com.github.bordertech.wcomponents.util.I18nUtilities;
 import com.github.bordertech.wcomponents.util.SystemException;
@@ -486,15 +486,15 @@ final class WTableRenderer extends AbstractWebXmlRenderer {
 			final WebXmlRenderContext renderContext) {
 		XmlStringBuilder xml = renderContext.getWriter();
 		int width = col.getWidth();
-		Alignment align = col.getAlign();
+		CellAlignment align = col.getCellAlignment();
 
 		xml.appendTagOpen("ui:th");
 		xml.appendOptionalAttribute("width", width > 0, width);
 		xml.appendOptionalAttribute("sortable", sortable, "true");
 
-		if (Alignment.RIGHT.equals(align)) {
+		if (CellAlignment.RIGHT.equals(align)) {
 			xml.appendAttribute("align", "right");
-		} else if (Alignment.CENTER.equals(align)) {
+		} else if (CellAlignment.CENTER.equals(align)) {
 			xml.appendAttribute("align", "center");
 		}
 

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WColumn_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WColumn_Test.java
@@ -1,6 +1,7 @@
 package com.github.bordertech.wcomponents;
 
 import com.github.bordertech.wcomponents.WColumn.Alignment;
+import com.github.bordertech.wcomponents.layout.CellAlignment;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -35,6 +36,12 @@ public class WColumn_Test extends AbstractWComponentTestCase {
 	public void testAlignmentAccessors() {
 		assertAccessorsCorrect(new WColumn(10), "alignment", Alignment.LEFT, Alignment.CENTER,
 				Alignment.RIGHT);
+	}
+
+	@Test
+	public void testCellAlignmentAccessors() {
+		assertAccessorsCorrect(new WColumn(10), "cellAlignment", CellAlignment.LEFT, CellAlignment.CENTER,
+				CellAlignment.RIGHT);
 	}
 
 	@Test

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WTableColumn_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WTableColumn_Test.java
@@ -1,5 +1,6 @@
 package com.github.bordertech.wcomponents;
 
+import com.github.bordertech.wcomponents.layout.CellAlignment;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -108,6 +109,13 @@ public final class WTableColumn_Test extends AbstractWComponentTestCase {
 		assertAccessorsCorrect(new WTableColumn("align", WText.class), "align", null,
 				WTableColumn.Alignment.LEFT,
 				WTableColumn.Alignment.RIGHT);
+	}
+
+	@Test
+	public void testCellAlignmentAccessors() {
+		assertAccessorsCorrect(new WTableColumn("cellAlignment", WText.class), "cellAlignment", null,
+				CellAlignment.LEFT,
+				CellAlignment.RIGHT);
 	}
 
 	@Test

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/layout/ColumnLayout_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/layout/ColumnLayout_Test.java
@@ -69,6 +69,23 @@ public class ColumnLayout_Test {
 	}
 
 	@Test
+	public void testIntCellAlignmentConstructor() {
+		final int[] cols = new int[]{30, 70};
+		final CellAlignment[] align = new CellAlignment[]{CellAlignment.CENTER, CellAlignment.RIGHT};
+
+		ColumnLayout layout = new ColumnLayout(cols, align);
+		Assert.assertEquals("Incorrect column count", 2, layout.getColumnCount());
+		Assert.assertEquals("Incorrect column 1 width", 30, layout.getColumnWidth(0));
+		Assert.assertEquals("Incorrect column 2 width", 70, layout.getColumnWidth(1));
+		Assert.assertEquals("Incorrect column 1 alignment", CellAlignment.CENTER, layout.
+				getColumnCellAlignment(0));
+		Assert.assertEquals("Incorrect column 2 alignment", CellAlignment.RIGHT, layout.
+				getColumnCellAlignment(1));
+		Assert.assertNull("Incorrect default HGAP", layout.getHorizontalGap());
+		Assert.assertNull("Incorrect default VGAP", layout.getVerticalGap());
+	}
+
+	@Test
 	public void testIntAlignGapConstructor() {
 		final int[] cols = new int[]{100};
 		final ColumnLayout.Alignment[] align = new ColumnLayout.Alignment[]{ColumnLayout.Alignment.RIGHT};
@@ -78,6 +95,20 @@ public class ColumnLayout_Test {
 		Assert.assertEquals("Incorrect column width", 100, layout.getColumnWidth(0));
 		Assert.assertEquals("Incorrect column alignment", ColumnLayout.Alignment.RIGHT, layout.
 				getColumnAlignment(0));
+		Assert.assertEquals("Incorrect HGAP", GAP, layout.getHorizontalGap());
+		Assert.assertEquals("Incorrect VGAP", BIG_GAP, layout.getVerticalGap());
+	}
+
+	@Test
+	public void testIntCellAlignmentGapConstructor() {
+		final int[] cols = new int[]{100};
+		final CellAlignment[] align = new CellAlignment[]{CellAlignment.RIGHT};
+
+		ColumnLayout layout = new ColumnLayout(cols, align, GAP, BIG_GAP);
+		Assert.assertEquals("Incorrect column count", 1, layout.getColumnCount());
+		Assert.assertEquals("Incorrect column width", 100, layout.getColumnWidth(0));
+		Assert.assertEquals("Incorrect column alignment", CellAlignment.RIGHT, layout.
+				getColumnCellAlignment(0));
 		Assert.assertEquals("Incorrect HGAP", GAP, layout.getHorizontalGap());
 		Assert.assertEquals("Incorrect VGAP", BIG_GAP, layout.getVerticalGap());
 	}
@@ -94,6 +125,20 @@ public class ColumnLayout_Test {
 				getColumnAlignment(0));
 		Assert.assertEquals("Incorrect HGAP", GAP, layout.getHorizontalGap());
 		Assert.assertEquals("Incorrect VGAP", BIG_GAP, layout.getVerticalGap());
+	}
+
+	@Test
+	public void testIntCellAlignmentSizeConstructor() {
+		final int[] cols = new int[]{100};
+		final CellAlignment[] align = new CellAlignment[]{CellAlignment.RIGHT};
+
+		ColumnLayout layout = new ColumnLayout(cols, align, Size.MEDIUM, Size.SMALL);
+		Assert.assertEquals("Incorrect column count", 1, layout.getColumnCount());
+		Assert.assertEquals("Incorrect column width", 100, layout.getColumnWidth(0));
+		Assert.assertEquals("Incorrect column alignment", CellAlignment.RIGHT, layout.
+				getColumnCellAlignment(0));
+		Assert.assertEquals("Incorrect HGAP", Size.MEDIUM, layout.getHorizontalGap());
+		Assert.assertEquals("Incorrect VGAP", Size.SMALL, layout.getVerticalGap());
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -119,6 +164,6 @@ public class ColumnLayout_Test {
 	@Test(expected = IllegalArgumentException.class)
 	public void testMismatchingColumnCount() {
 		new ColumnLayout(new int[]{50, 50},
-				new ColumnLayout.Alignment[]{ColumnLayout.Alignment.LEFT});
+				new CellAlignment[]{CellAlignment.LEFT});
 	}
 }


### PR DESCRIPTION
WColumn, WTableColumn and ColumnLayout all have their own Alignment enums.
They all mean the same thing, that is to align a cell in the specified
way. It makes sense to unify these into a single enum.

Addresses #299