### PR TITLE
Upgrade to WebDriverManager 4.0.0

### DIFF
--- a/wcomponents-test-lib/pom.xml
+++ b/wcomponents-test-lib/pom.xml
@@ -74,8 +74,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<!-- Temporary version, see ci-settings.xml -->
-			<version>3.8.2-alpha</version>
+			<version>4.0.0</version>
 		</dependency>
 
 		<dependency>

--- a/wcomponents-test-lib/src/main/java/com/github/bordertech/wcomponents/test/selenium/driver/ChromeWebDriverType.java
+++ b/wcomponents-test-lib/src/main/java/com/github/bordertech/wcomponents/test/selenium/driver/ChromeWebDriverType.java
@@ -1,6 +1,6 @@
 package com.github.bordertech.wcomponents.test.selenium.driver;
 
-import io.github.bonigarcia.wdm.DriverManagerType;
+import io.github.bonigarcia.wdm.config.DriverManagerType;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeDriverService;

--- a/wcomponents-test-lib/src/main/java/com/github/bordertech/wcomponents/test/selenium/driver/EdgeWebDriverType.java
+++ b/wcomponents-test-lib/src/main/java/com/github/bordertech/wcomponents/test/selenium/driver/EdgeWebDriverType.java
@@ -1,6 +1,6 @@
 package com.github.bordertech.wcomponents.test.selenium.driver;
 
-import io.github.bonigarcia.wdm.DriverManagerType;
+import io.github.bonigarcia.wdm.config.DriverManagerType;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.edge.EdgeDriver;
 import org.openqa.selenium.edge.EdgeDriverService;

--- a/wcomponents-test-lib/src/main/java/com/github/bordertech/wcomponents/test/selenium/driver/FirefoxWebDriverType.java
+++ b/wcomponents-test-lib/src/main/java/com/github/bordertech/wcomponents/test/selenium/driver/FirefoxWebDriverType.java
@@ -1,6 +1,6 @@
 package com.github.bordertech.wcomponents.test.selenium.driver;
 
-import io.github.bonigarcia.wdm.DriverManagerType;
+import io.github.bonigarcia.wdm.config.DriverManagerType;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;

--- a/wcomponents-test-lib/src/main/java/com/github/bordertech/wcomponents/test/selenium/driver/InternetExplorerWebDriverType.java
+++ b/wcomponents-test-lib/src/main/java/com/github/bordertech/wcomponents/test/selenium/driver/InternetExplorerWebDriverType.java
@@ -1,6 +1,6 @@
 package com.github.bordertech.wcomponents.test.selenium.driver;
 
-import io.github.bonigarcia.wdm.DriverManagerType;
+import io.github.bonigarcia.wdm.config.DriverManagerType;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.ie.InternetExplorerDriverService;


### PR DESCRIPTION
This change allows WebDriverManager to be run behind a corporate proxy
using Nexus Repository Manager as a mirror.