### PR TITLE
Strip trailing dot from abbreviated months

### DIFF
--- a/wcomponents-theme/src/main/js/wc/date/monthName.mjs
+++ b/wcomponents-theme/src/main/js/wc/date/monthName.mjs
@@ -52,11 +52,14 @@ function getMonthNames(locale, short) {
 	const result = [];
 	const type = short ? "short" : "long";
 	for (let i = 0; i < 12; i++) {
-		result.push(referenceDate.toLocaleDateString(locale, { month: type }));
+		let name = referenceDate.toLocaleDateString(locale, { month: type });
+		name = name.replace(/\.$/, "");
+		result.push(name);
 		referenceDate.setMonth(referenceDate.getMonth() + 1);
 	}
 	return result;
 }
+
 
 /**
  * Get the month names.


### PR DESCRIPTION
Technically this is not a perfect fix but it restores the old behaviour.

It would be non-trivial to modify the pattern to match with an optional dot at the end of any abbreviated form