### PR TITLE
Ensure consistent usage of HeadingLevel

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WColumnLayout.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/WColumnLayout.java
@@ -40,7 +40,7 @@ public class WColumnLayout extends AbstractNamingContextContainer {
 	 * @param heading the heading text.
 	 */
 	public WColumnLayout(final String heading) {
-		this(new WHeading(WHeading.SECTION, heading));
+		this(new WHeading(HeadingLevel.H3, heading));
 	}
 
 	/**
@@ -80,7 +80,7 @@ public class WColumnLayout extends AbstractNamingContextContainer {
 	 * @param content the content.
 	 */
 	public void setLeftColumn(final String heading, final WComponent content) {
-		setLeftColumn(new WHeading(WHeading.MINOR, heading), content);
+		setLeftColumn(new WHeading(HeadingLevel.H4, heading), content);
 	}
 
 	/**
@@ -109,7 +109,7 @@ public class WColumnLayout extends AbstractNamingContextContainer {
 	 * @param content the content.
 	 */
 	public void setRightColumn(final String heading, final WComponent content) {
-		setRightColumn(new WHeading(WHeading.MINOR, heading), content);
+		setRightColumn(new WHeading(HeadingLevel.H4, heading), content);
 	}
 
 	/**

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WColumnLayout_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WColumnLayout_Test.java
@@ -36,7 +36,7 @@ public class WColumnLayout_Test extends AbstractWComponentTestCase {
 		WColumnLayout col = new WColumnLayout();
 		WLabel label = new WLabel("leftLabel");
 		String headingText = "leftHeading";
-		WHeading heading = new WHeading(WHeading.MINOR, headingText);
+		WHeading heading = new WHeading(HeadingLevel.H4, headingText);
 
 		Assert.assertFalse("Should not have any content by default", col.hasLeftContent());
 		col.setLeftColumn(label);
@@ -68,7 +68,7 @@ public class WColumnLayout_Test extends AbstractWComponentTestCase {
 		WColumnLayout col = new WColumnLayout();
 		WLabel label = new WLabel("rightLabel");
 		String headingText = "rightHeading";
-		WHeading heading = new WHeading(WHeading.MINOR, headingText);
+		WHeading heading = new WHeading(HeadingLevel.H4, headingText);
 
 		Assert.assertFalse("Should not have any content by default", col.hasRightContent());
 		col.setRightColumn(label);

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WHeading_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WHeading_Test.java
@@ -69,4 +69,20 @@ public class WHeading_Test extends AbstractWComponentTestCase {
 			HeadingLevel.H1, HeadingLevel.H2, HeadingLevel.H3);
 	}
 
+	@Test
+	public void testHeadingTypeToHeadingLevelConversion() {
+
+		testHeadingLevelConversion(WHeading.TITLE, HeadingLevel.H1);
+		testHeadingLevelConversion(WHeading.MAJOR, HeadingLevel.H2);
+		testHeadingLevelConversion(WHeading.SECTION, HeadingLevel.H3);
+		testHeadingLevelConversion(WHeading.MINOR, HeadingLevel.H4);
+		testHeadingLevelConversion(WHeading.SUB_HEADING, HeadingLevel.H5);
+		testHeadingLevelConversion(WHeading.SUB_SUB_HEADING, HeadingLevel.H6);
+	}
+
+	private void testHeadingLevelConversion(int type, HeadingLevel headingLevel) {
+		WHeading heading = new WHeading(type, "dummy");
+		Assert.assertEquals("WHeading type conversion to HeadingLevel failed",
+			headingLevel, heading.getHeadingLevel());
+	}
 }

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WHeadingRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WHeadingRenderer_Test.java
@@ -1,5 +1,6 @@
 package com.github.bordertech.wcomponents.render.webxml;
 
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.Margin;
 import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WDecoratedLabel;
@@ -21,7 +22,7 @@ public class WHeadingRenderer_Test extends AbstractWebXmlRendererTestCase {
 
 	@Test
 	public void testRendererCorrectlyConfigured() {
-		WHeading component = new WHeading(WHeading.TITLE, "");
+		WHeading component = new WHeading(HeadingLevel.H1, "");
 		Assert.assertTrue("Incorrect renderer supplied",
 				getWebXmlRenderer(component) instanceof WHeadingRenderer);
 	}
@@ -30,27 +31,27 @@ public class WHeadingRenderer_Test extends AbstractWebXmlRendererTestCase {
 	public void testPaint() throws IOException, SAXException, XpathException {
 		final String text = "WHeading_Test.testPaint.heading";
 
-		WHeading heading = new WHeading(WHeading.TITLE, text);
+		WHeading heading = new WHeading(HeadingLevel.H1, text);
 		assertSchemaMatch(heading);
 		assertXpathEvaluatesTo(text, "//ui:heading[@level=1]", heading);
 
-		heading = new WHeading(WHeading.MAJOR, text);
+		heading = new WHeading(HeadingLevel.H2, text);
 		assertSchemaMatch(heading);
 		assertXpathEvaluatesTo(text, "//ui:heading[@level=2]", heading);
 
-		heading = new WHeading(WHeading.SECTION, text);
+		heading = new WHeading(HeadingLevel.H3, text);
 		assertSchemaMatch(heading);
 		assertXpathEvaluatesTo(text, "//ui:heading[@level=3]", heading);
 
-		heading = new WHeading(WHeading.MINOR, text);
+		heading = new WHeading(HeadingLevel.H4, text);
 		assertSchemaMatch(heading);
 		assertXpathEvaluatesTo(text, "//ui:heading[@level=4]", heading);
 
-		heading = new WHeading(WHeading.SUB_HEADING, text);
+		heading = new WHeading(HeadingLevel.H5, text);
 		assertSchemaMatch(heading);
 		assertXpathEvaluatesTo(text, "//ui:heading[@level=5]", heading);
 
-		heading = new WHeading(WHeading.SUB_SUB_HEADING, text);
+		heading = new WHeading(HeadingLevel.H6, text);
 		assertSchemaMatch(heading);
 		assertXpathEvaluatesTo(text, "//ui:heading[@level=6]", heading);
 
@@ -67,7 +68,7 @@ public class WHeadingRenderer_Test extends AbstractWebXmlRendererTestCase {
 		final String text1 = "WHeading_Test.testPaintWithDecoratedLabel.text1";
 		final String text2 = "WHeading_Test.testPaintWithDecoratedLabel.text2";
 
-		WHeading heading = new WHeading(WHeading.TITLE, new WDecoratedLabel(new WText(text1)));
+		WHeading heading = new WHeading(HeadingLevel.H1, new WDecoratedLabel(new WText(text1)));
 		assertSchemaMatch(heading);
 
 		assertXpathEvaluatesTo(text1, "//ui:heading[@level=1]/ui:decoratedlabel/ui:labelbody/text()",
@@ -81,7 +82,7 @@ public class WHeadingRenderer_Test extends AbstractWebXmlRendererTestCase {
 
 	@Test
 	public void testRenderedWithMargins() throws IOException, SAXException, XpathException {
-		WHeading heading = new WHeading(WHeading.TITLE, "test");
+		WHeading heading = new WHeading(HeadingLevel.H1, "test");
 		assertXpathNotExists("//ui:heading/ui:margin", heading);
 
 		Margin margin = new Margin(0);
@@ -109,7 +110,7 @@ public class WHeadingRenderer_Test extends AbstractWebXmlRendererTestCase {
 
 	@Test
 	public void testXssEscaping() throws IOException, SAXException, XpathException {
-		WHeading heading = new WHeading(WHeading.TITLE, new WDecoratedLabel(new WText("dummy")));
+		WHeading heading = new WHeading(HeadingLevel.H1, new WDecoratedLabel(new WText("dummy")));
 
 		assertSafeContent(heading);
 

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/testapp/BigPanel.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/testapp/BigPanel.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.testapp;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.RadioButtonGroup;
 import com.github.bordertech.wcomponents.TestLookupTable;
 import com.github.bordertech.wcomponents.WButton;
@@ -47,7 +48,7 @@ public class BigPanel extends WContainer {
 
 		List<String> progTypeList = getProgrammerTypeList();
 
-		add(new WHeading(WHeading.MAJOR, "Programmer social network"));
+		add(new WHeading(HeadingLevel.H2, "Programmer social network"));
 		leftColumn.addField("Name", new WTextField());
 		leftColumn.addField("Date Of birth", new WDateField());
 		leftColumn.addField("Day of week", new WDropdown(TestLookupTable.DayOfWeekTable.class));

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/testapp/DetailsPage.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/testapp/DetailsPage.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.testapp;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.RadioButtonGroup;
 import com.github.bordertech.wcomponents.TestLookupTable;
 import com.github.bordertech.wcomponents.WButton;
@@ -34,7 +35,7 @@ public class DetailsPage extends WContainer {
 	 * Creates a DetailsPage.
 	 */
 	public DetailsPage() {
-		add(new WHeading(WHeading.MAJOR, "Details"));
+		add(new WHeading(HeadingLevel.H2, "Details"));
 		// core input fields, tabs, collapsible, menu
 
 		WTabSet tabs = new WTabSet();

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/KitchenSink.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/KitchenSink.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.examples;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WContainer;
@@ -55,7 +56,7 @@ public class KitchenSink extends WPanel {
 		tabs.addTab(new DuplicatorGroup(), "Dynamic Additions", WTabSet.TAB_MODE_CLIENT);
 		tabs.addTab(new TextDuplicator(), "Text Duplicator", WTabSet.TAB_MODE_CLIENT);
 
-		add(new WHeading(WHeading.MAJOR, "Selection of tests"));
+		add(new WHeading(HeadingLevel.H2, "Selection of tests"));
 		add(tabs);
 	}
 

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/LoadAjaxControlsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/LoadAjaxControlsExample.java
@@ -1,5 +1,6 @@
 package com.github.bordertech.wcomponents.examples;
 
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.WCollapsible;
 import com.github.bordertech.wcomponents.WCollapsible.CollapsibleMode;
 import com.github.bordertech.wcomponents.WContainer;
@@ -42,21 +43,21 @@ public class LoadAjaxControlsExample extends WContainer {
 				CollapsibleMode.DYNAMIC);
 		add(collapse);
 
-		content.add(new WHeading(WHeading.SECTION, "Lists using datalist"));
+		content.add(new WHeading(HeadingLevel.H3, "Lists using datalist"));
 
 		WFieldLayout layout = new WFieldLayout();
 		createFields(layout, "icao");
 		content.add(layout);
 
 		content.add(new WHorizontalRule());
-		content.add(new WHeading(WHeading.SECTION, "Lists using different datalist"));
+		content.add(new WHeading(HeadingLevel.H3, "Lists using different datalist"));
 
 		WFieldLayout layout2 = new WFieldLayout();
 		createFields(layout2, new TableWithNullOption("icao"));
 		content.add(layout2);
 
 		content.add(new WHorizontalRule());
-		content.add(new WHeading(WHeading.SECTION, "Eager Panel"));
+		content.add(new WHeading(HeadingLevel.H3, "Eager Panel"));
 
 		WPanel eager = new WPanel(WPanel.Type.BOX);
 		eager.setMode(PanelMode.EAGER);
@@ -64,39 +65,39 @@ public class LoadAjaxControlsExample extends WContainer {
 		content.add(eager);
 
 		content.add(new WHorizontalRule());
-		content.add(new WHeading(WHeading.SECTION, "Ajax - Button"));
+		content.add(new WHeading(HeadingLevel.H3, "Ajax - Button"));
 		content.add(new AjaxWButtonExample());
 
 		content.add(new WHorizontalRule());
-		content.add(new WHeading(WHeading.SECTION, "Ajax - CheckBox"));
+		content.add(new WHeading(HeadingLevel.H3, "Ajax - CheckBox"));
 		content.add(new AjaxWCheckboxExample());
 
 		content.add(new WHorizontalRule());
-		content.add(new WHeading(WHeading.SECTION, "Ajax - Dropdown"));
+		content.add(new WHeading(HeadingLevel.H3, "Ajax - Dropdown"));
 		content.add(new AjaxWDropdownExample());
 
 		content.add(new WHorizontalRule());
-		content.add(new WHeading(WHeading.SECTION, "Ajax - Table"));
+		content.add(new WHeading(HeadingLevel.H3, "Ajax - Table"));
 		content.add(new TreeTableExample());
 
 		content.add(new WHorizontalRule());
-		content.add(new WHeading(WHeading.SECTION, "Ajax - Polling"));
+		content.add(new WHeading(HeadingLevel.H3, "Ajax - Polling"));
 		content.add(new AjaxPollingWButtonExample());
 
 		content.add(new WHorizontalRule());
-		content.add(new WHeading(WHeading.SECTION, "Ajax - Lazy Panel"));
+		content.add(new WHeading(HeadingLevel.H3, "Ajax - Lazy Panel"));
 		content.add(new AjaxWPanelExample());
 
 		content.add(new WHorizontalRule());
-		content.add(new WHeading(WHeading.SECTION, "Ajax - RadioButtonSelect"));
+		content.add(new WHeading(HeadingLevel.H3, "Ajax - RadioButtonSelect"));
 		content.add(new AjaxWRadioButtonSelectExample());
 
 		content.add(new WHorizontalRule());
-		content.add(new WHeading(WHeading.SECTION, "Dialog"));
+		content.add(new WHeading(HeadingLevel.H3, "Dialog"));
 		content.add(new WDialogExample());
 
 		content.add(new WHorizontalRule());
-		content.add(new WHeading(WHeading.SECTION, "Tab Modes"));
+		content.add(new WHeading(HeadingLevel.H3, "Tab Modes"));
 		WTabSet tabset1 = new WTabSet();
 		tabset1.
 				addTab(new DateText("Tab Content 1"), "Tab 1 (client)", WTabSet.TAB_MODE_CLIENT, '1');
@@ -111,7 +112,7 @@ public class LoadAjaxControlsExample extends WContainer {
 		content.add(tabset1);
 
 		content.add(new WHorizontalRule());
-		content.add(new WHeading(WHeading.SECTION, "Collapsibles"));
+		content.add(new WHeading(HeadingLevel.H3, "Collapsibles"));
 		content.add(new WCollapsible(new DateText("Eager Collapsible Content"), "Eager Mode",
 				CollapsibleMode.EAGER));
 		content.add(new WCollapsible(new DateText("Lazy Collapsible Content"), "Lazy Mode",

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/TextFieldExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/TextFieldExample.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.examples;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WDefinitionList;
@@ -126,7 +127,7 @@ public class TextFieldExample extends WPanel {
 		fieldLayout.addField("Ten column field", tf5);
 
 		add(new WHorizontalRule());
-		WHeading heading = new WHeading(WHeading.MAJOR, "Values read from fields");
+		WHeading heading = new WHeading(HeadingLevel.H2, "Values read from fields");
 		add(heading);
 		WDefinitionList defList = new WDefinitionList(WDefinitionList.Type.COLUMN);
 		defList.addTerm(tf1.getLabel().getText(), plain);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WDataListServletExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WDataListServletExample.java
@@ -1,5 +1,6 @@
 package com.github.bordertech.wcomponents.examples;
 
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WComponent;
@@ -53,7 +54,7 @@ public class WDataListServletExample extends WContainer {
 	 * Construct the example.
 	 */
 	public WDataListServletExample() {
-		add(new WHeading(WHeading.SECTION,
+		add(new WHeading(HeadingLevel.H3,
 				"Example of components using cached lists (WDataListServlet)"));
 
 		add(layout);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WDefinitionListExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WDefinitionListExample.java
@@ -1,5 +1,6 @@
 package com.github.bordertech.wcomponents.examples;
 
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WDefinitionList;
 import com.github.bordertech.wcomponents.WHeading;
@@ -17,22 +18,22 @@ public class WDefinitionListExample extends WContainer {
 	 * Creates a WDefinitionListExample.
 	 */
 	public WDefinitionListExample() {
-		add(new WHeading(WHeading.SECTION, "Normal layout"));
+		add(new WHeading(HeadingLevel.H3, "Normal layout"));
 		WDefinitionList list = new WDefinitionList();
 		addListItems(list);
 		add(list);
 
-		add(new WHeading(WHeading.SECTION, "Flat layout"));
+		add(new WHeading(HeadingLevel.H3, "Flat layout"));
 		list = new WDefinitionList(WDefinitionList.Type.FLAT);
 		addListItems(list);
 		add(list);
 
-		add(new WHeading(WHeading.SECTION, "Stacked layout"));
+		add(new WHeading(HeadingLevel.H3, "Stacked layout"));
 		list = new WDefinitionList(WDefinitionList.Type.STACKED);
 		addListItems(list);
 		add(list);
 
-		add(new WHeading(WHeading.SECTION, "Column layout"));
+		add(new WHeading(HeadingLevel.H3, "Column layout"));
 		list = new WDefinitionList(WDefinitionList.Type.COLUMN);
 		addListItems(list);
 		add(list);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WDialogExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WDialogExample.java
@@ -251,13 +251,13 @@ public class WDialogExample extends WPanel implements MessageContainer {
 		add(dialogWithHeight2);
 		add(dialogWithMode);
 
-		add(new WHeading(WHeading.MAJOR, "Dialogs which open without page reload"));
+		add(new WHeading(HeadingLevel.H2, "Dialogs which open without page reload"));
 		//remember the button of an immediate is part of the dialog: it will be place into the UI wherever the dialog is placed
 		add(nonModalDialog);
 		add(modalDialog);
 		// for buttons which will result in a dialog on reload the button is added to the UI explicitly
 
-		add(new WHeading(WHeading.MAJOR, "Dialogs which open after page reload"));
+		add(new WHeading(HeadingLevel.H2, "Dialogs which open after page reload"));
 		add(dialogButton1);
 		add(dialogButton2);
 

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WPanelExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WPanelExample.java
@@ -1,5 +1,6 @@
 package com.github.bordertech.wcomponents.examples;
 
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WHeading;
@@ -26,7 +27,7 @@ public class WPanelExample extends WContainer {
 				add(new WHorizontalRule());
 			}
 
-			add(new WHeading(WHeading.SECTION, panelType.toString()));
+			add(new WHeading(HeadingLevel.H3, panelType.toString()));
 
 			WPanel panel = new WPanel(panelType);
 			panel.setTitleText("Panel title");

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WShufflerExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WShufflerExample.java
@@ -1,5 +1,6 @@
 package com.github.bordertech.wcomponents.examples;
 
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WContainer;
@@ -30,7 +31,7 @@ public class WShufflerExample extends WContainer {
 	 * Construct the example.
 	 */
 	public WShufflerExample() {
-		add(new WHeading(WHeading.SECTION, "WShuffler examples"));
+		add(new WHeading(HeadingLevel.H3, "WShuffler examples"));
 
 		WFieldLayout layout = new WFieldLayout();
 		add(layout);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WSkipLinksExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WSkipLinksExample.java
@@ -1,5 +1,6 @@
 package com.github.bordertech.wcomponents.examples;
 
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.WHeading;
 import com.github.bordertech.wcomponents.WHorizontalRule;
 import com.github.bordertech.wcomponents.WLabel;
@@ -31,7 +32,7 @@ public class WSkipLinksExample extends WPanel {
 		//note: the WSKipLinks component is actually added to the ancestor WApplication
 		//and is invoked by the presence of WPanel with an accessKey.
 
-		add(new WHeading(WHeading.SECTION, "WPanel skip-links targets"));
+		add(new WHeading(HeadingLevel.H3, "WPanel skip-links targets"));
 
 		add(buildPanel("Panel One Title", '1'));
 		add(buildPanel("Panel 2 - no access key is set on this panel"));

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WWindowExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WWindowExample.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.examples;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WHeading;
@@ -36,7 +37,7 @@ public class WWindowExample extends WContainer {
 			}
 		});
 
-		add(new WHeading(WHeading.SECTION, "Window with functional content, round-trip"));
+		add(new WHeading(HeadingLevel.H3, "Window with functional content, round-trip"));
 		add(button1);
 		add(window1);
 
@@ -56,7 +57,7 @@ public class WWindowExample extends WContainer {
 			}
 		});
 
-		add(new WHeading(WHeading.SECTION, "Window with functional content, AJAX-enabled"));
+		add(new WHeading(HeadingLevel.H3, "Window with functional content, AJAX-enabled"));
 		add(button2);
 		add(window2);
 
@@ -74,7 +75,7 @@ public class WWindowExample extends WContainer {
 			}
 		});
 
-		add(new WHeading(WHeading.SECTION, "Nested targetable content"));
+		add(new WHeading(HeadingLevel.H3, "Nested targetable content"));
 		add(button3);
 		add(window3);
 
@@ -92,7 +93,7 @@ public class WWindowExample extends WContainer {
 			}
 		});
 
-		add(new WHeading(WHeading.SECTION, "Window that uses change flag"));
+		add(new WHeading(HeadingLevel.H3, "Window that uses change flag"));
 		add(button4);
 		add(window4);
 

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WhiteSpaceExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WhiteSpaceExample.java
@@ -1,6 +1,7 @@
 package com.github.bordertech.wcomponents.examples;
 
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WContainer;
@@ -45,16 +46,16 @@ public class WhiteSpaceExample extends WContainer {
 	 */
 	public WhiteSpaceExample() {
 
-		add(new WHeading(WHeading.SECTION, "Messages with Whitespace"));
+		add(new WHeading(HeadingLevel.H3, "Messages with Whitespace"));
 		add(new WMessageBox(WMessageBox.INFO, EXAMPLE_MESSAGE));
 		add(new WMessageBox(WMessageBox.SUCCESS, EXAMPLE_MESSAGE));
 		add(new WMessageBox(WMessageBox.WARN, EXAMPLE_MESSAGE));
 		add(new WMessageBox(WMessageBox.ERROR, EXAMPLE_MESSAGE));
 
-		add(new WHeading(WHeading.SECTION, "Error Message with Whitespace"));
+		add(new WHeading(HeadingLevel.H3, "Error Message with Whitespace"));
 		add(errors);
 
-		add(new WHeading(WHeading.SECTION, "Text Areas with Whitespace"));
+		add(new WHeading(HeadingLevel.H3, "Text Areas with Whitespace"));
 		WFieldLayout layout = new WFieldLayout();
 		layout.addField("Text area", textArea);
 		WTextArea textArea2 = new WTextArea();

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/datatable/DataTableOptionsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/datatable/DataTableOptionsExample.java
@@ -4,6 +4,7 @@ import com.github.bordertech.wcomponents.AbstractTableDataModel;
 import com.github.bordertech.wcomponents.AbstractTreeTableDataModel;
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.TableDataModel;
 import com.github.bordertech.wcomponents.TableTreeNode;
@@ -166,19 +167,19 @@ public class DataTableOptionsExample extends WContainer {
 		table2 = createExpandedDataTable();
 		table3 = createHierarchicDataTable();
 
-		add(new WHeading(WHeading.SECTION, "Table"));
+		add(new WHeading(HeadingLevel.H3, "Table"));
 		add(table1);
 		add(selected1);
 
 		add(new WHorizontalRule());
 
-		add(new WHeading(WHeading.SECTION, "Expanded Content Table"));
+		add(new WHeading(HeadingLevel.H3, "Expanded Content Table"));
 		add(table2);
 		add(selected2);
 
 		add(new WHorizontalRule());
 
-		add(new WHeading(WHeading.SECTION, "Hierarchic Table"));
+		add(new WHeading(HeadingLevel.H3, "Hierarchic Table"));
 		add(table3);
 		add(selected3);
 	}

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/subordinate/SubordinateBuilderComplexExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/subordinate/SubordinateBuilderComplexExample.java
@@ -1,5 +1,6 @@
 package com.github.bordertech.wcomponents.examples.subordinate;
 
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.RadioButtonGroup;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WDropdown;
@@ -45,7 +46,7 @@ public class SubordinateBuilderComplexExample extends WContainer {
 	 * Creates a SubordinateBuilderComplexExample.
 	 */
 	public SubordinateBuilderComplexExample() {
-		add(new WHeading(WHeading.SECTION, "Payment options"));
+		add(new WHeading(HeadingLevel.H3, "Payment options"));
 
 		WRadioButtonSelect paymentType = new WRadioButtonSelect(new String[]{CREDIT_CARD, TRANSFER});
 		paymentType.setFrameless(true);
@@ -184,7 +185,7 @@ public class SubordinateBuilderComplexExample extends WContainer {
 			super(WPanel.Type.BLOCK);
 			setLayout(new FlowLayout(Alignment.VERTICAL, 0, 10));
 
-			add(new WHeading(WHeading.SECTION, "Transfer details"));
+			add(new WHeading(HeadingLevel.H3, "Transfer details"));
 
 			WStyledText text = new WStyledText(
 					"If paying by electronic transfer:"

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/table/WTableOptionsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/table/WTableOptionsExample.java
@@ -1,6 +1,7 @@
 package com.github.bordertech.wcomponents.examples.table;
 
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.SimpleBeanBoundTableModel;
 import com.github.bordertech.wcomponents.SimpleBeanBoundTableModel.LevelDetails;
@@ -278,19 +279,19 @@ public class WTableOptionsExample extends WContainer {
 		table2 = createExpandedDataTable();
 		table3 = createHierarchicDataTable();
 
-		add(new WHeading(WHeading.SECTION, "Basic Table"));
+		add(new WHeading(HeadingLevel.H3, "Basic Table"));
 		add(table1);
 		add(selected1);
 
 		add(new WHorizontalRule());
 
-		add(new WHeading(WHeading.SECTION, "Expanded Content Table"));
+		add(new WHeading(HeadingLevel.H3, "Expanded Content Table"));
 		add(table2);
 		add(selected2);
 
 		add(new WHorizontalRule());
 
-		add(new WHeading(WHeading.SECTION, "Hierarchic Table"));
+		add(new WHeading(HeadingLevel.H3, "Hierarchic Table"));
 		add(table3);
 		add(selected3);
 

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WCancelButtonExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WCancelButtonExample.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.examples.theme;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.Message;
 import com.github.bordertech.wcomponents.MessageContainer;
 import com.github.bordertech.wcomponents.WButton;
@@ -88,7 +89,7 @@ public class WCancelButtonExample extends WPanel implements MessageContainer {
 		buttonPanel.add(cancelButton);
 		add(buttonPanel);
 
-		add(new WHeading(WHeading.MAJOR, "Testing example for Internet Explorer"));
+		add(new WHeading(HeadingLevel.H2, "Testing example for Internet Explorer"));
 		add(new ExplanatoryText(
 				"Internet Explorer (up to and including IE11) honours clicks on disabled buttons and causes the event handlers to be called."
 				+ " This example is only used to check that we are correctly handling these click on disabled buttons. To undertake the test enter some text"

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WColumnLayoutExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WColumnLayoutExample.java
@@ -1,5 +1,6 @@
 package com.github.bordertech.wcomponents.examples.theme;
 
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.WColumnLayout;
 import com.github.bordertech.wcomponents.WHeading;
 import com.github.bordertech.wcomponents.WPanel;
@@ -29,7 +30,7 @@ public class WColumnLayoutExample extends WPanel {
 	public WColumnLayoutExample() {
 		super(Type.BLOCK);
 
-		add(new WHeading(WHeading.MAJOR, "Major Heading"));
+		add(new WHeading(HeadingLevel.H2, "Major Heading"));
 
 		WColumnLayout colLayout = new WColumnLayout("Section Heading - WColumnLayout");
 		colLayout.setLeftColumn("Minor Heading", new WText(LONG_TEXT));

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WFieldNestedExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WFieldNestedExample.java
@@ -1,6 +1,7 @@
 package com.github.bordertech.wcomponents.examples.theme;
 
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.Message;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WDateField;
@@ -58,7 +59,7 @@ public class WFieldNestedExample extends WPanel {
 		});
 
 		add(messages);
-		add(new WHeading(WHeading.MAJOR, "Nested WField Example With Validation"));
+		add(new WHeading(HeadingLevel.H2, "Nested WField Example With Validation"));
 		add(layout);
 
 	}

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WHiddenCommentExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WHiddenCommentExample.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.examples.theme;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WField;
@@ -37,7 +38,7 @@ public class WHiddenCommentExample extends WContainer {
 	 * Create the WHiddenComment example.
 	 */
 	public WHiddenCommentExample() {
-		add(new WHeading(WHeading.SECTION, "Hidden Comments Example"));
+		add(new WHeading(HeadingLevel.H3, "Hidden Comments Example"));
 		WStyledText text = new WStyledText(
 				"Right click the page to view the source and the hidden comments.");
 		text.setWhitespaceMode(WhitespaceMode.PARAGRAPHS);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WMenuExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WMenuExample.java
@@ -1,5 +1,6 @@
 package com.github.bordertech.wcomponents.examples.theme;
 
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WHeading;
 import com.github.bordertech.wcomponents.WMenu;
@@ -19,13 +20,13 @@ public class WMenuExample extends WContainer {
 	 * Creates a WMenu example.
 	 */
 	public WMenuExample() {
-		add(new WHeading(WHeading.MAJOR, "Menu bar"));
+		add(new WHeading(HeadingLevel.H2, "Menu bar"));
 		add(new MenuBarExample());
 
-		add(new WHeading(WHeading.MAJOR, "Tree menu"));
+		add(new WHeading(HeadingLevel.H2, "Tree menu"));
 		add(new TreeMenuExample());
 
-		add(new WHeading(WHeading.MAJOR, "Column  menu"));
+		add(new WHeading(HeadingLevel.H2, "Column  menu"));
 		add(new ColumnMenuExample());
 	}
 }

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WMenuSelectModeExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WMenuSelectModeExample.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.examples.theme;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.WAjaxControl;
 import com.github.bordertech.wcomponents.WButton;
@@ -281,9 +282,9 @@ public class WMenuSelectModeExample extends WContainer {
 					"Selectable");
 
 			add(menu);
-			add(new WHeading(WHeading.SECTION, "Details"));
+			add(new WHeading(HeadingLevel.H3, "Details"));
 			add(layout1);
-			add(new WHeading(WHeading.SECTION, "Configuration"));
+			add(new WHeading(HeadingLevel.H3, "Configuration"));
 			add(layout2);
 			add(new WButton("Submit"));
 

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WMultiDropdownExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WMultiDropdownExample.java
@@ -1,5 +1,6 @@
 package com.github.bordertech.wcomponents.examples.theme;
 
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WFieldLayout;
@@ -29,7 +30,7 @@ public class WMultiDropdownExample extends WContainer {
 	 * Creates a WMultiDropdownExample.
 	 */
 	public WMultiDropdownExample() {
-		add(new WHeading(WHeading.SECTION, "Dynamic Multi-dropdown examples"));
+		add(new WHeading(HeadingLevel.H3, "Dynamic Multi-dropdown examples"));
 		add(layout);
 
 		WMultiDropdown dropdown = new WMultiDropdown("icao");

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WRadioButtonExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WRadioButtonExample.java
@@ -1,5 +1,6 @@
 package com.github.bordertech.wcomponents.examples.theme;
 
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.Margin;
 import com.github.bordertech.wcomponents.RadioButtonGroup;
 import com.github.bordertech.wcomponents.Size;
@@ -24,7 +25,7 @@ public class WRadioButtonExample extends WContainer {
 	 */
 	public WRadioButtonExample() {
 		//Normal WRadioButtons in a RadioButtonGroup
-		add(new WHeading(WHeading.MAJOR, "Radio buttons are answers to a particular question."));
+		add(new WHeading(HeadingLevel.H2, "Radio buttons are answers to a particular question."));
 
 		add(new ExplanatoryText(
 				"It is not required that all WRadioButtons in a group be in the same field set (or even in the same part of the UI)"
@@ -32,7 +33,7 @@ public class WRadioButtonExample extends WContainer {
 				+ " A table column (or, less commonly a row) may server to provide the question context. There are no other arrangements which can be"
 				+ " guaranteed to provide adequate accessible context for the relationship between the question and the answers."));
 
-		add(new WHeading(WHeading.SECTION, "Normal, interactive radio buttons."));
+		add(new WHeading(HeadingLevel.H3, "Normal, interactive radio buttons."));
 		RadioButtonGroup quest = new RadioButtonGroup();
 		add(quest);
 
@@ -68,7 +69,7 @@ public class WRadioButtonExample extends WContainer {
 
 		//now for the other properties
 		//disabled
-		add(new WHeading(WHeading.SECTION, "Radio buttons may be disabled."));
+		add(new WHeading(HeadingLevel.H3, "Radio buttons may be disabled."));
 		fset = new WFieldSet("What ails thee my Lord?");
 		add(fset);
 		layout = new WFieldLayout(WFieldLayout.LAYOUT_STACKED);
@@ -86,7 +87,7 @@ public class WRadioButtonExample extends WContainer {
 		layout.addField("Speak not of mild and bitter in this holy house.", rb);
 
 		add(new WHorizontalRule());
-		add(new WHeading(WHeading.SECTION, "Radio buttons may be read-only."));
+		add(new WHeading(HeadingLevel.H3, "Radio buttons may be read-only."));
 		add(new ExplanatoryText(
 				"Radio Buttons may be read-only. In this case the widget is replaced with a render which does not allow for malicious or accidental change of state."));
 		fset = new WFieldSet("Here's some we answered earlier.");

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/ajax/AjaxWRepeaterExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/ajax/AjaxWRepeaterExample.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.examples.theme.ajax;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.Margin;
 import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.Size;
@@ -58,7 +59,7 @@ public class AjaxWRepeaterExample extends WContainer {
 		});
 		button.setAjaxTarget(panel);
 
-		add(new WHeading(WHeading.MAJOR, "WRepeater using ajax"));
+		add(new WHeading(HeadingLevel.H2, "WRepeater using ajax"));
 		add(panel);
 
 		WPanel buttonPanel = new WPanel(WPanel.Type.FEATURE);


### PR DESCRIPTION
Replaced usage of ```WHeading.TITLE``` and other constant based heading levels with ```HeadingLevel``` values.