### PR TITLE
Remove CSS selector ambiguity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@
 ## Release in-progress
 
 ### API Changes
+
 ### Enhancements
+
 ### Bug Fixes
+
+* Removed a selector ambiguity which caused position to be overridden in combo listboxes when the listbox was busy #1747.
 
 ## 1.5.21
 

--- a/wcomponents-theme/src/main/sass/common/_combo.scss
+++ b/wcomponents-theme/src/main/sass/common/_combo.scss
@@ -62,8 +62,14 @@
   max-height: (7 * 1.125 * (1 + (2 * $wc-gap-small)));
   max-width: 100%;
   overflow: auto;
-  position: absolute;
   z-index: $wc-z-index-common;
+  
+  // #1747 build-source-order dependent flaw - single attibute selector
+  // can clash with [aria-busy='true'] which uses position:relative to place spinner
+  &,
+  &[aria-busy='true'] {
+	position: absolute;  
+  }
 
   dialog & {
     position: fixed;


### PR DESCRIPTION
The selector ambiguity caused position flicker but was dependent on built CSS source order. The fix removes the ambiguity and removes the source order dependency.
Fixes #1747