### PR TITLE
Deprecated FlowLayout constructors must not be used

### DIFF
--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/ErrorGenerator.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/ErrorGenerator.java
@@ -4,6 +4,7 @@ import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
 import com.github.bordertech.wcomponents.RenderContext;
 import com.github.bordertech.wcomponents.Request;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WPanel;
@@ -40,7 +41,7 @@ public class ErrorGenerator extends WPanel {
 	 * Creates an ErrorGenerator.
 	 */
 	public ErrorGenerator() {
-		setLayout(new FlowLayout(FlowLayout.VERTICAL, 24));
+		setLayout(new FlowLayout(FlowLayout.VERTICAL, Size.XL));
 
 		actionErrorBtn.setAction(new Action() {
 			@Override

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/I18nExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/I18nExample.java
@@ -66,7 +66,7 @@ public class I18nExample extends WPanel implements MessageContainer {
 		add(messages);
 
 		WPanel buttons = new WPanel(WPanel.Type.FEATURE);
-		buttons.setLayout(new FlowLayout(Alignment.LEFT, 10, 0));
+		buttons.setLayout(new FlowLayout(Alignment.LEFT, Size.LARGE));
 		add(buttons);
 
 		buttons.add(new ChangeLocaleButton(null));

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/InputBeanBindingExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/InputBeanBindingExample.java
@@ -5,6 +5,7 @@ import com.github.bordertech.wcomponents.ActionEvent;
 import com.github.bordertech.wcomponents.Input;
 import com.github.bordertech.wcomponents.RadioButtonGroup;
 import com.github.bordertech.wcomponents.Request;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.SubordinateTarget;
 import com.github.bordertech.wcomponents.WAjaxControl;
 import com.github.bordertech.wcomponents.WBeanComponent;
@@ -481,7 +482,7 @@ public class InputBeanBindingExample extends WBeanContainer {
 			add(input);
 
 			WPanel details = new WPanel();
-			details.setLayout(new FlowLayout(Alignment.VERTICAL, 0, 5));
+			details.setLayout(new FlowLayout(Alignment.VERTICAL, Size.MEDIUM));
 			add(details);
 			details.add(stringValue);
 			details.add(dataValue);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/MultiPollingExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/MultiPollingExample.java
@@ -5,6 +5,7 @@
 package com.github.bordertech.wcomponents.examples;
 
 import com.github.bordertech.wcomponents.Request;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WAjaxControl;
 import com.github.bordertech.wcomponents.WDateField;
 import com.github.bordertech.wcomponents.WPanel;
@@ -29,7 +30,7 @@ public class MultiPollingExample extends WPanel {
 	 * Construct example.
 	 */
 	public MultiPollingExample() {
-		setLayout(new FlowLayout(FlowLayout.VERTICAL, 0, 12));
+		setLayout(new FlowLayout(FlowLayout.VERTICAL, Size.LARGE));
 		add(new WText(
 				"This example is for framework testing only. It is not to be used as an example of setting up a polling region."));
 

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/RadioButtonExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/RadioButtonExample.java
@@ -1,6 +1,7 @@
 package com.github.bordertech.wcomponents.examples;
 
 import com.github.bordertech.wcomponents.RadioButtonGroup;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WLabel;
 import com.github.bordertech.wcomponents.WPanel;
 import com.github.bordertech.wcomponents.WRadioButton;
@@ -54,7 +55,7 @@ public class RadioButtonExample extends WPanel {
 		WRadioButton rb6 = group.addRadioButton("C");
 
 		panel = new WPanel();
-		panel.setLayout(new FlowLayout(Alignment.LEFT, 5, 0));
+		panel.setLayout(new FlowLayout(Alignment.LEFT, Size.MEDIUM));
 		add(new WLabel("Group"));
 		panel.add(new WLabel("A", rb4));
 		panel.add(rb4);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WButtonActionExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WButtonActionExample.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.examples;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WPanel;
 import com.github.bordertech.wcomponents.WText;
@@ -36,7 +37,7 @@ public class WButtonActionExample extends WPanel {
 	 * Creates a WButtonActionExample.
 	 */
 	public WButtonActionExample() {
-		setLayout(new FlowLayout(Alignment.VERTICAL, 0, 6));
+		setLayout(new FlowLayout(Alignment.VERTICAL, Size.MEDIUM));
 		add(message);
 
 		// Add the button to the panel.

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WButtonExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WButtonExample.java
@@ -5,6 +5,7 @@ import com.github.bordertech.wcomponents.ActionEvent;
 import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.MessageContainer;
 import com.github.bordertech.wcomponents.Request;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WApplication;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WButton.ImagePosition;
@@ -144,7 +145,7 @@ public class WButtonExample extends WPanel implements MessageContainer {
 		add(new WHeading(HeadingLevel.H4, "Rendered as a button"));
 
 		WPanel buttonLayoutPanel = new WPanel(WPanel.Type.BOX);
-		buttonLayoutPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 6, 0,
+		buttonLayoutPanel.setLayout(new FlowLayout(FlowLayout.LEFT, Size.MEDIUM,
 				FlowLayout.ContentAlignment.BOTTOM));
 		add(buttonLayoutPanel);
 		buttonLayoutPanel.
@@ -158,7 +159,7 @@ public class WButtonExample extends WPanel implements MessageContainer {
 		add(new ExplanatoryText(
 				"This example shows how to use an image and text as the content of a button without the button styling."));
 		buttonLayoutPanel = new WPanel(WPanel.Type.BOX);
-		buttonLayoutPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 6, 0,
+		buttonLayoutPanel.setLayout(new FlowLayout(FlowLayout.LEFT, Size.MEDIUM,
 				FlowLayout.ContentAlignment.BOTTOM));
 		add(buttonLayoutPanel);
 		buttonLayoutPanel.add(makeImageButtonWithPosition("Image on the North", ImagePosition.NORTH,
@@ -317,7 +318,7 @@ public class WButtonExample extends WPanel implements MessageContainer {
 		add(new WHeading(HeadingLevel.H2, "Examples of disabled buttons"));
 
 		WPanel disabledButtonLayoutPanel = new WPanel(WPanel.Type.BOX);
-		disabledButtonLayoutPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 6, 0,
+		disabledButtonLayoutPanel.setLayout(new FlowLayout(FlowLayout.LEFT, Size.MEDIUM,
 				FlowLayout.ContentAlignment.BASELINE));
 		add(disabledButtonLayoutPanel);
 
@@ -331,7 +332,7 @@ public class WButtonExample extends WPanel implements MessageContainer {
 
 		add(new WHeading(HeadingLevel.H3, "Examples of disabled buttons displaying only an image"));
 		disabledButtonLayoutPanel = new WPanel(WPanel.Type.BOX);
-		disabledButtonLayoutPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 6, 0,
+		disabledButtonLayoutPanel.setLayout(new FlowLayout(FlowLayout.LEFT, Size.MEDIUM,
 				FlowLayout.ContentAlignment.BASELINE));
 		add(disabledButtonLayoutPanel);
 
@@ -351,7 +352,7 @@ public class WButtonExample extends WPanel implements MessageContainer {
 				"Examples of disabled buttons displaying an image with imagePosition EAST"));
 
 		disabledButtonLayoutPanel = new WPanel(WPanel.Type.BOX);
-		disabledButtonLayoutPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 6, 0,
+		disabledButtonLayoutPanel.setLayout(new FlowLayout(FlowLayout.LEFT, Size.MEDIUM,
 				FlowLayout.ContentAlignment.BASELINE));
 		add(disabledButtonLayoutPanel);
 		button = new WButton("Disabled button");

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WDropdownOptionsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WDropdownOptionsExample.java
@@ -3,6 +3,7 @@ package com.github.bordertech.wcomponents.examples;
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
 import com.github.bordertech.wcomponents.Request;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.SubordinateTarget;
 import com.github.bordertech.wcomponents.WAjaxControl;
 import com.github.bordertech.wcomponents.WButton;
@@ -147,7 +148,7 @@ public class WDropdownOptionsExample extends WContainer {
 		WFieldSet fieldSet = getDropDownControls();
 		add(fieldSet);
 		add(new WHorizontalRule());
-		container.setLayout(new FlowLayout(Alignment.VERTICAL, 0, 6));
+		container.setLayout(new FlowLayout(Alignment.VERTICAL, Size.MEDIUM));
 		add(container);
 		add(new WHorizontalRule());
 		add(infoPanel);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WImageExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WImageExample.java
@@ -4,6 +4,7 @@ import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
 import com.github.bordertech.wcomponents.Image;
 import com.github.bordertech.wcomponents.ImageResource;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WImage;
 import com.github.bordertech.wcomponents.WPanel;
@@ -43,7 +44,7 @@ public class WImageExample extends WPanel {
 	 * Creates a WImageExample.
 	 */
 	public WImageExample() {
-		setLayout(new FlowLayout(Alignment.VERTICAL, 0, 6));
+		setLayout(new FlowLayout(Alignment.VERTICAL, Size.MEDIUM));
 
 		// This image is a static resource, and will be cached on the client.
 		final ImageResource bannerImage = new ImageResource(

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WSkipLinksExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WSkipLinksExample.java
@@ -1,5 +1,7 @@
 package com.github.bordertech.wcomponents.examples;
 
+import com.github.bordertech.wcomponents.HeadingLevel;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WHeading;
 import com.github.bordertech.wcomponents.WHorizontalRule;
 import com.github.bordertech.wcomponents.WLabel;
@@ -27,11 +29,11 @@ public class WSkipLinksExample extends WPanel {
 	 * Creates a WSkipLinksExample.
 	 */
 	public WSkipLinksExample() {
-		setLayout(new FlowLayout(Alignment.VERTICAL, 0, 10));
+		setLayout(new FlowLayout(Alignment.VERTICAL, Size.LARGE));
 		//note: the WSKipLinks component is actually added to the ancestor WApplication
 		//and is invoked by the presence of WPanel with an accessKey.
 
-		add(new WHeading(WHeading.SECTION, "WPanel skip-links targets"));
+		add(new WHeading(HeadingLevel.H3, "WPanel skip-links targets"));
 
 		add(buildPanel("Panel One Title", '1'));
 		add(buildPanel("Panel 2 - no access key is set on this panel"));

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WStyledTextFontAwesomeExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/WStyledTextFontAwesomeExample.java
@@ -1,6 +1,7 @@
 package com.github.bordertech.wcomponents.examples;
 
 import com.github.bordertech.wcomponents.HeadingLevel;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WHeading;
 import com.github.bordertech.wcomponents.WPanel;
@@ -24,7 +25,7 @@ public class WStyledTextFontAwesomeExample extends WPanel {
 	 * Create the example.
 	 */
 	public WStyledTextFontAwesomeExample() {
-		setLayout(new FlowLayout(FlowLayout.Alignment.VERTICAL, 0, 12));
+		setLayout(new FlowLayout(FlowLayout.Alignment.VERTICAL, Size.LARGE));
 
 		add(new WHeading(HeadingLevel.H2, "A simple icon"));
 		WStyledText text = new WStyledText("Fort Awesome");

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/datatable/DataTableBeanExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/datatable/DataTableBeanExample.java
@@ -4,6 +4,7 @@ import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
 import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.SimpleBeanBoundTableDataModel;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WDataTable;
 import com.github.bordertech.wcomponents.WDateField;
@@ -37,7 +38,7 @@ public class DataTableBeanExample extends WPanel {
 	 * Creates a DataTableBeanExample.
 	 */
 	public DataTableBeanExample() {
-		setLayout(new FlowLayout(Alignment.VERTICAL, 0, 5));
+		setLayout(new FlowLayout(Alignment.VERTICAL, Size.MEDIUM));
 
 		// Since this data model doesn't store any user state information within it,
 		// we can safely use a single shared instance.
@@ -66,7 +67,7 @@ public class DataTableBeanExample extends WPanel {
 		});
 
 		WPanel buttonPanel = new WPanel();
-		buttonPanel.setLayout(new FlowLayout(Alignment.LEFT, 5, 0));
+		buttonPanel.setLayout(new FlowLayout(Alignment.LEFT, Size.MEDIUM));
 		buttonPanel.add(saveButton);
 		buttonPanel.add(new WButton("Refresh page"));
 		add(buttonPanel);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/datatable/DataTableOptionsExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/datatable/DataTableOptionsExample.java
@@ -5,6 +5,7 @@ import com.github.bordertech.wcomponents.AbstractTreeTableDataModel;
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
 import com.github.bordertech.wcomponents.Request;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.TableDataModel;
 import com.github.bordertech.wcomponents.TableTreeNode;
 import com.github.bordertech.wcomponents.TreeTableDataModel;
@@ -859,7 +860,7 @@ public class DataTableOptionsExample extends WContainer {
 		 */
 		public ExtraDetailsPanel() {
 			WPanel panel = new WPanel();
-			panel.setLayout(new FlowLayout(Alignment.LEFT, 5, 0));
+			panel.setLayout(new FlowLayout(Alignment.LEFT, Size.MEDIUM));
 			add(panel);
 
 			WText colA = new WText();

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/layout/FlowLayoutExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/layout/FlowLayoutExample.java
@@ -137,7 +137,7 @@ public class FlowLayoutExample extends WPanel {
 
 		add(new WHeading(HeadingLevel.H3, "Flow layout - left, horizontal gap and ignored vertical gap"));
 		flowPanel = new WPanel();
-		flowPanel.setLayout(new FlowLayout(Alignment.LEFT, 6, 12));
+		flowPanel.setLayout(new FlowLayout(Alignment.LEFT, Size.MEDIUM));
 		add(flowPanel);
 		addBoxes(flowPanel, 12);
 		flowPanel.add(new WText("some text"));
@@ -145,7 +145,7 @@ public class FlowLayoutExample extends WPanel {
 
 		add(new WHeading(HeadingLevel.H3, "Vertical, ignored horizontal gap and implemented vertical gap"));
 		flowPanel = new WPanel();
-		flowPanel.setLayout(new FlowLayout(Alignment.VERTICAL, 6, 12));
+		flowPanel.setLayout(new FlowLayout(Alignment.VERTICAL, Size.LARGE));
 		add(flowPanel);
 		addBoxes(flowPanel, 5);
 		flowPanel.add(new WText("some text"));
@@ -153,7 +153,7 @@ public class FlowLayoutExample extends WPanel {
 
 		add(new WHeading(HeadingLevel.H3, "Left, horizontal gap and ignored vertical gap, content align bottom"));
 		flowPanel = new WPanel();
-		flowPanel.setLayout(new FlowLayout(Alignment.LEFT, 6, 12, ContentAlignment.BOTTOM));
+		flowPanel.setLayout(new FlowLayout(Alignment.LEFT, Size.MEDIUM, ContentAlignment.BOTTOM));
 		add(flowPanel);
 		addBoxesWithDiffContent(flowPanel, 5);
 		flowPanel.add(new WText("some text"));
@@ -162,7 +162,7 @@ public class FlowLayoutExample extends WPanel {
 
 		add(new WHeading(HeadingLevel.H3, "VERTICAL, ignored horizontal gap, vertical gap, ignored content align bottom"));
 		flowPanel = new WPanel();
-		flowPanel.setLayout(new FlowLayout(Alignment.VERTICAL, 6, 12, ContentAlignment.BOTTOM));
+		flowPanel.setLayout(new FlowLayout(Alignment.VERTICAL, Size.LARGE, ContentAlignment.BOTTOM));
 		add(flowPanel);
 		addBoxes(flowPanel, 5);
 		flowPanel.add(new WText("some text"));
@@ -191,7 +191,7 @@ public class FlowLayoutExample extends WPanel {
 	private static void addBoxesWithDiffContent(final WPanel panel, final int amount) {
 		for (int i = 1; i <= amount; i++) {
 			WPanel content = new WPanel(WPanel.Type.BOX);
-			content.setLayout(new FlowLayout(FlowLayout.VERTICAL, 3));
+			content.setLayout(new FlowLayout(FlowLayout.VERTICAL, Size.SMALL));
 			for (int j = 1; j <= i; j++) {
 				content.add(new WText(Integer.toString(i)));
 			}

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/menu/TreeMenuExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/menu/TreeMenuExample.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.examples.menu;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WComponent;
 import com.github.bordertech.wcomponents.WDecoratedLabel;
 import com.github.bordertech.wcomponents.WImage;
@@ -33,7 +34,7 @@ public class TreeMenuExample extends WPanel {
 	 * Creates a TreeMenuExample.
 	 */
 	public TreeMenuExample() {
-		setLayout(new FlowLayout(Alignment.VERTICAL, 0, 24));
+		setLayout(new FlowLayout(Alignment.VERTICAL, Size.XL));
 		add(new WText("Example java object hierarchy"));
 
 		WPanel content = new WPanel(WPanel.Type.BLOCK);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/subordinate/SubordinateBuilderComplexExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/subordinate/SubordinateBuilderComplexExample.java
@@ -1,6 +1,7 @@
 package com.github.bordertech.wcomponents.examples.subordinate;
 
 import com.github.bordertech.wcomponents.RadioButtonGroup;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WDropdown;
 import com.github.bordertech.wcomponents.WField;
@@ -93,7 +94,7 @@ public class SubordinateBuilderComplexExample extends WContainer {
 			WRadioButton cardCButton = creditCardType.addRadioButton("cardC");
 
 			WPanel cardTypePanel = new WPanel();
-			cardTypePanel.setLayout(new FlowLayout(Alignment.LEFT, 10, 0));
+			cardTypePanel.setLayout(new FlowLayout(Alignment.LEFT, Size.LARGE));
 			cardTypePanel.add(cardAButton);
 			cardTypePanel.add(createCardImage("A"));
 			cardTypePanel.add(cardBButton);
@@ -182,7 +183,7 @@ public class SubordinateBuilderComplexExample extends WContainer {
 		 */
 		private TransferPanel() {
 			super(WPanel.Type.BLOCK);
-			setLayout(new FlowLayout(Alignment.VERTICAL, 0, 10));
+			setLayout(new FlowLayout(Alignment.VERTICAL, Size.LARGE));
 
 			add(new WHeading(WHeading.SECTION, "Transfer details"));
 

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WCancelButtonExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WCancelButtonExample.java
@@ -4,6 +4,7 @@ import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
 import com.github.bordertech.wcomponents.Message;
 import com.github.bordertech.wcomponents.MessageContainer;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WCancelButton;
 import com.github.bordertech.wcomponents.WCardManager;
@@ -80,7 +81,7 @@ public class WCancelButtonExample extends WPanel implements MessageContainer {
 		}
 
 		WPanel buttonPanel = new WPanel(Type.FEATURE);
-		buttonPanel.setLayout(new FlowLayout(Alignment.LEFT, 3, 0));
+		buttonPanel.setLayout(new FlowLayout(Alignment.LEFT, Size.SMALL));
 		buttonPanel.setMargin(new com.github.bordertech.wcomponents.Margin(12, 0, 0, 0));
 		buttonPanel.add(prevButton);
 		buttonPanel.add(nextButton);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WCollapsibleExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WCollapsibleExample.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.examples.theme;
 
 import com.github.bordertech.wcomponents.CollapsibleGroup;
 import com.github.bordertech.wcomponents.HeadingLevel;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WCollapsible;
 import com.github.bordertech.wcomponents.WCollapsibleToggle;
 import com.github.bordertech.wcomponents.WDecoratedLabel;
@@ -26,7 +27,7 @@ public class WCollapsibleExample extends WPanel {
 	 * Creates a WCollapsibleExample.
 	 */
 	public WCollapsibleExample() {
-		setLayout(new FlowLayout(FlowLayout.Alignment.VERTICAL, 0, 12));
+		setLayout(new FlowLayout(FlowLayout.Alignment.VERTICAL, Size.LARGE));
 
 		WTextField component3 = new WTextField() {
 			// We want some dynamic text to show that there's a trip to the server.

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WConfirmationButtonExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WConfirmationButtonExample.java
@@ -3,6 +3,7 @@ package com.github.bordertech.wcomponents.examples.theme;
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
 import com.github.bordertech.wcomponents.HeadingLevel;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WAjaxControl;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WConfirmationButton;
@@ -53,7 +54,7 @@ public class WConfirmationButtonExample extends WContainer {
 		clearLink.setRenderAsLink(true);
 
 		WPanel buttonPanel = new WPanel();
-		buttonPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 6, 0,
+		buttonPanel.setLayout(new FlowLayout(FlowLayout.LEFT, Size.MEDIUM,
 				FlowLayout.ContentAlignment.BASELINE));
 		buttonPanel.add(clear);
 		buttonPanel.add(clearLink);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WFieldInputWidthExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WFieldInputWidthExample.java
@@ -3,6 +3,7 @@ package com.github.bordertech.wcomponents.examples.theme;
 import com.github.bordertech.wcomponents.HeadingLevel;
 import com.github.bordertech.wcomponents.RadioButtonGroup;
 import com.github.bordertech.wcomponents.Request;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WCheckBox;
 import com.github.bordertech.wcomponents.WCheckBoxSelect;
@@ -205,7 +206,7 @@ public class WFieldInputWidthExample extends WPanel {
 		// Now it gets confusing. We want the radio buttons to flow with their labels but be apart from each other...
 		//The WPanel which flowLayout and hgap will make the two control:label pairs sit apart from each other
 		WPanel rbLayout = new WPanel();
-		rbLayout.setLayout(new FlowLayout(FlowLayout.LEFT, 12, 0,
+		rbLayout.setLayout(new FlowLayout(FlowLayout.LEFT, Size.MEDIUM,
 				FlowLayout.ContentAlignment.BASELINE));
 		//then we use WContainer to add each control:label pair to the WPanel
 		WContainer rbContainer = new WContainer();

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WMenuWithAccessKeysExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WMenuWithAccessKeysExample.java
@@ -2,6 +2,7 @@ package com.github.bordertech.wcomponents.examples.theme;
 
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WMenu;
 import com.github.bordertech.wcomponents.WMenuItem;
 import com.github.bordertech.wcomponents.WPanel;
@@ -56,7 +57,7 @@ public class WMenuWithAccessKeysExample extends WPanel {
 		subMenu.add(externalLink);
 
 		// Layout the UI
-		setLayout(new FlowLayout(Alignment.VERTICAL, 0, 5));
+		setLayout(new FlowLayout(Alignment.VERTICAL, Size.MEDIUM));
 		add(bar);
 		add(console);
 	}

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WMultiFileWidgetExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WMultiFileWidgetExample.java
@@ -3,6 +3,7 @@ package com.github.bordertech.wcomponents.examples.theme;
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
 import com.github.bordertech.wcomponents.HeadingLevel;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WHeading;
@@ -95,7 +96,7 @@ public class WMultiFileWidgetExample extends WContainer {
 		add(new WHorizontalRule());
 
 		WPanel panel = new WPanel();
-		panel.setLayout(new FlowLayout(Alignment.VERTICAL, 0, 6));
+		panel.setLayout(new FlowLayout(Alignment.VERTICAL, Size.MEDIUM));
 		add(panel);
 
 		// Actions

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WPartialDateFieldExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WPartialDateFieldExample.java
@@ -54,7 +54,7 @@ public class WPartialDateFieldExample extends WContainer {
 		WButton btnGetDate = new WButton("Copy the Java Date");
 
 		WPanel buttonPanel = new WPanel(WPanel.Type.FEATURE);
-		buttonPanel.setLayout(new FlowLayout(Alignment.LEFT, 6));
+		buttonPanel.setLayout(new FlowLayout(Alignment.LEFT, Size.MEDIUM));
 		buttonPanel.setMargin(new Margin(Size.MEDIUM, null, null, null));
 		buttonPanel.add(copyBtn);
 		buttonPanel.add(btnGetDay);
@@ -80,7 +80,7 @@ public class WPartialDateFieldExample extends WContainer {
 
 		WPanel setDateButtonPanel = new WPanel(WPanel.Type.FEATURE);
 		wrapper.add(setDateButtonPanel);
-		setDateButtonPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 6));
+		setDateButtonPanel.setLayout(new FlowLayout(FlowLayout.LEFT, Size.MEDIUM));
 		setDateButtonPanel.setMargin(new com.github.bordertech.wcomponents.Margin(6, 0, 0, 0));
 
 		final WButton btnSetDMY = new WButton("Set the day month year");

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WProgressBarExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WProgressBarExample.java
@@ -4,6 +4,7 @@ import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
 import com.github.bordertech.wcomponents.BeanProvider;
 import com.github.bordertech.wcomponents.BeanProviderBound;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WPanel;
 import com.github.bordertech.wcomponents.WProgressBar;
@@ -27,7 +28,7 @@ public class WProgressBarExample extends WPanel {
 	 * Creates a WProgressBarExample.
 	 */
 	public WProgressBarExample() {
-		setLayout(new FlowLayout(Alignment.VERTICAL, 4));
+		setLayout(new FlowLayout(Alignment.VERTICAL, Size.SMALL));
 
 		add(new WText("Default, 10 max"));
 		WProgressBar progressBar = new WProgressBar(10);
@@ -110,7 +111,7 @@ public class WProgressBarExample extends WPanel {
 		 * @param bar the progress bar.
 		 */
 		private ProgressBarWithButtons(final WProgressBar bar) {
-			setLayout(new FlowLayout(Alignment.LEFT, 6, 0));
+			setLayout(new FlowLayout(Alignment.LEFT, Size.MEDIUM));
 			//setLayout(new ColumnLayout(EXAMPLE_COLUMN_WIDTHS, 6, 0));
 			add(bar);
 			//WPanel buttonPanel = new WPanel();

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WToggleButtonExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WToggleButtonExample.java
@@ -27,7 +27,7 @@ public class WToggleButtonExample extends WPanel {
 	 * Construct example.
 	 */
 	public WToggleButtonExample() {
-		setLayout(new FlowLayout(FlowLayout.Alignment.VERTICAL, 8));
+		setLayout(new FlowLayout(FlowLayout.Alignment.VERTICAL, Size.MEDIUM));
 		WToggleButton toggle;
 
 		add(new ExplanatoryText("Simple toggle button, no action."));

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/ajax/AjaxWPanelExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/ajax/AjaxWPanelExample.java
@@ -1,5 +1,6 @@
 package com.github.bordertech.wcomponents.examples.theme.ajax;
 
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WCheckBox;
 import com.github.bordertech.wcomponents.WHorizontalRule;
@@ -54,7 +55,7 @@ public class AjaxWPanelExample extends WPanel {
 		// Create the "lazy" WPanel
 		WPanel panel = new WPanel();
 		panel.setMode(WPanel.PanelMode.LAZY);
-		panel.setLayout(new FlowLayout(FlowLayout.VERTICAL, 0, 6));
+		panel.setLayout(new FlowLayout(FlowLayout.VERTICAL, Size.MEDIUM));
 		panel.add(new WText("This is the content in a lazy panel"));
 
 		// Subordinate to Show/Hide the panel

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/ajax/AjaxWRadioButtonSelectExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/ajax/AjaxWRadioButtonSelectExample.java
@@ -1,6 +1,7 @@
 package com.github.bordertech.wcomponents.examples.theme.ajax;
 
 import com.github.bordertech.wcomponents.Request;
+import com.github.bordertech.wcomponents.Size;
 import com.github.bordertech.wcomponents.WPanel;
 import com.github.bordertech.wcomponents.WRadioButtonSelect;
 import com.github.bordertech.wcomponents.WText;
@@ -49,7 +50,7 @@ public class AjaxWRadioButtonSelectExample extends WPanel {
 	 * Construct the WRadioButtonSelect AJAX example.
 	 */
 	public AjaxWRadioButtonSelectExample() {
-		setLayout(new FlowLayout(Alignment.VERTICAL, 0, 6));
+		setLayout(new FlowLayout(Alignment.VERTICAL, Size.MEDIUM));
 
 		rbSelect.setAccessibleText("Content selection");
 		rbSelect.setFrameless(true);

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/ajax/AjaxWRepeaterExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/ajax/AjaxWRepeaterExample.java
@@ -62,7 +62,7 @@ public class AjaxWRepeaterExample extends WContainer {
 		add(panel);
 
 		WPanel buttonPanel = new WPanel(WPanel.Type.FEATURE);
-		buttonPanel.setLayout(new FlowLayout(FlowLayout.RIGHT, 3, 0));
+		buttonPanel.setLayout(new FlowLayout(FlowLayout.RIGHT, Size.SMALL));
 		buttonPanel.setMargin(new Margin(Size.LARGE, null, null, null));
 		add(buttonPanel);
 		buttonPanel.add(button);


### PR DESCRIPTION
Removed usage of deprecated ```int``` based ```FlowLayout``` constructors and replaced with ```Size``` based constructors.