### PR TITLE
Allow intern config to be overridden via JSON

### DIFF
--- a/wcomponents-theme/Gruntfile.js
+++ b/wcomponents-theme/Gruntfile.js
@@ -106,6 +106,8 @@ module.exports = function (grunt) {
 			let internArgs = process.env.INTERN_ARGS;
 			if (internArgs) {
 				logIt("INTERN_ARGS: " + process.env.INTERN_ARGS);
+			} else if (internConfig.environments) {
+				logIt("INTERN_ARGS not set, using environments from config");
 			} else {
 				logIt("INTERN_ARGS not set, using default: " + defaultInternArgs);
 				logIt("https://github.com/theintern/intern/blob/master/docs/configuration.md#environment-variable");

--- a/wcomponents-theme/scripts/intern.js
+++ b/wcomponents-theme/scripts/intern.js
@@ -1,8 +1,10 @@
 /* eslint-env node, es6  */
 const path = require("path");
-const { getConfig, dirs } = require("./build-util");
+const { getConfig, dirs, requireAmd } = require("./build-util");
 const scriptDir = path.relative(dirs.script.target, dirs.script[getConfig("testMinOrMax")]);  // dirs.script.min will test minifed code, dirs.script.max tests debug code
 const targetDir = path.relative(dirs.project.basedir, dirs.project.build);
+const mixin = requireAmd("wc/mixin");
+const internOverrides = getConfig("internOverrides");
 let testRootPath = path.join(dirs.test.target, "intern");
 let srcRootPath = dirs.script.target;
 
@@ -124,6 +126,11 @@ let internConfig = {
 	},
 	"defaultTimeout": 240000
 };
+
+if (internOverrides) {
+	console.log("Got internOverrides from config", internOverrides);
+	mixin(internOverrides, internConfig);
+}
 
 module.exports = {
 	config: internConfig


### PR DESCRIPTION
This change will facilitate running intern tests behind a corporate firewall as it will be easy to set `baseUrl` where necessary.

wcomponents-theme provides a powerful build-time config mechanism
which had previously not been harnessed to override intern testing
configuration.