### PR TITLE
Update WebDriverManager to 3.8.2-alpha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jdk:
 
 ## Travis installs the project with the following maven command:- "mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V"
 install:
- - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -DskipOptionalQA=true -Dwc.pmd.verbose=false
+ - mvn --settings ci-settings.xml install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -DskipOptionalQA=true -Dwc.pmd.verbose=false
 
 script:
  - ./travis.sh

--- a/ci-settings.xml
+++ b/ci-settings.xml
@@ -1,0 +1,34 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+	<!--
+		This is a temporary measure to pick up WebDriverManager 3.8.2
+		before it has been released to Maven Central by the official maintainer.
+	-->
+
+	<activeProfiles>
+		<activeProfile>github</activeProfile>
+	</activeProfiles>
+
+	<profiles>
+		<profile>
+			<id>github</id>
+			<repositories>
+				<repository>
+					<id>github</id>
+					<name>GitHub ricksbrown Apache Maven Packages</name>
+					<url>https://maven.pkg.github.com/ricksbrown/webdrivermanager</url>
+				</repository>
+			</repositories>
+		</profile>
+	</profiles>
+
+	<servers>
+		<server>
+			<id>github</id>
+			<username>>${env.GITHUB_USERNAME}</username>
+			<password>${env.GITHUB_TOKEN}</password>
+		</server>
+	</servers>
+</settings>

--- a/travis.sh
+++ b/travis.sh
@@ -4,8 +4,8 @@
 
 if [[ -n ${TRAVIS_SECURE_ENV_VARS+x} && ${TRAVIS_SECURE_ENV_VARS} == true && ! -z ${SONAR_TOKEN} ]]; then
 	echo "Travis secure variables ARE available"
-	mvn --batch-mode package sonar:sonar -Dsonar.projectKey="bordertech-wcomponents" -PskipCoreOptionalTests
+	mvn --settings ci-settings.xml --batch-mode package sonar:sonar -Dsonar.projectKey="bordertech-wcomponents" -PskipCoreOptionalTests
 else
 	echo "Travis secure variables not available"
-	mvn --batch-mode package -PskipCoreOptionalTests
+	mvn --settings ci-settings.xml --batch-mode package -PskipCoreOptionalTests
 fi

--- a/wcomponents-test-lib/pom.xml
+++ b/wcomponents-test-lib/pom.xml
@@ -74,7 +74,8 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>3.6.2</version>
+			<!-- Temporary version, see ci-settings.xml -->
+			<version>3.8.2-alpha</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
While we wait for the maintainer to release the official version of WebDriverManager 3.8.2 (with fixes we need) we can pick up this patched version from GitHub Packages.

Note to developers: you now need to authenticate with GitHub Packages to build.
You can [configure your settings.xml](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-apache-maven-for-use-with-github-packages#authenticating-with-a-personal-access-token) OR you can use the new `ci-settings.xml` in your maven commands:

```bash
export GITHUB_USERNAME=username
export GITHUB_TOKEN=token
mvn --settings ci-settings.xml install
```

Either way you will need a personal access token with rights to read packages (it doesn't need anything else).